### PR TITLE
Update from `fastrtpsgen` to `fastddsgen`

### DIFF
--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.h
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.h
@@ -29,7 +29,7 @@
 #include "HelloWorld.h"
 
 #if !defined(GEN_API_VER) || (GEN_API_VER != 1)
-#error Generated HelloWorld is not compatible with current installed Fast-RTPS. Please, regenerate it with fastrtpsgen.
+#error Generated HelloWorld is not compatible with current installed Fast-RTPS. Please, regenerate it with fastddsgen.
 #endif
 
 /*!

--- a/docs/fastdds/dds_layer/topic/fastddsgen/fastddsgen.rst
+++ b/docs/fastdds/dds_layer/topic/fastddsgen/fastddsgen.rst
@@ -23,13 +23,13 @@ The IDL file containing the data type definition is given with the ``<IDLfile>``
 +----------------------------------------------------------------------------------------------------------------------+
 | .. code-block:: bash                                                                                                 |
 |                                                                                                                      |
-|    fastddsgen [<options>] <IDLfile> [<IDLfile> ...]                                                                 |
+|    fastddsgen [<options>] <IDLfile> [<IDLfile> ...]                                                                  |
 +----------------------------------------------------------------------------------------------------------------------+
 | **Windows**                                                                                                          |
 +----------------------------------------------------------------------------------------------------------------------+
 | .. code-block:: bash                                                                                                 |
 |                                                                                                                      |
-|    fastddsgen.bat [<options>] <IDLfile> [<IDLfile> ...]                                                             |
+|    fastddsgen.bat [<options>] <IDLfile> [<IDLfile> ...]                                                              |
 +----------------------------------------------------------------------------------------------------------------------+
 
 Among the available arguments defined in :ref:`fastddsgen_usage`, the main *Fast DDS-Gen* options for data type source

--- a/docs/fastdds/dds_layer/topic/fastddsgen/fastddsgen.rst
+++ b/docs/fastdds/dds_layer/topic/fastddsgen/fastddsgen.rst
@@ -15,7 +15,7 @@ To learn about all the features that *Fast DDS* offers, please refer to :ref:`Fa
 Basic usage
 ^^^^^^^^^^^
 
-*Fast DDS* can be executed by calling *fastrtpsgen* on Linux or *fastrtpsgen.bat* on Windows.
+*Fast DDS* can be executed by calling *fastddsgen* on Linux or *fastddsgen.bat* on Windows.
 The IDL file containing the data type definition is given with the ``<IDLfile>`` argument.
 
 +----------------------------------------------------------------------------------------------------------------------+
@@ -23,13 +23,13 @@ The IDL file containing the data type definition is given with the ``<IDLfile>``
 +----------------------------------------------------------------------------------------------------------------------+
 | .. code-block:: bash                                                                                                 |
 |                                                                                                                      |
-|    fastrtpsgen [<options>] <IDLfile> [<IDLfile> ...]                                                                 |
+|    fastddsgen [<options>] <IDLfile> [<IDLfile> ...]                                                                 |
 +----------------------------------------------------------------------------------------------------------------------+
 | **Windows**                                                                                                          |
 +----------------------------------------------------------------------------------------------------------------------+
 | .. code-block:: bash                                                                                                 |
 |                                                                                                                      |
-|    fastrtpsgen.bat [<options>] <IDLfile> [<IDLfile> ...]                                                             |
+|    fastddsgen.bat [<options>] <IDLfile> [<IDLfile> ...]                                                             |
 +----------------------------------------------------------------------------------------------------------------------+
 
 Among the available arguments defined in :ref:`fastddsgen_usage`, the main *Fast DDS-Gen* options for data type source

--- a/docs/fastdds/getting_started/simple_app/includes/dataType.rst
+++ b/docs/fastdds/getting_started/simple_app/includes/dataType.rst
@@ -37,7 +37,7 @@ To do this, run the following command from the ``src`` directory.
 
 .. code-block:: bash
 
-    <path/to/Fast DDS-Gen>/scripts/fastrtpsgen HelloWorld.idl
+    <path/to/Fast DDS-Gen>/scripts/fastddsgen HelloWorld.idl
 
 This must have generated the following files:
 

--- a/docs/fastddsgen/pubsub_app/includes/first_app.rst
+++ b/docs/fastddsgen/pubsub_app/includes/first_app.rst
@@ -18,7 +18,7 @@ installation followed and the operating system.
 
     .. code:: bash
 
-        <path-to-Fast-DDS-workspace>/src/fastrtpsgen/scripts/fastddsgen -example CMake HelloWorld.idl
+        <path-to-Fast-DDS-workspace>/src/fastddsgen/scripts/fastddsgen -example CMake HelloWorld.idl
 
     - For a **stand-alone installation**, run:
 
@@ -32,7 +32,7 @@ installation followed and the operating system.
 
     .. code:: bash
 
-        <path-to-Fast-DDS-workspace>/src/fastrtpsgen/scripts/fastddsgen.bat -example CMake HelloWorld.idl
+        <path-to-Fast-DDS-workspace>/src/fastddsgen/scripts/fastddsgen.bat -example CMake HelloWorld.idl
 
     - For a **stand-alone installation**, run:
 
@@ -44,7 +44,7 @@ installation followed and the operating system.
 
     .. code:: bash
 
-        fastrtpsgen.bat -example CMake HelloWorld.idl
+        fastddsgen.bat -example CMake HelloWorld.idl
 
 .. warning::
 
@@ -53,7 +53,7 @@ installation followed and the operating system.
 
     .. code-block:: bash
 
-        cd <path-to-Fast-DDS-workspace>/src/fastrtpsgen
+        cd <path-to-Fast-DDS-workspace>/src/fastddsgen
         gradle assemble
 
 

--- a/docs/fastddsgen/usage/usage.rst
+++ b/docs/fastddsgen/usage/usage.rst
@@ -21,17 +21,17 @@ the following commands:
 
     .. code-block:: bash
 
-        $ fastrtpsgen
+        $ fastddsgen
 
 -  Windows:
 
     .. code-block:: bash
 
-        > fastrtpsgen.bat
+        > fastddsgen.bat
 
 .. note::
 
-    In case the PATH has not been modified, these scripts can be found in the ``<fastrtpsgen_directory>/scripts``
+    In case the PATH has not been modified, these scripts can be found in the ``<fastddsgen_directory>/scripts``
     directory.
 
 
@@ -42,7 +42,7 @@ The expected argument list of the application is:
 
 .. code-block:: bash
 
-    fastrtpsgen [<options>] <IDL file> [<IDL file> ...]
+    fastddsgen [<options>] <IDL file> [<IDL file> ...]
 
 Where the option choices are:
 

--- a/docs/installation/binaries/binaries_linux.rst
+++ b/docs/installation/binaries/binaries_linux.rst
@@ -44,7 +44,7 @@ The :code:`src` folder contains the following packages:
 * :code:`fastcdr`, a C++ library for data serialization according to the
   `CDR standard <https://www.omg.org/spec/DDSI-RTPS/2.2>`_ (*Section 10.2.1.2 OMG CDR*).
 * :code:`fastrtps`, the core library of *eProsima Fast DDS* library.
-* :code:`fastrtpsgen`, a Java application that generates source code using the data types defined in an IDL file.
+* :code:`fastddsgen`, a Java application that generates source code using the data types defined in an IDL file.
 
 In case any of these components is unwanted, it can be simply renamed or removed from the :code:`src`
 directory.

--- a/docs/installation/binaries/binaries_windows.rst
+++ b/docs/installation/binaries/binaries_windows.rst
@@ -67,7 +67,7 @@ By default, the installation will download all the available packages, namely:
 * :code:`fastcdr`, a C++ library that serializes according to the
   `standard CDR <https://www.omg.org/cgi-bin/doc?formal/02-06-51>`_ serialization mechanism.
 * :code:`fastrtps`, the core library of *eProsima Fast DDS* library.
-* :code:`fastrtpsgen`, a Java application that generates source code using the data types defined in an IDL file.
+* :code:`fastddsgen`, a Java application that generates source code using the data types defined in an IDL file.
 
 .. _env_vars_bw:
 

--- a/docs/notes/previous_versions/v1.10.0.rst
+++ b/docs/notes/previous_versions/v1.10.0.rst
@@ -40,5 +40,5 @@ Several bug fixes on discovery server:
 * Fixed timing issues.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.
 If you are upgrading from a version older than 1.10.0, regenerating the code is *recommended*.

--- a/docs/notes/previous_versions/v1.4.0.rst
+++ b/docs/notes/previous_versions/v1.4.0.rst
@@ -9,5 +9,5 @@ This release included the following:
 * Bug fixing.
 
 **Note:** After upgrading to this release, it is advisable to regenerate generated source from IDL files using
-*fastrtpsgen*.
+*fastddsgen*.
 

--- a/docs/notes/previous_versions/v1.5.0.rst
+++ b/docs/notes/previous_versions/v1.5.0.rst
@@ -9,5 +9,5 @@ This release included the following features:
 Also bug fixing.
 
 **Note:** If you are upgrading from an older version than 1.4.0, it is advisable to regenerate generated source from IDL
-files using *fastrtpsgen*.
+files using *fastddsgen*.
 

--- a/docs/notes/previous_versions/v1.6.0.rst
+++ b/docs/notes/previous_versions/v1.6.0.rst
@@ -9,5 +9,5 @@ This release included the following features:
 Also bug fixing.
 
 **Note:** If you are upgrading from an older version than 1.4.0, it is advisable to regenerate generated source from IDL
-files using *fastrtpsgen*.
+files using *fastddsgen*.
 

--- a/docs/notes/previous_versions/v1.7.0.rst
+++ b/docs/notes/previous_versions/v1.7.0.rst
@@ -10,4 +10,4 @@ This release included the following features:
 Also bug fixing, allocation and performance improvements.
 
 **Note:** If you are upgrading from an older version, it is **required** to regenerate generated source from IDL files
-using *fastrtpsgen*.
+using *fastddsgen*.

--- a/docs/notes/previous_versions/v1.7.1.rst
+++ b/docs/notes/previous_versions/v1.7.1.rst
@@ -22,5 +22,5 @@ Some other minor bugs and performance improvements.
   and doesn't take history depth into account.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.
 

--- a/docs/notes/previous_versions/v1.7.2.rst
+++ b/docs/notes/previous_versions/v1.7.2.rst
@@ -14,4 +14,4 @@ It also has the following improvements:
 Some other minor bugs and performance improvements.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.

--- a/docs/notes/previous_versions/v1.8.0.rst
+++ b/docs/notes/previous_versions/v1.8.0.rst
@@ -31,4 +31,4 @@ It also adds the following improvements and bug fixes:
 * When using TPC transport, sometimes callbacks are not invoked when removing a participant due to a bug in ASIO.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.

--- a/docs/notes/previous_versions/v1.8.1.rst
+++ b/docs/notes/previous_versions/v1.8.1.rst
@@ -13,7 +13,7 @@ It also adds the following bug fixes and improvements:
 * Fix for race conditions in SubscriberHistory, UDPTransportInterface and StatefulReader.
 * Fix for lroundl error on Windows in Time_t.
 * CDR & IDL submodules update.
-* Use of java 1.8 or greater for fastrtpsgen.jar generation.
+* Use of java 1.8 or greater for fastddsgen.jar generation.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.

--- a/docs/notes/previous_versions/v1.8.2.rst
+++ b/docs/notes/previous_versions/v1.8.2.rst
@@ -13,7 +13,7 @@ It also adds the following bug fixes and improvements:
 * Fix for setting `nullptr` in a fixed string.
 * Fix for not sending GAP in several cases.
 * Solve *Coverity* report issues.
-* Fix issue of *fastrtpsgen* failing to open *IDL.g4* file.
+* Fix issue of *fastddsgen* failing to open *IDL.g4* file.
 * Fix unnamed lock in *AESGCMGMAC_KeyFactory.cpp*.
 * Improve *XMLProfiles* example.
 * Multicast is now sent through *localhost* too.
@@ -27,4 +27,4 @@ It also adds the following bug fixes and improvements:
 * *WLP* improvements.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*
+from IDL files using *fastddsgen*

--- a/docs/notes/previous_versions/v1.8.3.rst
+++ b/docs/notes/previous_versions/v1.8.3.rst
@@ -8,4 +8,4 @@ This release adds the following bug fixes and improvements:
 * Bump to IDL-Parser v1.0.1.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*
+from IDL files using *fastddsgen*

--- a/docs/notes/previous_versions/v1.8.4.rst
+++ b/docs/notes/previous_versions/v1.8.4.rst
@@ -12,4 +12,4 @@ It also has the following **important bug fixes**:
   have been sent, a new subscriber is matched.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*
+from IDL files using *fastddsgen*

--- a/docs/notes/previous_versions/v1.9.0.rst
+++ b/docs/notes/previous_versions/v1.9.0.rst
@@ -29,4 +29,4 @@ It also adds the following bug fixes and improvements:
 * IDL sub-module updated to current version.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.

--- a/docs/notes/previous_versions/v1.9.1.rst
+++ b/docs/notes/previous_versions/v1.9.1.rst
@@ -28,4 +28,4 @@ It also adds the following bug fixes and improvements:
 * Fixed error while setting next deadline event in *create_new_change_with_params*.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.

--- a/docs/notes/previous_versions/v1.9.2.rst
+++ b/docs/notes/previous_versions/v1.9.2.rst
@@ -12,4 +12,4 @@ It also adds the following bug fixes and improvements:
 * Bump to IDL-Parser v1.0.1.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.

--- a/docs/notes/previous_versions/v1.9.3.rst
+++ b/docs/notes/previous_versions/v1.9.3.rst
@@ -23,4 +23,4 @@ It also includes the following bug fixes and improvements:
 
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.

--- a/docs/notes/previous_versions/v1.9.4.rst
+++ b/docs/notes/previous_versions/v1.9.4.rst
@@ -22,5 +22,5 @@ It also includes the following bug fixes and improvements:
 * Other minor bug fixes and improvements.
 
 **Note:** If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source
-from IDL files using *fastrtpsgen*.
+from IDL files using *fastddsgen*.
 

--- a/docs/notes/previous_versions/v2.0.1.rst
+++ b/docs/notes/previous_versions/v2.0.1.rst
@@ -20,5 +20,5 @@ PRs in merge order:
 
 .. note::
   If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source from IDL
-  files using *fastrtpsgen*.
+  files using *fastddsgen*.
   If you are upgrading from a version older than 1.10.0, regenerating the code is *recommended*.

--- a/docs/notes/previous_versions/v2.0.2.rst
+++ b/docs/notes/previous_versions/v2.0.2.rst
@@ -19,5 +19,5 @@ This release includes the following improvements:
 
 .. note::
   If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source from IDL
-  files using *fastrtpsgen*.
+  files using *fastddsgen*.
   If you are upgrading from a version older than 1.10.0, regenerating the code is *recommended*.

--- a/docs/notes/previous_versions/v2.1.0.rst
+++ b/docs/notes/previous_versions/v2.1.0.rst
@@ -54,5 +54,5 @@ Some important **bugfixes** are also included:
 
 .. note::
   If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source from IDL
-  files using *fastrtpsgen*.
+  files using *fastddsgen*.
   If you are upgrading from a version older than 1.10.0, regenerating the code is *recommended*.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -76,7 +76,7 @@ executables
 extensibility
 fastcdr
 fastdds
-fastrtpsgen
+fastddsgen
 foonathan
 GCM
 getter

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -170,6 +170,7 @@ Structs
 subfolder
 submessage
 submessages
+submodule
 submodules
 takeNextData
 TCP


### PR DESCRIPTION
This PR updates the name for `fastddsgen`. It also fixes a spelling error currently on master.

This PR depends on eProsima/Fast-DDS#1975 so the paths are correctly named.