### PR TITLE
Pin doc-utils version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ colcon-mixin==0.1.8
 vcstool==0.2.7
 GitPython==3.1.1
 setuptools==46.1.3
+docutils==0.16.0


### PR DESCRIPTION
This PR fixes the style of TOC titles and unordered lists. It seems that it comes from a bug in `docutils` 0.17.0, which is a Sphinx dependency. Pinning `docutils` version to an older goes around the issue.

Related issues and PRs upstream:
* https://github.com/sphinx-doc/sphinx/issues/9051
* https://github.com/readthedocs/sphinx_rtd_theme/issues/1111
* https://github.com/sphinx-doc/sphinx/pull/9053

Signed-off-by: EduPonz <eduardoponz@eprosima.com>