### PR TITLE
[12340] Improve documentation about callback conflicts

### DIFF
--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -171,6 +171,8 @@
 .. |Publishers-api| replace:: :cpp:class:`Publishers <eprosima::fastdds::dds::Publisher>`
 .. |QosPolicy-api| replace:: :cpp:class:`QosPolicy <eprosima::fastdds::dds::QosPolicy>`
 .. |StatusMask-api| replace:: :cpp:class:`StatusMask <eprosima::fastdds::dds::StatusMask>`
+.. |StatusMask::all-api| replace:: :cpp:func:`StatusMask::all()<eprosima::fastdds::dds::StatusMask::all>`
+.. |StatusMask::none-api| replace:: :cpp:func:`StatusMask::none()<eprosima::fastdds::dds::StatusMask::none>`
 .. |Subscriber-api| replace:: :cpp:class:`Subscriber <eprosima::fastdds::dds::Subscriber>`
 .. |Subscriber::get_qos-api| replace:: :cpp:func:`get_qos()<eprosima::fastdds::dds::Subscriber::get_qos>`
 .. |Subscriber::set_qos-api| replace:: :cpp:func:`Subscriber::set_qos()<eprosima::fastdds::dds::Subscriber::set_qos>`

--- a/docs/fastdds/api_reference/spelling_wordlist.txt
+++ b/docs/fastdds/api_reference/spelling_wordlist.txt
@@ -49,6 +49,7 @@ eprosima
 expectsInlineQos
 fastrtps
 fragmentnumbers
+FlowController
 GenericDataQosPolicy
 getHistory
 getTypeDependencies

--- a/docs/fastdds/dds_layer/core/entity/entity.rst
+++ b/docs/fastdds/dds_layer/core/entity/entity.rst
@@ -100,9 +100,20 @@ diagram:
   Listeners inheritance diagram.
 
 .. note::
-  The |SubscriberListener::on_data_on_readers-api| callback intercepts messages before
-  |DataReaderListener::on_data_available-api|. Within each callback entity hierarchy remains the same.
 
+   The |SubscriberListener::on_data_on_readers-api| callback intercepts messages before
+   |DataReaderListener::on_data_available-api|.
+   This implies that if |DomainParticipantListener-api| is enabled, the user should take into account that by default
+   the listener uses |StatusMask::all-api|.
+   As the callback entity hierachy is kept, the |SubscriberListener::on_data_on_readers-api| is going to be called
+   in this case.
+   If the user wants to use |DataReaderListener::on_data_available-api| instead, the corresponding bit of
+   |StatusMask-api| should be disabled.
+   
+.. important::
+
+   Using |StatusMask::none-api| when creating the |Entity-api| only disables the DDS standard callbacks.
+   Any callback specific to *Fast DDS* is always enabled.
 
 .. warning::
 

--- a/docs/fastdds/dds_layer/core/entity/entity.rst
+++ b/docs/fastdds/dds_layer/core/entity/entity.rst
@@ -103,13 +103,13 @@ diagram:
 
    The |SubscriberListener::on_data_on_readers-api| callback intercepts messages before
    |DataReaderListener::on_data_available-api|.
-   This implies that if |DomainParticipantListener-api| is enabled, the user should take into account that by default
+   This implies that if |DomainParticipantListener-api| is enabled, users should take into account that by default
    the listener uses |StatusMask::all-api|.
-   As the callback entity hierachy is kept, the |SubscriberListener::on_data_on_readers-api| is going to be called
+   As the callback entity hierarchy is kept, the |SubscriberListener::on_data_on_readers-api| is going to be called
    in this case.
-   If the user wants to use |DataReaderListener::on_data_available-api| instead, the corresponding bit of
+   If an application wants to use |DataReaderListener::on_data_available-api| instead, the corresponding bit of
    |StatusMask-api| should be disabled.
-   
+
 .. important::
 
    Using |StatusMask::none-api| when creating the |Entity-api| only disables the DDS standard callbacks.

--- a/docs/fastdds/dds_layer/domain/domainParticipantListener/domainParticipantListener.rst
+++ b/docs/fastdds/dds_layer/domain/domainParticipantListener/domainParticipantListener.rst
@@ -50,6 +50,10 @@ Additionally, DomainParticipantListener adds the following callbacks:
  * |DomainParticipantListener::onParticipantAuthentication-api|: Informs about the result of the authentication process
    of a remote DomainParticipant (either on failure or success).
 
+.. important::
+
+   Read more about callbacks and its hierarchy :ref:`here<dds_layer_core_entity_commonchars_listener>`
+
 .. literalinclude:: /../code/DDSCodeTester.cpp
    :language: c++
    :start-after: //DDS_DOMAINPARTICIPANT_LISTENER_SPECIALIZATION

--- a/docs/fastdds/discovery/disc_callbacks.rst
+++ b/docs/fastdds/discovery/disc_callbacks.rst
@@ -33,3 +33,7 @@ of the DomainParticipant.
    :start-after: //SET-DISCOVERY-CALLBACKS
    :end-before: //!--
    :dedent: 8
+
+.. important::
+
+   Read more about callbacks and its hierarchy :ref:`here<dds_layer_core_entity_commonchars_listener>`


### PR DESCRIPTION
This PR improves the documentation about `on_data_on_readers` and `on_data_available` callbacks.
It intends to solve #277.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>