### PR TITLE
[10991] Update Statistics QoS documentation

### DIFF
--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -778,5 +778,8 @@
 .. |disable_statistics_datawriter| replace:: :cpp:func:`disable_statistics_datawriter() <eprosima::fastdds::statistics::dds::DomainParticipant::disable_statistics_datawriter>`
 .. |statistics_narrow| replace:: :cpp:func:`narrow() <eprosima::fastdds::statistics::dds::DomainParticipant::narrow>`
 
+.. |STATISTICS_DATAREADER_QOS-api| replace:: :cpp:member:`STATISTICS_DATAREADER_QOS <eprosima::fastdds::statistics::dds::STATISTICS_DATAREADER_QOS>`
+.. |STATISTICS_DATAWRITER_QOS-api| replace:: :cpp:member:`STATISTICS_DATAWRITER_QOS <eprosima::fastdds::statistics::dds::STATISTICS_DATAWRITER_QOS>`
+
 .. |RTPSMessageGroup| replace:: :cpp:class:`RTPSMessageGroup <eprosima::fastrtps::rtps::RTPSMessageGroup>`
 .. |MessageReceiver| replace:: :cpp:class:`MessageReceiver <eprosima::fastrtps::rtps::MessageReceiver>`

--- a/docs/fastdds/statistics/dds_layer/domainParticipant.rst
+++ b/docs/fastdds/statistics/dds_layer/domainParticipant.rst
@@ -46,3 +46,8 @@ The |DomainParticipant-api| is created using the |DomainParticipantFactory::crea
 This method returns a pointer to the DDS standard DomainParticipant created.
 In order to obtain the pointer to the child |StatisticsDomainParticipant-api| which extends the DDS API, the
 ``static`` method |statistics_narrow| is provided.
+
+.. _auto_enabling_statistics_datawriters:
+
+Automatically enabling statistics DataWriters
+---------------------------------------------

--- a/docs/fastdds/statistics/dds_layer/qos.rst
+++ b/docs/fastdds/statistics/dds_layer/qos.rst
@@ -41,7 +41,7 @@ The recommended profile can be accessed through constant |STATISTICS_DATAWRITER_
    * - |history_depth-api|
      - 100
    * - |PropertyPolicyQos-api| name/value
-     - ``"pushMode"``/``"false"``
+     - ``"fastdds.push_mode"``/``"false"``
 
 Statistics DataReader recommended QoS
 -------------------------------------

--- a/docs/fastdds/statistics/dds_layer/qos.rst
+++ b/docs/fastdds/statistics/dds_layer/qos.rst
@@ -22,6 +22,7 @@ The following table shows the recommended |DataWriterQos-api| profile for enabli
 This profile enables the ``pull mode`` on the statistics DataWriters (please refer to :ref:`push_mode_qos_policy`).
 This entails that the DataWriters will only send information upon the reception of acknack submessages sent by the
 monitoring DataReader.
+The recommended profile can be accessed through constant |STATISTICS_DATAWRITER_QOS-api|.
 
 .. list-table::
    :header-rows: 1
@@ -46,6 +47,7 @@ Statistics DataReader recommended QoS
 -------------------------------------
 
 The following table shows the recommended |DataReaderQos-api| profile for creating the monitoring DataReaders.
+The recommended profile can be accessed through constant |STATISTICS_DATAREADER_QOS-api|.
 
 .. list-table::
    :header-rows: 1

--- a/docs/fastdds/statistics/dds_layer/qos.rst
+++ b/docs/fastdds/statistics/dds_layer/qos.rst
@@ -19,10 +19,12 @@ Statistics DataWriter recommended QoS
 -------------------------------------
 
 The following table shows the recommended |DataWriterQos-api| profile for enabling the statistics DataWriters.
-This profile enables the ``pull mode`` on the statistics DataWriters (please refer to :ref:`push_mode_qos_policy`).
+This profile enables the ``pull mode`` :ref:`operating mode <push_mode_qos_policy>` on the statistics DataWriters.
 This entails that the DataWriters will only send information upon the reception of acknack submessages sent by the
 monitoring DataReader.
-The recommended profile can be accessed through constant |STATISTICS_DATAWRITER_QOS-api|.
+This QoS profile is always used when the statistics DataWriters are
+:ref:`auto-enabled <auto_enabling_statistics_datawriters>`.
+The recommended profile can be accessed through the constant |STATISTICS_DATAWRITER_QOS-api|.
 
 .. list-table::
    :header-rows: 1
@@ -40,8 +42,8 @@ The recommended profile can be accessed through constant |STATISTICS_DATAWRITER_
      - |KEEP_LAST_HISTORY_QOS-api|
    * - |history_depth-api|
      - 100
-   * - |PropertyPolicyQos-api| name/value
-     - ``"fastdds.push_mode"``/``"false"``
+   * - |PropertyPolicyQos-api| name = value
+     - ``"fastdds.push_mode"`` = ``"false"``
 
 Statistics DataReader recommended QoS
 -------------------------------------

--- a/docs/fastdds/statistics/dds_layer/qos.rst
+++ b/docs/fastdds/statistics/dds_layer/qos.rst
@@ -19,6 +19,9 @@ Statistics DataWriter recommended QoS
 -------------------------------------
 
 The following table shows the recommended |DataWriterQos-api| profile for enabling the statistics DataWriters.
+This profile enables the ``pull mode`` on the statistics DataWriters (please refer to :ref:`push_mode_qos_policy`).
+This entails that the DataWriters will only send information upon the reception of acknack submessages sent by the
+monitoring DataReader.
 
 .. list-table::
    :header-rows: 1
@@ -36,6 +39,8 @@ The following table shows the recommended |DataWriterQos-api| profile for enabli
      - |KEEP_LAST_HISTORY_QOS-api|
    * - |history_depth-api|
      - 100
+   * - |PropertyPolicyQos-api| name/value
+     - ``"pushMode"``/``"false"``
 
 Statistics DataReader recommended QoS
 -------------------------------------


### PR DESCRIPTION
This PR also documents the `pushMode` property used in the `statistics::DataWriterQos`.

This PR depends on #251.