### PR TITLE
[11498] Update docs to cover new installer feature

### DIFF
--- a/docs/installation/binaries/binaries_linux.rst
+++ b/docs/installation/binaries/binaries_linux.rst
@@ -70,6 +70,25 @@ packages have been installed, :code:`/usr/local/lib/`. There are two possibiliti
 
       echo 'export LD_LIBRARY_PATH=/usr/local/lib/' >> ~/.bashrc
 
+
+.. _linking_bw:
+
+Including Fast-DDS in a CMake project
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The installer deploys *CMake config* files that simplify to incorporate **Fast-DDS** to any CMake project via
+the *find_package* CMake API.
+
+By setting the CMake variable **FASTDDS_STATIC** is possible to choose the desired linkage (dynamic or static library)
+in the CMake generator stage. If the variable is missing defaults to dynamic linking.
+
+For example in order to build the examples statically linked to **Fast-DDS** do:
+
+   .. code-block:: bash
+
+    $ cmake -Bbuildexample -DFASTDDS_STATIC=ON .
+    $ cmake --build buildexample --target install
+
 .. _uninstall_bl:
 
 Uninstall

--- a/docs/installation/binaries/binaries_linux.rst
+++ b/docs/installation/binaries/binaries_linux.rst
@@ -71,7 +71,7 @@ packages have been installed, :code:`/usr/local/lib/`. There are two possibiliti
       echo 'export LD_LIBRARY_PATH=/usr/local/lib/' >> ~/.bashrc
 
 
-.. _linking_bw:
+.. _linking_bl:
 
 Including Fast-DDS in a CMake project
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/installation/binaries/binaries_windows.rst
+++ b/docs/installation/binaries/binaries_windows.rst
@@ -81,3 +81,21 @@ Environment variables
   appended to the ``PATH``.
 
 These variables are set automatically by checking the corresponding box during the installation process.
+
+.. _linking_bw:
+
+Including Fast-DDS in a CMake project
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The installer deploys *CMake config* files that simplify to incorporate **Fast-DDS** to any CMake project via
+the *find_package* CMake API.
+
+By setting the CMake variable **FASTDDS_STATIC** is possible to choose the desired linkage (dynamic or static library)
+in the CMake generator stage. If the variable is missing defaults to dynamic linking.
+
+For example in order to build the examples statically linked to **Fast-DDS** do:
+
+   .. code-block:: cmd
+
+    > cmake -Bbuildexample -DFASTDDS_STATIC=ON .
+    > cmake --build buildexample --target install

--- a/docs/installation/binaries/binaries_windows.rst
+++ b/docs/installation/binaries/binaries_windows.rst
@@ -95,7 +95,7 @@ in the CMake generator stage. If the variable is missing defaults to dynamic lin
 
 For example in order to build the examples statically linked to **Fast-DDS** do:
 
-   .. code-block:: cmd
+   .. code-block:: console
 
     > cmake -Bbuildexample -DFASTDDS_STATIC=ON .
     > cmake --build buildexample --target install


### PR DESCRIPTION
Now CMake external projects can link either statically or dynamically to the **Fast-DDS** deployed binaries.