### PR TITLE
Specify default values for participant lease and announcement

### DIFF
--- a/docs/fastdds/discovery/general_disc_settings.rst
+++ b/docs/fastdds/discovery/general_disc_settings.rst
@@ -146,6 +146,7 @@ The local DomainParticipant's liveliness is asserted on the remote DomainPartici
 DomainParticipant receives any kind of traffic from the local DomainParticipant.
 
 The lease duration is specified as a time expressed in seconds and nanosecond using a |Duration_t-api|.
+Is has a default value of 20 seconds.
 
 +----------------------------------------------------------------------------------------------------------------------+
 | **C++**                                                                                                              |
@@ -177,6 +178,7 @@ delay the discovery of late joiners.
 
 DomainParticipant's announcement period is specified as a time expressed in seconds and nanosecond using a
 |Duration_t-api|.
+It has a default value of 3 seconds.
 
 +----------------------------------------------------------------------------------------------------------------------+
 | **C++**                                                                                                              |


### PR DESCRIPTION
[Lease duration](https://github.com/eProsima/Fast-DDS/blob/master/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h#L252)
[Announcement period](https://github.com/eProsima/Fast-DDS/blob/master/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h#L258)
Signed-off-by: EduPonz <eduardoponz@eprosima.com>