### PR TITLE
FASTDDS_INSTRUMENTATION CMake option [10700]

### DIFF
--- a/docs/fastdds/instrumentation/includes/intro.rst
+++ b/docs/fastdds/instrumentation/includes/intro.rst
@@ -1,0 +1,6 @@
+The *Fast DDS Instrumentation module* is an extension to Fast DDS that enables the recollection of statistical data
+concerning the DDS communication.
+By default, Fast DDS does not compile this tool because it may entail affecting the application performance.
+The Instrumentation module can be activating using the ``-DFASTDDS_INSTRUMENTATION=ON`` at CMake configuration step.
+For more information about Fast DDS compilation, see :ref:`linux_sources` and :ref:`windows_sources`.
+

--- a/docs/fastdds/instrumentation/instrumentation.rst
+++ b/docs/fastdds/instrumentation/instrumentation.rst
@@ -1,0 +1,13 @@
+.. include:: ../../03-exports/aliases.include
+.. include:: ../../03-exports/aliases-api.include
+.. include:: ../../03-exports/roles.include
+
+.. _instrumentation:
+
+Instrumentation
+===============
+
+.. include:: includes/intro.rst
+
+.. toctree::
+   :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@
    /fastdds/persistence/persistence
    /fastdds/security/security
    /fastdds/logging/intro
+   /fastdds/instrumentation/instrumentation
    /fastdds/xml_configuration/xml_configuration
    /fastdds/env_vars/env_vars
    /fastdds/dynamic_types/dynamic_types

--- a/docs/installation/configuration/cmake_options.rst
+++ b/docs/installation/configuration/cmake_options.rst
@@ -81,6 +81,11 @@ dependency on other options.
           for more information on *Fast DDS* SHM transport.
         - ``ON`` ``OFF``
         - ``ON``
+    *   - :class:`FASTDDS_INSTRUMENTATION`
+        - Enables the *Fast DDS* instrumentation module. Please refer to :ref:`instrumentation` for more |br|
+          information on instrumentation module.
+        - ``ON`` ``OFF``
+        - ``OFF``
     *   - :class:`COMPILE_EXAMPLES`
         - Builds the *Fast DDS* examples. It is set to ``ON`` if :class:`EPROSIMA_BUILD` is ``ON`` and |br|
           :class:`EPROSIMA_INSTALLER` is ``OFF``. These examples can be found in the


### PR DESCRIPTION
Documentation of the new CMake option `FASTDDS_INSTRUMENTATION` which enables the compilation of the Fast DDS instrumentation module specific code.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>