### PR TITLE
Add Doxygen skip definition to doxyfile

### DIFF
--- a/code/doxygen-config.in
+++ b/code/doxygen-config.in
@@ -322,6 +322,7 @@ INCLUDE_PATH           =
 INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = "HAVE_SECURITY=1" \
                          "DOXYGEN_DOCUMENTATION=1" \
+                         "DOXYGEN_SHOULD_SKIP_THIS" \
                           RTPS_DllAPI=
 EXPAND_AS_DEFINED      = YES
 SKIP_FUNCTION_MACROS   = YES


### PR DESCRIPTION
This PR depends on eProsima/Fast-DDS#2395. It adds `DOXYGEN_SHOULD_SKIP_THIS` to doxyfile-config

Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>