### PR TITLE
[13276] DurabilityQosPolicy requires RELIABLE ReliabilityQosPolicy

### DIFF
--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -1047,6 +1047,10 @@ List of QoS Policy data members:
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
+.. important::
+    Setting this QoS Policy to |BEST_EFFORT_RELIABILITY_QOS-api| affects to the :ref:`durabilityqospolicy` making the
+    endpoints behave as |VOLATILE_DURABILITY_QOS-api|.
+
 .. warning::
     For DataWriters and DataReaders to match, they must follow the compatibility rule.
     See :ref:`reliability_compatibilityrule` for further details.

--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -1048,7 +1048,7 @@ List of QoS Policy data members:
      It cannot be changed on enabled entities.
 
 .. important::
-    Setting this QoS Policy to |BEST_EFFORT_RELIABILITY_QOS-api| affects to the :ref:`durabilityqospolicy` making the
+    Setting this QoS Policy to |BEST_EFFORT_RELIABILITY_QOS-api| affects to the :ref:`durabilityqospolicy`, making the
     endpoints behave as |VOLATILE_DURABILITY_QOS-api|.
 
 .. warning::

--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -188,6 +188,10 @@ List of QoS Policy data members:
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
+.. important::
+    In order to receive past samples in the DataReader, besides setting this Qos Policy, it is required that the
+    :ref:`reliabilityqospolicy` is set to |RELIABLE_RELIABILITY_QOS-api|.
+
 .. warning::
     For DataWriters and DataReaders to match, they must follow the compatibility rule.
     See :ref:`durability_compatibilityrule` for further details.


### PR DESCRIPTION
Since Fast DDS v2.4.0 in order to receive past samples in the DataReaders, besides setting the DurabilityQosPolicy, ReliabilityQosPolicy must be set to `RELIABLE`.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>