### PR TITLE
Add Python API reference [13580]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ project(fastdds-docs VERSION "${LIB_VERSION_STR}" LANGUAGES C CXX)
 find_package(fastrtps REQUIRED)
 get_target_property(FAST_INCLUDE_DIR fastrtps INTERFACE_INCLUDE_DIRECTORIES)
 
+find_package(fastdds_python REQUIRED)
+get_target_property(FASTDDS_PYTHON_IMPORTED_LOCATION fastdds_python "LOCATION")
+get_filename_component (FASTDDS_PYTHON_IMPORTED_LOCATION ${FASTDDS_PYTHON_IMPORTED_LOCATION} DIRECTORY)
+
 message(STATUS "Fast DDS include directories: ${FAST_INCLUDE_DIR}")
 file(GLOB_RECURSE HPP_FILES "${FAST_INCLUDE_DIR}/fastdds/**/*.h*")
 
@@ -108,6 +112,7 @@ if (BUILD_DOCUMENTATION)
         ${SPHINX_EXECUTABLE} -b ${FASTDDS_DOCS_BUILDER}
         # Tell Breathe where to find the Doxygen output
         -D breathe_projects.FastDDS=${DOXYGEN_OUTPUT_DIR}/xml
+        -D fastdds_python_imported_location=${FASTDDS_PYTHON_IMPORTED_LOCATION}
         -d "${PROJECT_BINARY_DIR}/doctrees"
         ${SPHINX_SOURCE}
         ${PROJECT_BINARY_DIR}/${FASTDDS_DOCS_BUILDER}

--- a/README.md
+++ b/README.md
@@ -181,14 +181,20 @@ When this variable is set to `True`, [conf.py](docs/conf.py) will clone Fast DDS
 1. If the variable is not set, or the branch does not exist, try to checkout to a branch with the same name as the current branch on this repository.
 1. If the previous fails, fallback to `master`.
 
+Also Fast DDS Python bindings is cloned and follows a similar criteria:
+
+1. Try to checkout to the branch specified by environment variable `FASTDDS_PYTHON_BRANCH`.
+1. If the variable is not set, or the branch does not exist, try to checkout to a branch with the same name as the current branch on this repository.
+1. If the previous fails, fallback to `main`.
+
 To simulate ReadTheDocs operation, make sure you do not have a `build` directory.
-Then, set `READTHEDOCS` and `FASTDDS_BRANCH`, and run sphinx:
+Then, set `READTHEDOCS`, `FASTDDS_BRANCH` and `FASTDDS_PYTHON_BRANCH` and run sphinx:
 
 ```bash
 source <path_to_venv>/fastdds-docs-venv/bin/activate
 cd <path_to_docs_repo>/fastdds-docs
 rm -rf build
-READTHEDOCS=True FASTDDS_BRANCH=<branch> sphinx-build \
+READTHEDOCS=True FASTDDS_BRANCH=<branch> FASTDDS_PYTHON_BRANCH=<branch> sphinx-build \
     -b html \
     -D breathe_projects.FastDDS=<abs_path_to_docs_repo>/fastdds-docs/build/doxygen/xml \
     -d <abs_path_to_docs_repo>/fastdds-docs/build/doctrees \

--- a/colcon.meta
+++ b/colcon.meta
@@ -5,6 +5,13 @@
                 "-DSECURITY=ON",
             ]
         },
+        "fastdds_python":
+        {
+            "cmake-args":
+            [
+                "-DBUILD_DOCUMENTATION=ON",
+            ]
+        },
         "fastdds-docs":
         {
             "cmake-args":

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,5 +1,5 @@
 {
     "name": "fastdds-docs",
     "type": "cmake",
-    "dependencies": ["fastrtps"]
+    "dependencies": ["fastrtps", "fastdds_python"]
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ import git
 
 import requests
 
+# Add configuration variables which can be set when calling sphinx.
 def setup(app):
     app.add_config_value('fastdds_python_imported_location', None, '')
 
@@ -296,6 +297,7 @@ breathe_projects = {
 }
 breathe_default_project = 'FastDDS'
 
+# Tell `autodoc` where is the Pydoc documentation if it was set.
 if fastdds_python_imported_location:
     sys.path.insert(0, fastdds_python_imported_location)
 
@@ -311,7 +313,7 @@ if fastdds_python_imported_location:
 extensions = [
     'breathe',
     'sphinxcontrib.plantuml',
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc' # Document Pydoc documentation from Python bindings.
 ]
 
 try:
@@ -331,6 +333,7 @@ try:
 except ImportError:
     pass
 
+# Default behaviour for `autodoc`: always show documented members.
 autodoc_default_options = {
         'members': True,
         'undoc-members': False,
@@ -428,8 +431,11 @@ suppress_warnings = [
     'cpp.parse_function_declaration'
 ]
 
+# Check if we are checking the spelling. In this case...
 if 'spelling' in sys.argv:
+    # Exclude Python API Reference because `autodoc` shows warnings.
     exclude_patterns.append('fastdds/python_api_reference/dds_pim/*')
+    # Avoid the warning of a wrong reference in the TOC entries, because fails the Python API Reference reference.
     suppress_warnings.append('toc.excluded')
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -297,7 +297,6 @@ breathe_projects = {
 breathe_default_project = 'FastDDS'
 
 if fastdds_python_imported_location:
-    print('AUTO {}'.format(fastdds_python_imported_location))
     sys.path.insert(0, fastdds_python_imported_location)
 
 # -- General configuration ------------------------------------------------
@@ -314,6 +313,7 @@ extensions = [
     'sphinxcontrib.plantuml',
     'sphinx.ext.autodoc'
 ]
+
 try:
     import sphinxcontrib.spelling  # noqa: F401
     extensions.append('sphinxcontrib.spelling')
@@ -330,6 +330,11 @@ try:
     spelling_verbose = True
 except ImportError:
     pass
+
+autodoc_default_options = {
+        'members': True,
+        'undoc-members': False,
+        }
 
 plantuml = '/usr/bin/plantuml -Djava.awt.headless=true '
 plantuml_output_format = "svg"
@@ -422,6 +427,10 @@ suppress_warnings = [
     'cpp.duplicate_declaration',
     'cpp.parse_function_declaration'
 ]
+
+if 'spelling' in sys.argv:
+    exclude_patterns.append('fastdds/python_api_reference/dds_pim/*')
+    suppress_warnings.append('toc.excluded')
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -257,7 +257,7 @@ if read_the_docs_build:
                 docs_branch
             )
         )
-        fastdds_python_branch = 'origin/master'
+        fastdds_python_branch = 'origin/main'
 
     # Actual checkout
     print('Checking out Fast DDS Python branch "{}"'.format(fastdds_python_branch))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,11 +22,14 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 
 import git
 
 import requests
 
+def setup(app):
+    app.add_config_value('fastdds_python_imported_location', None, '')
 
 def download_css(html_css_dir):
     """
@@ -238,6 +241,11 @@ breathe_projects = {
 }
 breathe_default_project = 'FastDDS'
 
+fastdds_python_imported_location = None
+
+if fastdds_python_imported_location:
+    sys.path.insert(0, fastdds_python_imported_location)
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -250,6 +258,7 @@ breathe_default_project = 'FastDDS'
 extensions = [
     'breathe',
     'sphinxcontrib.plantuml',
+    'sphinx.ext.autodoc'
 ]
 try:
     import sphinxcontrib.spelling  # noqa: F401

--- a/docs/fastdds/api_reference/api_reference.rst
+++ b/docs/fastdds/api_reference/api_reference.rst
@@ -1,7 +1,7 @@
 .. _api_reference:
 
-API Reference
-=============
+C++ API Reference
+=================
 
 *Fast DDS*, as a Data Distribution Service (DDS) standard implementation, exposes the DDS Data-Centric Publish-Subscribe
 (DCPS) Platform Independent Model (PIM) API, as specified in the

--- a/docs/fastdds/python_api_reference/dds_pim/core/core.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/core.rst
@@ -1,0 +1,13 @@
+Core
+====
+
+.. toctree::
+
+   /fastdds/python_api_reference/dds_pim/core/entity.rst
+   /fastdds/python_api_reference/dds_pim/core/domainentity.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/policy.rst
+   /fastdds/python_api_reference/dds_pim/core/status/status.rst
+   /fastdds/python_api_reference/dds_pim/core/loanablearray.rst
+   /fastdds/python_api_reference/dds_pim/core/loanablecollection.rst
+   /fastdds/python_api_reference/dds_pim/core/loanablesequence.rst
+   /fastdds/python_api_reference/dds_pim/core/stackallocatedsequence.rst

--- a/docs/fastdds/python_api_reference/dds_pim/core/domainentity.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/domainentity.rst
@@ -1,0 +1,10 @@
+
+.. _python_api_pim_domainentity:
+
+.. rst-class:: api-ref
+
+DomainEntity
+------------
+
+.. autoclass:: fastdds.DomainEntity
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/domainentity.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/domainentity.rst
@@ -7,4 +7,3 @@ DomainEntity
 ------------
 
 .. autoclass:: fastdds.DomainEntity
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/entity.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/entity.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_entity:
+
+.. rst-class:: api-ref
+
+Entity
+------
+
+.. autoclass:: fastdds.Entity
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/entity.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/entity.rst
@@ -6,4 +6,3 @@ Entity
 ------
 
 .. autoclass:: fastdds.Entity
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/loanablearray.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/loanablearray.rst
@@ -7,4 +7,3 @@ LoanableArray
 
 .. TODO
    .. autoclass:: fastdds.LoanableArray
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/loanablearray.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/loanablearray.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_loanablearray:
+
+.. rst-class:: api-ref
+
+LoanableArray
+-------------
+
+.. TODO
+   .. autoclass:: fastdds.LoanableArray
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/loanablecollection.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/loanablecollection.rst
@@ -6,4 +6,3 @@ LoanableCollection
 ------------------
 
 .. autoclass:: fastdds.LoanableCollection
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/loanablecollection.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/loanablecollection.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_loanablecollection:
+
+.. rst-class:: api-ref
+
+LoanableCollection
+------------------
+
+.. autoclass:: fastdds.LoanableCollection
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/loanablesequence.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/loanablesequence.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_loanablesequence:
+
+.. rst-class:: api-ref
+
+LoanableSequence
+------------------
+
+.. TODO
+   .. autoclass:: fastdds.LoanableSequence
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/loanablesequence.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/loanablesequence.rst
@@ -7,4 +7,3 @@ LoanableSequence
 
 .. TODO
    .. autoclass:: fastdds.LoanableSequence
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/datarepresentationid.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/datarepresentationid.rst
@@ -1,0 +1,12 @@
+.. _python_api_pim_datarepresentationid:
+
+.. rst-class:: api-ref
+
+DataRepresentationId
+--------------------
+
+.. autoclass:: fastdds.XCDR_DATA_REPRESENTATION
+
+.. autoclass:: fastdds.XML_DATA_REPRESENTATION
+
+.. autoclass:: fastdds.XCDR2_DATA_REPRESENTATION

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/datarepresentationqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/datarepresentationqospolicy.rst
@@ -6,5 +6,3 @@ DataRepresentationQosPolicy
 ---------------------------
 
 .. autoclass:: fastdds.DataRepresentationQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/datarepresentationqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/datarepresentationqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_datarepresentationqospolicy:
+
+.. rst-class:: api-ref
+
+DataRepresentationQosPolicy
+---------------------------
+
+.. autoclass:: fastdds.DataRepresentationQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/datasharingkind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/datasharingkind.rst
@@ -1,0 +1,12 @@
+.. _python_api_pim_datasharingkind:
+
+.. rst-class:: api-ref
+
+DataSharingKind
+---------------
+
+.. autoclass:: fastdds.AUTO
+
+.. autoclass:: fastdds.ON
+
+.. autoclass:: fastdds.OFF

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/datasharingqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/datasharingqospolicy.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_datasharingqospolicy:
+
+.. rst-class:: api-ref
+
+DataSharingQosPolicy
+--------------------
+
+.. autoclass:: fastdds.DataSharingQosPolicy
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/datasharingqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/datasharingqospolicy.rst
@@ -6,4 +6,3 @@ DataSharingQosPolicy
 --------------------
 
 .. autoclass:: fastdds.DataSharingQosPolicy
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/deadlineqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/deadlineqospolicy.rst
@@ -6,5 +6,3 @@ DeadlineQosPolicy
 -----------------
 
 .. autoclass:: fastdds.DeadlineQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/deadlineqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/deadlineqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_deadlineqospolicy:
+
+.. rst-class:: api-ref
+
+DeadlineQosPolicy
+-----------------
+
+.. autoclass:: fastdds.DeadlineQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/destinationorderqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/destinationorderqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_destinationorderqospolicy:
+
+.. rst-class:: api-ref
+
+DestinationOrderQosPolicy
+-------------------------
+
+.. autoclass:: fastdds.DestinationOrderQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/destinationorderqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/destinationorderqospolicy.rst
@@ -6,5 +6,3 @@ DestinationOrderQosPolicy
 -------------------------
 
 .. autoclass:: fastdds.DestinationOrderQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/destinationorderqospolicykind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/destinationorderqospolicykind.rst
@@ -1,0 +1,11 @@
+.. _python_api_pim_destinationorderqospolicykind:
+
+.. rst-class:: api-ref
+
+DestinationOrderQosPolicyKind
+-----------------------------
+
+.. autoclass:: fastdds.BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS
+
+.. autoclass:: fastdds.BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/disablepositiveacksqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/disablepositiveacksqospolicy.rst
@@ -6,5 +6,3 @@ DisablePositiveACKsQosPolicy
 ----------------------------
 
 .. autoclass:: fastdds.DisablePositiveACKsQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/disablepositiveacksqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/disablepositiveacksqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_disablepositiveacksqospolicy:
+
+.. rst-class:: api-ref
+
+DisablePositiveACKsQosPolicy
+----------------------------
+
+.. autoclass:: fastdds.DisablePositiveACKsQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityqospolicy.rst
@@ -6,5 +6,3 @@ DurabilityQosPolicy
 -------------------
 
 .. autoclass:: fastdds.DurabilityQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_durabilityqospolicy:
+
+.. rst-class:: api-ref
+
+DurabilityQosPolicy
+-------------------
+
+.. autoclass:: fastdds.DurabilityQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityqospolicykind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityqospolicykind.rst
@@ -1,0 +1,14 @@
+.. _python_api_pim_durabilityqospolicykind:
+
+.. rst-class:: api-ref
+
+DurabilityQosPolicyKind
+-----------------------
+
+.. autoclass:: fastdds.VOLATILE_DURABILITY_QOS
+
+.. autoclass:: fastdds.TRANSIENT_LOCAL_DURABILITY_QOS
+
+.. autoclass:: fastdds.TRANSIENT_DURABILITY_QOS
+
+.. autoclass:: fastdds.PERSISTENT_DURABILITY_QOS

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityserviceqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityserviceqospolicy.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_durabilityserviceqospolicy:
+
+.. rst-class:: api-ref
+
+DurabilityServiceQosPolicy
+--------------------------
+
+.. autoclass:: fastdds.DurabilityServiceQosPolicy
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityserviceqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/durabilityserviceqospolicy.rst
@@ -6,4 +6,3 @@ DurabilityServiceQosPolicy
 --------------------------
 
 .. autoclass:: fastdds.DurabilityServiceQosPolicy
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/entityfactoryqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/entityfactoryqospolicy.rst
@@ -6,5 +6,3 @@ EntityFactoryQosPolicy
 ----------------------
 
 .. autoclass:: fastdds.EntityFactoryQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/entityfactoryqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/entityfactoryqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_entityfactoryqospolicy:
+
+.. rst-class:: api-ref
+
+EntityFactoryQosPolicy
+----------------------
+
+.. autoclass:: fastdds.EntityFactoryQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/genericdataqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/genericdataqospolicy.rst
@@ -6,5 +6,3 @@ GenericDataQosPolicy
 --------------------
 
 .. autoclass:: fastdds.GenericDataQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/genericdataqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/genericdataqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_genericdataqospolicy:
+
+.. rst-class:: api-ref
+
+GenericDataQosPolicy
+--------------------
+
+.. autoclass:: fastdds.GenericDataQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/groupdataqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/groupdataqospolicy.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_groupdataqospolicy:
+
+.. rst-class:: api-ref
+
+GroupDataQosPolicy
+------------------
+
+.. autoclass:: fastdds.GroupDataQosPolicy
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/groupdataqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/groupdataqospolicy.rst
@@ -6,4 +6,3 @@ GroupDataQosPolicy
 ------------------
 
 .. autoclass:: fastdds.GroupDataQosPolicy
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/historyqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/historyqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_historyqospolicy:
+
+.. rst-class:: api-ref
+
+HistoryQosPolicy
+----------------
+
+.. autoclass:: fastdds.HistoryQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/historyqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/historyqospolicy.rst
@@ -6,5 +6,3 @@ HistoryQosPolicy
 ----------------
 
 .. autoclass:: fastdds.HistoryQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/historyqospolicykind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/historyqospolicykind.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_historyqospolicykind:
+
+.. rst-class:: api-ref
+
+HistoryQosPolicyKind
+--------------------
+
+.. autoclass:: fastdds.KEEP_LAST_HISTORY_QOS
+
+.. autoclass:: fastdds.KEEP_ALL_HISTORY_QOS

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/latencybudgetqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/latencybudgetqospolicy.rst
@@ -6,5 +6,3 @@ LatencyBudgetQosPolicy
 ----------------------
 
 .. autoclass:: fastdds.LatencyBudgetQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/latencybudgetqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/latencybudgetqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_latencybudgetqospolicy:
+
+.. rst-class:: api-ref
+
+LatencyBudgetQosPolicy
+----------------------
+
+.. autoclass:: fastdds.LatencyBudgetQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/lifespanqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/lifespanqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_lifespanqospolicy:
+
+.. rst-class:: api-ref
+
+LifespanQosPolicy
+-----------------
+
+.. autoclass:: fastdds.LifespanQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/lifespanqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/lifespanqospolicy.rst
@@ -6,5 +6,3 @@ LifespanQosPolicy
 -----------------
 
 .. autoclass:: fastdds.LifespanQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/livelinessqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/livelinessqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_livelinessqospolicy:
+
+.. rst-class:: api-ref
+
+LivelinessQosPolicy
+-------------------
+
+.. autoclass:: fastdds.LivelinessQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/livelinessqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/livelinessqospolicy.rst
@@ -6,5 +6,3 @@ LivelinessQosPolicy
 -------------------
 
 .. autoclass:: fastdds.LivelinessQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/livelinessqospolicykind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/livelinessqospolicykind.rst
@@ -1,0 +1,12 @@
+.. _python_api_pim_livelinessqospolicykind:
+
+.. rst-class:: api-ref
+
+LivelinessQosPolicyKind
+-----------------------
+
+.. autoclass:: fastdds.AUTOMATIC_LIVELINESS_QOS
+
+.. autoclass:: fastdds.MANUAL_BY_PARTICIPANT_LIVELINESS_QOS
+
+.. autoclass:: fastdds.MANUAL_BY_TOPIC_LIVELINESS_QOS

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_ownershipqospolicy:
+
+.. rst-class:: api-ref
+
+OwnershipQosPolicy
+------------------
+
+.. autoclass:: fastdds.OwnershipQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipqospolicy.rst
@@ -6,5 +6,3 @@ OwnershipQosPolicy
 ------------------
 
 .. autoclass:: fastdds.OwnershipQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipqospolicykind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipqospolicykind.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_ownershipqospolicykind:
+
+.. rst-class:: api-ref
+
+OwnershipQosPolicyKind
+----------------------
+
+.. autoclass:: fastdds.SHARED_OWNERSHIP_QOS
+
+.. autoclass:: fastdds.EXCLUSIVE_OWNERSHIP_QOS

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipstrengthqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipstrengthqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_ownershipstrengthqospolicy:
+
+.. rst-class:: api-ref
+
+OwnershipStrengthQosPolicy
+--------------------------
+
+.. autoclass:: fastdds.OwnershipStrengthQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipstrengthqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/ownershipstrengthqospolicy.rst
@@ -6,5 +6,3 @@ OwnershipStrengthQosPolicy
 --------------------------
 
 .. autoclass:: fastdds.OwnershipStrengthQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/participantresourcelimitsqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/participantresourcelimitsqos.rst
@@ -1,0 +1,8 @@
+.. rst-class:: api-ref
+
+ParticipantResourceLimitsQos
+----------------------------
+
+.. TODO
+
+.. autoclass:: ParticipantResourceLimitsQos

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/participantresourcelimitsqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/participantresourcelimitsqos.rst
@@ -4,5 +4,4 @@ ParticipantResourceLimitsQos
 ----------------------------
 
 .. TODO
-
-.. autoclass:: ParticipantResourceLimitsQos
+        .. autoclass:: ParticipantResourceLimitsQos

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/partition_t.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/partition_t.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_partition_t:
+
+.. rst-class:: api-ref
+
+Partition_t
+-----------
+
+.. autoclass:: fastdds.Partition_t
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/partition_t.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/partition_t.rst
@@ -6,5 +6,3 @@ Partition_t
 -----------
 
 .. autoclass:: fastdds.Partition_t
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/partitionqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/partitionqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_partitionqospolicy:
+
+.. rst-class:: api-ref
+
+PartitionQosPolicy
+------------------
+
+.. autoclass:: fastdds.PartitionQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/partitionqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/partitionqospolicy.rst
@@ -6,5 +6,3 @@ PartitionQosPolicy
 ------------------
 
 .. autoclass:: fastdds.PartitionQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/policy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/policy.rst
@@ -1,0 +1,53 @@
+Policy
+======
+
+.. toctree::
+
+   /fastdds/python_api_reference/dds_pim/core/policy/datarepresentationid.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/datarepresentationqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/datasharingqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/datasharingkind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/deadlineqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/destinationorderqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/destinationorderqospolicykind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/disablepositiveacksqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/durabilityqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/durabilityqospolicykind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/durabilityserviceqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/entityfactoryqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/genericdataqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/groupdataqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/historyqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/historyqospolicykind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/latencybudgetqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/lifespanqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/livelinessqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/livelinessqospolicykind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/ownershipqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/ownershipqospolicykind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/ownershipstrengthqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/participantresourcelimitsqos.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/partition_t.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/partitionqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/presentationqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/presentationqospolicyaccessscopekind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/propertypolicyqos.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/publishmodeqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/publishmodeqospolicykind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/qospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/qospolicyid_t.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/readerdatalifecycleqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/reliabilityqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/reliabilityqospolicykind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/resourcelimitsqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/rtpsendpointqos.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/timebasedfilterqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/topicdataqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/transportconfigqos.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/transportpriorityqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/typeconsistencyenforcementqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/typeconsistencykind.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/userdataqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/wireprotocolconfigqos.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/writerdatalifecycleqospolicy.rst
+   /fastdds/python_api_reference/dds_pim/core/policy/writerresourcelimitsqos.rst

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/presentationqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/presentationqospolicy.rst
@@ -6,5 +6,3 @@ PresentationQosPolicy
 ---------------------
 
 .. autoclass:: fastdds.PresentationQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/presentationqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/presentationqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_presentationqospolicy:
+
+.. rst-class:: api-ref
+
+PresentationQosPolicy
+---------------------
+
+.. autoclass:: fastdds.PresentationQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/presentationqospolicyaccessscopekind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/presentationqospolicyaccessscopekind.rst
@@ -1,0 +1,12 @@
+.. _python_api_pim_presentationqospolicyaccessscopekind:
+
+.. rst-class:: api-ref
+
+PresentationQosPolicyAccessScopeKind
+------------------------------------
+
+.. autoclass:: fastdds.INSTANCE_PRESENTATION_QOS
+
+.. autoclass:: fastdds.TOPIC_PRESENTATION_QOS
+
+.. autoclass:: fastdds.GROUP_PRESENTATION_QOS

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/propertypolicyqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/propertypolicyqos.rst
@@ -1,0 +1,11 @@
+.. _python_api_pim_propertypolicyqos:
+
+.. rst-class:: api-ref
+
+PropertyPolicyQos
+-----------------
+
+.. TODO
+   .. autoclass:: fastdds.PropertyPolicyQos
+   :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/propertypolicyqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/propertypolicyqos.rst
@@ -7,5 +7,3 @@ PropertyPolicyQos
 
 .. TODO
    .. autoclass:: fastdds.PropertyPolicyQos
-   :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/publishmodeqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/publishmodeqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_publishmodeqospolicy:
+
+.. rst-class:: api-ref
+
+PublishModeQosPolicy
+--------------------
+
+.. autoclass:: fastdds.PublishModeQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/publishmodeqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/publishmodeqospolicy.rst
@@ -6,5 +6,3 @@ PublishModeQosPolicy
 --------------------
 
 .. autoclass:: fastdds.PublishModeQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/publishmodeqospolicykind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/publishmodeqospolicykind.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_publishmodeqospolicykind:
+
+.. rst-class:: api-ref
+
+PublishModeQosPolicyKind
+------------------------
+
+.. autoclass:: fastdds.SYNCHRONOUS_PUBLISH_MODE
+
+.. autoclass:: fastdds.ASYNCHRONOUS_PUBLISH_MODE

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/qospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/qospolicy.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_qospolicy:
+
+.. rst-class:: api-ref
+
+QosPolicy
+---------
+
+.. autoclass:: fastdds.QosPolicy
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/qospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/qospolicy.rst
@@ -6,4 +6,3 @@ QosPolicy
 ---------
 
 .. autoclass:: fastdds.QosPolicy
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/qospolicyid_t.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/qospolicyid_t.rst
@@ -1,0 +1,82 @@
+.. _python_api_pim_qospolicyid_t:
+
+.. rst-class:: api-ref
+
+QosPolicyId_t
+-------------
+
+.. autoclass:: fastdds.INVALID_QOS_POLICY_ID
+
+.. autoclass:: fastdds.USERDATA_QOS_POLICY_ID
+
+.. autoclass:: fastdds.DURABILITY_QOS_POLICY_ID
+
+.. autoclass:: fastdds.PRESENTATION_QOS_POLICY_ID
+
+.. autoclass:: fastdds.DEADLINE_QOS_POLICY_ID
+
+.. autoclass:: fastdds.LATENCYBUDGET_QOS_POLICY_ID
+
+.. autoclass:: fastdds.OWNERSHIP_QOS_POLICY_ID
+
+.. autoclass:: fastdds.OWNERSHIPSTRENGTH_QOS_POLICY_ID
+
+.. autoclass:: fastdds.LIVELINESS_QOS_POLICY_ID
+
+.. autoclass:: fastdds.TIMEBASEDFILTER_QOS_POLICY_ID
+
+.. autoclass:: fastdds.PARTITION_QOS_POLICY_ID
+
+.. autoclass:: fastdds.RELIABILITY_QOS_POLICY_ID
+
+.. autoclass:: fastdds.DESTINATIONORDER_QOS_POLICY_ID
+
+.. autoclass:: fastdds.HISTORY_QOS_POLICY_ID
+
+.. autoclass:: fastdds.RESOURCELIMITS_QOS_POLICY_ID
+
+.. autoclass:: fastdds.ENTITYFACTORY_QOS_POLICY_ID
+
+.. autoclass:: fastdds.WRITERDATALIFECYCLE_QOS_POLICY_ID
+
+.. autoclass:: fastdds.READERDATALIFECYCLE_QOS_POLICY_ID
+
+.. autoclass:: fastdds.TOPICDATA_QOS_POLICY_ID
+
+.. autoclass:: fastdds.GROUPDATA_QOS_POLICY_ID
+
+.. autoclass:: fastdds.TRANSPORTPRIORITY_QOS_POLICY_ID
+
+.. autoclass:: fastdds.LIFESPAN_QOS_POLICY_ID
+
+.. autoclass:: fastdds.DURABILITYSERVICE_QOS_POLICY_ID
+
+.. autoclass:: fastdds.DATAREPRESENTATION_QOS_POLICY_ID
+
+.. autoclass:: fastdds.TYPECONSISTENCYENFORCEMENT_QOS_POLICY_ID
+
+.. autoclass:: fastdds.DISABLEPOSITIVEACKS_QOS_POLICY_ID
+
+.. autoclass:: fastdds.PARTICIPANTRESOURCELIMITS_QOS_POLICY_ID
+
+.. autoclass:: fastdds.PROPERTYPOLICY_QOS_POLICY_ID
+
+.. autoclass:: fastdds.PUBLISHMODE_QOS_POLICY_ID
+
+.. autoclass:: fastdds.READERRESOURCELIMITS_QOS_POLICY_ID
+
+.. autoclass:: fastdds.RTPSENDPOINT_QOS_POLICY_ID
+
+.. autoclass:: fastdds.RTPSRELIABLEREADER_QOS_POLICY_ID
+
+.. autoclass:: fastdds.RTPSRELIABLEWRITER_QOS_POLICY_ID
+
+.. autoclass:: fastdds.TRANSPORTCONFIG_QOS_POLICY_ID
+
+.. autoclass:: fastdds.TYPECONSISTENCY_QOS_POLICY_ID
+
+.. autoclass:: fastdds.WIREPROTOCOLCONFIG_QOS_POLICY_ID
+
+.. autoclass:: fastdds.WRITERRESOURCELIMITS_QOS_POLICY_ID
+
+.. autoclass:: fastdds.NEXT_QOS_POLICY_ID

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/readerdatalifecycleqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/readerdatalifecycleqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_readerdatalifecycleqospolicy:
+
+.. rst-class:: api-ref
+
+ReaderDataLifecycleQosPolicy
+----------------------------
+
+.. autoclass:: fastdds.ReaderDataLifecycleQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/readerdatalifecycleqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/readerdatalifecycleqospolicy.rst
@@ -6,5 +6,3 @@ ReaderDataLifecycleQosPolicy
 ----------------------------
 
 .. autoclass:: fastdds.ReaderDataLifecycleQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/reliabilityqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/reliabilityqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_reliabilityqospolicy:
+
+.. rst-class:: api-ref
+
+ReliabilityQosPolicy
+--------------------
+
+.. autoclass:: fastdds.ReliabilityQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/reliabilityqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/reliabilityqospolicy.rst
@@ -6,5 +6,3 @@ ReliabilityQosPolicy
 --------------------
 
 .. autoclass:: fastdds.ReliabilityQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/reliabilityqospolicykind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/reliabilityqospolicykind.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_reliabilityqospolicykind:
+
+.. rst-class:: api-ref
+
+ReliabilityQosPolicyKind
+------------------------
+
+.. autoclass:: fastdds.BEST_EFFORT_RELIABILITY_QOS
+
+.. autoclass:: fastdds.RELIABLE_RELIABILITY_QOS

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/resourcelimitsqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/resourcelimitsqospolicy.rst
@@ -6,5 +6,3 @@ ResourceLimitsQosPolicy
 -----------------------
 
 .. autoclass:: fastdds.ResourceLimitsQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/resourcelimitsqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/resourcelimitsqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_resourcelimitsqospolicy:
+
+.. rst-class:: api-ref
+
+ResourceLimitsQosPolicy
+-----------------------
+
+.. autoclass:: fastdds.ResourceLimitsQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/rtpsendpointqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/rtpsendpointqos.rst
@@ -6,5 +6,3 @@ RTPSEndpointQos
 ---------------
 
 .. autoclass:: fastdds.RTPSEndpointQos
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/rtpsendpointqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/rtpsendpointqos.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_rtpsendpointqos:
+
+.. rst-class:: api-ref
+
+RTPSEndpointQos
+---------------
+
+.. autoclass:: fastdds.RTPSEndpointQos
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/timebasedfilterqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/timebasedfilterqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_timebasedfilterqospolicy:
+
+.. rst-class:: api-ref
+
+TimeBasedFilterQosPolicy
+------------------------
+
+.. autoclass:: fastdds.TimeBasedFilterQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/timebasedfilterqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/timebasedfilterqospolicy.rst
@@ -6,5 +6,3 @@ TimeBasedFilterQosPolicy
 ------------------------
 
 .. autoclass:: fastdds.TimeBasedFilterQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/topicdataqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/topicdataqospolicy.rst
@@ -6,4 +6,3 @@ TopicDataQosPolicy
 ------------------
 
 .. autoclass:: fastdds.TopicDataQosPolicy
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/topicdataqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/topicdataqospolicy.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_topicdataqospolicy:
+
+.. rst-class:: api-ref
+
+TopicDataQosPolicy
+------------------
+
+.. autoclass:: fastdds.TopicDataQosPolicy
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/transportconfigqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/transportconfigqos.rst
@@ -6,5 +6,3 @@ TransportConfigQos
 ------------------
 
 .. autoclass:: fastdds.TransportConfigQos
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/transportconfigqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/transportconfigqos.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_transportconfigqos:
+
+.. rst-class:: api-ref
+
+TransportConfigQos
+------------------
+
+.. autoclass:: fastdds.TransportConfigQos
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/transportpriorityqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/transportpriorityqospolicy.rst
@@ -6,5 +6,3 @@ TransportPriorityQosPolicy
 --------------------------
 
 .. autoclass:: fastdds.TransportPriorityQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/transportpriorityqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/transportpriorityqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_transportpriorityqospolicy:
+
+.. rst-class:: api-ref
+
+TransportPriorityQosPolicy
+--------------------------
+
+.. autoclass:: fastdds.TransportPriorityQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/typeconsistencyenforcementqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/typeconsistencyenforcementqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_typeconsistencyenforcementqospolicy:
+
+.. rst-class:: api-ref
+
+TypeConsistencyEnforcementQosPolicy
+-----------------------------------
+
+.. autoclass:: fastdds.TypeConsistencyEnforcementQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/typeconsistencyenforcementqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/typeconsistencyenforcementqospolicy.rst
@@ -6,5 +6,3 @@ TypeConsistencyEnforcementQosPolicy
 -----------------------------------
 
 .. autoclass:: fastdds.TypeConsistencyEnforcementQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/typeconsistencykind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/typeconsistencykind.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_typeconsistencykind:
+
+.. rst-class:: api-ref
+
+TypeConsistencyKind
+-------------------
+
+.. autoclass:: fastdds.DISALLOW_TYPE_COERCION
+
+.. autoclass:: fastdds.ALLOW_TYPE_COERCION

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/userdataqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/userdataqospolicy.rst
@@ -6,4 +6,3 @@ UserDataQosPolicy
 -----------------
 
 .. autoclass:: fastdds.UserDataQosPolicy
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/userdataqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/userdataqospolicy.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_userdataqospolicy:
+
+.. rst-class:: api-ref
+
+UserDataQosPolicy
+-----------------
+
+.. autoclass:: fastdds.UserDataQosPolicy
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/wireprotocolconfigqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/wireprotocolconfigqos.rst
@@ -6,5 +6,3 @@ WireProtocolConfigQos
 ---------------------
 
 .. autoclass:: fastdds.WireProtocolConfigQos
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/wireprotocolconfigqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/wireprotocolconfigqos.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_wireprotocolconfigqos:
+
+.. rst-class:: api-ref
+
+WireProtocolConfigQos
+---------------------
+
+.. autoclass:: fastdds.WireProtocolConfigQos
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/writerdatalifecycleqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/writerdatalifecycleqospolicy.rst
@@ -6,5 +6,3 @@ WriterDataLifecycleQosPolicy
 ----------------------------
 
 .. autoclass:: fastdds.WriterDataLifecycleQosPolicy
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/writerdatalifecycleqospolicy.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/writerdatalifecycleqospolicy.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_writerdatalifecycleqospolicy:
+
+.. rst-class:: api-ref
+
+WriterDataLifecycleQosPolicy
+----------------------------
+
+.. autoclass:: fastdds.WriterDataLifecycleQosPolicy
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/writerresourcelimitsqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/writerresourcelimitsqos.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_writerresourcelimitsqos:
+
+.. rst-class:: api-ref
+
+WriterResourceLimitsQos
+-----------------------
+
+.. autoclass:: fastdds.WriterResourceLimitsQos
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/core/policy/writerresourcelimitsqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/policy/writerresourcelimitsqos.rst
@@ -6,5 +6,3 @@ WriterResourceLimitsQos
 -----------------------
 
 .. autoclass:: fastdds.WriterResourceLimitsQos
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/core/stackallocatedsequence.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/stackallocatedsequence.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_stackallocatedsequence:
+
+.. rst-class:: api-ref
+
+StackAllocatedSequence
+----------------------
+
+.. TODO
+   .. autoclass:: fastdds.StackAllocatedSequence
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/stackallocatedsequence.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/stackallocatedsequence.rst
@@ -7,4 +7,3 @@ StackAllocatedSequence
 
 .. TODO
    .. autoclass:: fastdds.StackAllocatedSequence
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/basestatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/basestatus.rst
@@ -6,4 +6,3 @@ BaseStatus
 ----------
 
 .. autoclass:: fastdds.BaseStatus
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/basestatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/basestatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_basestatus:
+
+.. rst-class:: api-ref
+
+BaseStatus
+----------
+
+.. autoclass:: fastdds.BaseStatus
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/deadlinemissedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/deadlinemissedstatus.rst
@@ -6,4 +6,3 @@ DeadlineMissedStatus
 --------------------
 
 .. autoclass:: fastdds.DeadlineMissedStatus
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/deadlinemissedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/deadlinemissedstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_deadlinemissedstatus:
+
+.. rst-class:: api-ref
+
+DeadlineMissedStatus
+--------------------
+
+.. autoclass:: fastdds.DeadlineMissedStatus
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/incompatibleqosstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/incompatibleqosstatus.rst
@@ -6,4 +6,3 @@ IncompatibleQosStatus
 ---------------------
 
 .. autoclass:: fastdds.IncompatibleQosStatus
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/incompatibleqosstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/incompatibleqosstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_incompatibleqosstatus:
+
+.. rst-class:: api-ref
+
+IncompatibleQosStatus
+---------------------
+
+.. autoclass:: fastdds.IncompatibleQosStatus
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/inconsistenttopicstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/inconsistenttopicstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_inconsistenttopicstatus:
+
+.. rst-class:: api-ref
+
+InconsistentTopicStatus
+-----------------------
+
+.. TODO
+   .. autoclass:: fastdds.InconsistentTopicStatus

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/livelinesschangedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/livelinesschangedstatus.rst
@@ -6,4 +6,3 @@ LivelinessChangedStatus
 -----------------------
 
 .. autoclass:: fastdds.LivelinessChangedStatus
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/livelinesschangedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/livelinesschangedstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_livelinesschangedstatus:
+
+.. rst-class:: api-ref
+
+LivelinessChangedStatus
+-----------------------
+
+.. autoclass:: fastdds.LivelinessChangedStatus
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/matchedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/matchedstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_matchedstatus:
+
+.. rst-class:: api-ref
+
+MatchedStatus
+-------------
+
+.. autoclass:: fastdds.MatchedStatus
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/matchedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/matchedstatus.rst
@@ -6,4 +6,3 @@ MatchedStatus
 -------------
 
 .. autoclass:: fastdds.MatchedStatus
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/offereddeadlinemissedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/offereddeadlinemissedstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_offereddeadlinemissedstatus:
+
+.. rst-class:: api-ref
+
+OfferedDeadlineMissedStatus
+---------------------------
+
+.. TODO
+   .. autoclass:: fastdds.OfferedDeadlineMissedStatus

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/offeredincompatibleqosstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/offeredincompatibleqosstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_offeredincompatibleqosstatus:
+
+.. rst-class:: api-ref
+
+OfferedIncompatibleQosStatus
+----------------------------
+
+.. TODO
+   .. autoclass:: fastdds.OfferedIncompatibleQosStatus

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/publicationmatchedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/publicationmatchedstatus.rst
@@ -6,4 +6,3 @@ PublicationMatchedStatus
 ------------------------
 
 .. autoclass:: fastdds.PublicationMatchedStatus
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/publicationmatchedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/publicationmatchedstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_publicationmatchedstatus:
+
+.. rst-class:: api-ref
+
+PublicationMatchedStatus
+------------------------
+
+.. autoclass:: fastdds.PublicationMatchedStatus
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/qospolicycount.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/qospolicycount.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_qospolicycount:
+
+.. rst-class:: api-ref
+
+QosPolicyCount
+--------------
+
+.. autoclass:: fastdds.QosPolicyCount
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/qospolicycount.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/qospolicycount.rst
@@ -6,4 +6,3 @@ QosPolicyCount
 --------------
 
 .. autoclass:: fastdds.QosPolicyCount
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/qospolicycountseq.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/qospolicycountseq.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_qospolicycountseq:
+
+.. rst-class:: api-ref
+
+QosPolicyCountSeq
+-----------------
+
+.. TODO
+   .. autoclass:: fastdds.QosPolicyCountSeq

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/requesteddeadlinemissedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/requesteddeadlinemissedstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_requesteddeadlinemissedstatus:
+
+.. rst-class:: api-ref
+
+RequestedDeadlineMissedStatus
+-----------------------------
+
+.. TODO
+   .. autoclass:: fastdds.RequestedDeadlineMissedStatus

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/requestedincompatibleqosstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/requestedincompatibleqosstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_requestedincompatibleqosstatus:
+
+.. rst-class:: api-ref
+
+RequestedIncompatibleQosStatus
+------------------------------
+
+.. TODO
+   .. autoclass:: fastdds.RequestedIncompatibleQosStatus

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/rtpslivelinessloststatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/rtpslivelinessloststatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_livelinessloststatus:
+
+.. rst-class:: api-ref
+
+LivelinessLostStatus
+--------------------
+
+.. TODO
+   .. autoclass:: fastdds.LivelinessLostStatus

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/sampleloststatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/sampleloststatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_sampleloststatus:
+
+.. rst-class:: api-ref
+
+SampleLostStatus
+----------------
+
+.. TODO
+   .. autoclass:: fastdds.SampleLostStatus

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/samplerejectedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/samplerejectedstatus.rst
@@ -6,4 +6,3 @@ SampleRejectedStatus
 --------------------
 
 .. autoclass:: fastdds.SampleRejectedStatus
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/samplerejectedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/samplerejectedstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_samplerejectedstatus:
+
+.. rst-class:: api-ref
+
+SampleRejectedStatus
+--------------------
+
+.. autoclass:: fastdds.SampleRejectedStatus
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/samplerejectedstatuskind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/samplerejectedstatuskind.rst
@@ -1,0 +1,14 @@
+.. _python_api_pim_samplerejectedstatuskind:
+
+.. rst-class:: api-ref
+
+SampleRejectedStatusKind
+------------------------
+
+.. autoclass:: fastdds.NOT_REJECTED
+
+.. autoclass:: fastdds.REJECTED_BY_INSTANCES_LIMIT
+
+.. autoclass:: fastdds.REJECTED_BY_SAMPLES_LIMIT
+
+.. autoclass:: fastdds.REJECTED_BY_SAMPLES_PER_INSTANCE_LIMIT

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/status.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/status.rst
@@ -1,0 +1,24 @@
+Status
+======
+
+.. toctree::
+
+   /fastdds/python_api_reference/dds_pim/core/status/basestatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/deadlinemissedstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/incompatibleqosstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/inconsistenttopicstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/livelinesschangedstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/matchedstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/offereddeadlinemissedstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/offeredincompatibleqosstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/publicationmatchedstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/qospolicycount.rst
+   /fastdds/python_api_reference/dds_pim/core/status/qospolicycountseq.rst
+   /fastdds/python_api_reference/dds_pim/core/status/requesteddeadlinemissedstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/requestedincompatibleqosstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/rtpslivelinessloststatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/sampleloststatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/samplerejectedstatus.rst
+   /fastdds/python_api_reference/dds_pim/core/status/samplerejectedstatuskind.rst
+   /fastdds/python_api_reference/dds_pim/core/status/statusmask.rst
+   /fastdds/python_api_reference/dds_pim/core/status/subscriptionmatchedstatus.rst

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/statusmask.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/statusmask.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_statusmask:
+
+.. rst-class:: api-ref
+
+StatusMask
+----------
+
+.. autoclass:: fastdds.StatusMask
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/statusmask.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/statusmask.rst
@@ -6,4 +6,3 @@ StatusMask
 ----------
 
 .. autoclass:: fastdds.StatusMask
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/subscriptionmatchedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/subscriptionmatchedstatus.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_subscriptionmatchedstatus:
+
+.. rst-class:: api-ref
+
+SubscriptionMatchedStatus
+-------------------------
+
+.. autoclass:: fastdds.SubscriptionMatchedStatus
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/core/status/subscriptionmatchedstatus.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/core/status/subscriptionmatchedstatus.rst
@@ -6,4 +6,3 @@ SubscriptionMatchedStatus
 -------------------------
 
 .. autoclass:: fastdds.SubscriptionMatchedStatus
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/dds_pim.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/dds_pim.rst
@@ -6,6 +6,7 @@ DDS DCPS PIM
 Data Distribution Service (DDS) Data-Centric Publish-Subscribe (DCPS) Platform Independent Model (PIM) API
 
 .. toctree::
+    :orphan:
 
    /fastdds/python_api_reference/dds_pim/core/core.rst
    /fastdds/python_api_reference/dds_pim/domain/domain.rst

--- a/docs/fastdds/python_api_reference/dds_pim/dds_pim.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/dds_pim.rst
@@ -6,7 +6,6 @@ DDS DCPS PIM
 Data Distribution Service (DDS) Data-Centric Publish-Subscribe (DCPS) Platform Independent Model (PIM) API
 
 .. toctree::
-    :orphan:
 
    /fastdds/python_api_reference/dds_pim/core/core.rst
    /fastdds/python_api_reference/dds_pim/domain/domain.rst

--- a/docs/fastdds/python_api_reference/dds_pim/dds_pim.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/dds_pim.rst
@@ -1,0 +1,14 @@
+.. _python_api_pim_dds_dcps_pim:
+
+DDS DCPS PIM
+============
+
+Data Distribution Service (DDS) Data-Centric Publish-Subscribe (DCPS) Platform Independent Model (PIM) API
+
+.. toctree::
+
+   /fastdds/python_api_reference/dds_pim/core/core.rst
+   /fastdds/python_api_reference/dds_pim/domain/domain.rst
+   /fastdds/python_api_reference/dds_pim/publisher/publisher.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/subscriber.rst
+   /fastdds/python_api_reference/dds_pim/topic/topic.rst

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domain.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domain.rst
@@ -1,0 +1,10 @@
+Domain
+======
+
+.. toctree::
+
+   /fastdds/python_api_reference/dds_pim/domain/domainparticipant.rst
+   /fastdds/python_api_reference/dds_pim/domain/domainparticipantfactory.rst
+   /fastdds/python_api_reference/dds_pim/domain/domainparticipantfactoryqos.rst
+   /fastdds/python_api_reference/dds_pim/domain/domainparticipantlistener.rst
+   /fastdds/python_api_reference/dds_pim/domain/domainparticipantqos.rst

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipant.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipant.rst
@@ -6,4 +6,3 @@ DomainParticipant
 -----------------
 
 .. autoclass:: fastdds.DomainParticipant
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipant.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipant.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_domainparticipant:
+
+.. rst-class:: api-ref
+
+DomainParticipant
+-----------------
+
+.. autoclass:: fastdds.DomainParticipant
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantfactory.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantfactory.rst
@@ -6,4 +6,3 @@ DomainParticipantFactory
 ------------------------
 
 .. autoclass:: fastdds.DomainParticipantFactory
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantfactory.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantfactory.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_domainparticipantfactory:
+
+.. rst-class:: api-ref
+
+DomainParticipantFactory
+------------------------
+
+.. autoclass:: fastdds.DomainParticipantFactory
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantfactoryqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantfactoryqos.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_domainparticipantfactoryqos:
+
+.. rst-class:: api-ref
+
+DomainParticipantFactoryQos
+---------------------------
+
+.. autoclass:: fastdds.DomainParticipantFactoryQos
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantfactoryqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantfactoryqos.rst
@@ -6,4 +6,3 @@ DomainParticipantFactoryQos
 ---------------------------
 
 .. autoclass:: fastdds.DomainParticipantFactoryQos
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantlistener.rst
@@ -6,4 +6,3 @@ DomainParticipantListener
 -------------------------
 
 .. autoclass:: fastdds.DomainParticipantListener
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantlistener.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_domainparticipantlistener:
+
+.. rst-class:: api-ref
+
+DomainParticipantListener
+-------------------------
+
+.. autoclass:: fastdds.DomainParticipantListener
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantqos.rst
@@ -1,0 +1,13 @@
+.. _python_api_pim_domainparticipantqos:
+
+.. rst-class:: api-ref
+
+DomainParticipantQos
+--------------------
+
+.. autoclass:: fastdds.DomainParticipantQos
+    :members:
+
+
+.. TODO
+   .. autoclass:: fastdds.PARTICIPANT_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/domain/domainparticipantqos.rst
@@ -6,7 +6,6 @@ DomainParticipantQos
 --------------------
 
 .. autoclass:: fastdds.DomainParticipantQos
-    :members:
 
 
 .. TODO

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/datawriter.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/datawriter.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_datawriter:
+
+.. rst-class:: api-ref
+
+DataWriter
+----------
+
+.. autoclass:: fastdds.DataWriter
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/datawriter.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/datawriter.rst
@@ -6,4 +6,3 @@ DataWriter
 ----------
 
 .. autoclass:: fastdds.DataWriter
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterlistener.rst
@@ -6,4 +6,3 @@ DataWriterListener
 ------------------
 
 .. autoclass:: fastdds.DataWriterListener
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterlistener.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_datawriterlistener:
+
+.. rst-class:: api-ref
+
+DataWriterListener
+------------------
+
+.. autoclass:: fastdds.DataWriterListener
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterqos.rst
@@ -6,6 +6,5 @@ DataWriterQos
 -------------
 
 .. autoclass:: fastdds.DataWriterQos
-    :members:
 
 .. autoclass:: fastdds.DATAWRITER_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterqos.rst
@@ -1,0 +1,11 @@
+.. _python_api_pim_datawriterqos:
+
+.. rst-class:: api-ref
+
+DataWriterQos
+-------------
+
+.. autoclass:: fastdds.DataWriterQos
+    :members:
+
+.. autoclass:: fastdds.DATAWRITER_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/publisher.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/publisher.rst
@@ -1,0 +1,12 @@
+Publisher
+=========
+
+.. toctree::
+
+   /fastdds/python_api_reference/dds_pim/publisher/datawriter.rst
+   /fastdds/python_api_reference/dds_pim/publisher/datawriterlistener.rst
+   /fastdds/python_api_reference/dds_pim/publisher/datawriterqos.rst
+   /fastdds/python_api_reference/dds_pim/publisher/publisher_class.rst
+   /fastdds/python_api_reference/dds_pim/publisher/publisherlistener.rst
+   /fastdds/python_api_reference/dds_pim/publisher/publisherqos.rst
+   /fastdds/python_api_reference/dds_pim/publisher/rtpsreliablewriterqos.rst

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/publisher_class.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/publisher_class.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_publisher_class:
+
+.. rst-class:: api-ref
+
+Publisher
+---------
+
+.. autoclass:: fastdds.Publisher
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/publisher_class.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/publisher_class.rst
@@ -6,4 +6,3 @@ Publisher
 ---------
 
 .. autoclass:: fastdds.Publisher
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/publisherlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/publisherlistener.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_publisherlistener:
+
+.. rst-class:: api-ref
+
+PublisherListener
+-----------------
+
+.. autoclass:: fastdds.PublisherListener
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/publisherlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/publisherlistener.rst
@@ -6,4 +6,3 @@ PublisherListener
 -----------------
 
 .. autoclass:: fastdds.PublisherListener
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/publisherqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/publisherqos.rst
@@ -6,6 +6,5 @@ PublisherQos
 ------------
 
 .. autoclass:: fastdds.PublisherQos
-    :members:
 
 .. autoclass:: fastdds.PUBLISHER_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/publisherqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/publisherqos.rst
@@ -1,0 +1,11 @@
+.. _python_api_pim_publisherqos:
+
+.. rst-class:: api-ref
+
+PublisherQos
+------------
+
+.. autoclass:: fastdds.PublisherQos
+    :members:
+
+.. autoclass:: fastdds.PUBLISHER_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/rtpsreliablewriterqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/rtpsreliablewriterqos.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_rtpsreliablewriterqos:
+
+.. rst-class:: api-ref
+
+RTPSReliableWriterQos
+---------------------
+
+.. autoclass:: fastdds.RTPSReliableWriterQos
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/rtpsreliablewriterqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/rtpsreliablewriterqos.rst
@@ -6,4 +6,3 @@ RTPSReliableWriterQos
 ---------------------
 
 .. autoclass:: fastdds.RTPSReliableWriterQos
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/datareader.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/datareader.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_datareader:
+
+.. rst-class:: api-ref
+
+DataReader
+----------
+
+.. autoclass:: fastdds.DataReader
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/datareader.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/datareader.rst
@@ -6,4 +6,3 @@ DataReader
 ----------
 
 .. autoclass:: fastdds.DataReader
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderlistener.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_datareaderlistener:
+
+.. rst-class:: api-ref
+
+DataReaderListener
+------------------
+
+.. autoclass:: fastdds.DataReaderListener
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderlistener.rst
@@ -6,4 +6,3 @@ DataReaderListener
 ------------------
 
 .. autoclass:: fastdds.DataReaderListener
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderqos.rst
@@ -1,0 +1,11 @@
+.. _python_api_pim_datareaderqos:
+
+.. rst-class:: api-ref
+
+DataReaderQos
+-------------
+
+.. autoclass:: fastdds.DataReaderQos
+    :members:
+
+.. autoclass:: fastdds.DATAREADER_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderqos.rst
@@ -6,6 +6,5 @@ DataReaderQos
 -------------
 
 .. autoclass:: fastdds.DataReaderQos
-    :members:
 
 .. autoclass:: fastdds.DATAREADER_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/instancestatekind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/instancestatekind.rst
@@ -1,0 +1,12 @@
+.. _python_api_pim_instancestatekind:
+
+.. rst-class:: api-ref
+
+InstanceStateKind
+-----------------
+
+.. autoclass:: fastdds.ALIVE_INSTANCE_STATE
+
+.. autoclass:: fastdds.NOT_ALIVE_DISPOSED_INSTANCE_STATE
+
+.. autoclass:: fastdds.NOT_ALIVE_NO_WRITERS_INSTANCE_STATE

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/readerresourcelimitsqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/readerresourcelimitsqos.rst
@@ -6,4 +6,3 @@ ReaderResourceLimitsQos
 -----------------------
 
 .. autoclass:: fastdds.ReaderResourceLimitsQos
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/readerresourcelimitsqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/readerresourcelimitsqos.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_readerresourcelimitsqos:
+
+.. rst-class:: api-ref
+
+ReaderResourceLimitsQos
+-----------------------
+
+.. autoclass:: fastdds.ReaderResourceLimitsQos
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/rtpsreliablereaderqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/rtpsreliablereaderqos.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_rtpsreliablereaderqos:
+
+.. rst-class:: api-ref
+
+RTPSReliableReaderQos
+---------------------
+
+.. autoclass:: fastdds.RTPSReliableReaderQos
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/rtpsreliablereaderqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/rtpsreliablereaderqos.rst
@@ -6,4 +6,3 @@ RTPSReliableReaderQos
 ---------------------
 
 .. autoclass:: fastdds.RTPSReliableReaderQos
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/sampleinfo.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/sampleinfo.rst
@@ -6,4 +6,3 @@ SampleInfo
 ----------
 
 .. autoclass:: fastdds.SampleInfo
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/sampleinfo.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/sampleinfo.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_sampleinfo:
+
+.. rst-class:: api-ref
+
+SampleInfo
+----------
+
+.. autoclass:: fastdds.SampleInfo
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/samplestatekind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/samplestatekind.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_samplestatekind:
+
+.. rst-class:: api-ref
+
+SampleStateKind
+---------------
+
+.. autoclass:: fastdds.READ_SAMPLE_STATE
+
+.. autoclass:: fastdds.NOT_READ_SAMPLE_STATE

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriber.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriber.rst
@@ -1,0 +1,18 @@
+Subscriber
+==========
+
+.. toctree::
+
+   /fastdds/python_api_reference/dds_pim/subscriber/datareader.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/datareaderlistener.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/datareaderqos.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/instancestatekind.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/readerresourcelimitsqos.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/rtpsreliablereaderqos.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/sampleinfo.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/samplestatekind.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/subscriber_class.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/subscriberlistener.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/subscriberqos.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/typeconsistencyqos.rst
+   /fastdds/python_api_reference/dds_pim/subscriber/viewstatekind.rst

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriber_class.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriber_class.rst
@@ -6,4 +6,3 @@ Subscriber
 ----------
 
 .. autoclass:: fastdds.Subscriber
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriber_class.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriber_class.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_subscriber_class:
+
+.. rst-class:: api-ref
+
+Subscriber
+----------
+
+.. autoclass:: fastdds.Subscriber
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriberlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriberlistener.rst
@@ -6,4 +6,3 @@ SubscriberListener
 ------------------
 
 .. autoclass:: fastdds.SubscriberListener
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriberlistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriberlistener.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_subscriberlistener:
+
+.. rst-class:: api-ref
+
+SubscriberListener
+------------------
+
+.. autoclass:: fastdds.SubscriberListener
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriberqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriberqos.rst
@@ -6,6 +6,5 @@ SubscriberQos
 -------------
 
 .. autoclass:: fastdds.SubscriberQos
-    :members:
 
 .. autoclass:: fastdds.SUBSCRIBER_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriberqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/subscriberqos.rst
@@ -1,0 +1,11 @@
+.. _python_api_pim_subscriberqos:
+
+.. rst-class:: api-ref
+
+SubscriberQos
+-------------
+
+.. autoclass:: fastdds.SubscriberQos
+    :members:
+
+.. autoclass:: fastdds.SUBSCRIBER_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/typeconsistencyqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/typeconsistencyqos.rst
@@ -6,4 +6,3 @@ TypeConsistencyQos
 ------------------
 
 .. autoclass:: fastdds.TypeConsistencyQos
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/typeconsistencyqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/typeconsistencyqos.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_typeconsistencyqos:
+
+.. rst-class:: api-ref
+
+TypeConsistencyQos
+------------------
+
+.. autoclass:: fastdds.TypeConsistencyQos
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/viewstatekind.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/viewstatekind.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_viewstatekind:
+
+.. rst-class:: api-ref
+
+ViewStateKind
+-------------
+
+.. autoclass:: fastdds.NEW_VIEW_STATE
+
+.. autoclass:: fastdds.NOT_NEW_VIEW_STATE

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topic.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topic.rst
@@ -1,0 +1,14 @@
+Topic
+=====
+
+.. toctree::
+
+   /fastdds/python_api_reference/dds_pim/topic/topic_class.rst
+   /fastdds/python_api_reference/dds_pim/topic/topicdatatype.rst
+   /fastdds/python_api_reference/dds_pim/topic/topicdescription.rst
+   /fastdds/python_api_reference/dds_pim/topic/topiclistener.rst
+   /fastdds/python_api_reference/dds_pim/topic/topicqos.rst
+   /fastdds/python_api_reference/dds_pim/topic/typeidv1.rst
+   /fastdds/python_api_reference/dds_pim/topic/typeinformation.rst
+   /fastdds/python_api_reference/dds_pim/topic/typeobjectv1.rst
+   /fastdds/python_api_reference/dds_pim/topic/typesupport.rst

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topic_class.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topic_class.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_topic_class:
+
+.. rst-class:: api-ref
+
+Topic
+-----
+
+.. autoclass:: fastdds.Topic
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topic_class.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topic_class.rst
@@ -6,4 +6,3 @@ Topic
 -----
 
 .. autoclass:: fastdds.Topic
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topicdatatype.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topicdatatype.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_topicdatatype:
+
+.. rst-class:: api-ref
+
+TopicDataType
+-------------
+
+.. autoclass:: fastdds.TopicDataType
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topicdatatype.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topicdatatype.rst
@@ -6,4 +6,3 @@ TopicDataType
 -------------
 
 .. autoclass:: fastdds.TopicDataType
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topicdescription.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topicdescription.rst
@@ -6,4 +6,3 @@ TopicDescription
 ----------------
 
 .. autoclass:: fastdds.TopicDescription
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topicdescription.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topicdescription.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_topicdescription:
+
+.. rst-class:: api-ref
+
+TopicDescription
+----------------
+
+.. autoclass:: fastdds.TopicDescription
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topiclistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topiclistener.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_topiclistener:
+
+.. rst-class:: api-ref
+
+TopicListener
+-------------
+
+.. autoclass:: fastdds.TopicListener
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topiclistener.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topiclistener.rst
@@ -6,4 +6,3 @@ TopicListener
 -------------
 
 .. autoclass:: fastdds.TopicListener
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topicqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topicqos.rst
@@ -6,6 +6,5 @@ TopicQos
 --------
 
 .. autoclass:: fastdds.TopicQos
-    :members:
 
 .. autoclass:: fastdds.TOPIC_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/topic/topicqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/topicqos.rst
@@ -1,0 +1,11 @@
+.. _python_api_pim_topicqos:
+
+.. rst-class:: api-ref
+
+TopicQos
+--------
+
+.. autoclass:: fastdds.TopicQos
+    :members:
+
+.. autoclass:: fastdds.TOPIC_QOS_DEFAULT

--- a/docs/fastdds/python_api_reference/dds_pim/topic/typeidv1.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/typeidv1.rst
@@ -6,5 +6,3 @@ TypeIdV1
 --------
 
 .. autoclass:: fastdds.TypeIdV1
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/topic/typeidv1.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/typeidv1.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_typeidv1:
+
+.. rst-class:: api-ref
+
+TypeIdV1
+--------
+
+.. autoclass:: fastdds.TypeIdV1
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/topic/typeinformation.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/typeinformation.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_typeinformation:
+
+.. rst-class:: api-ref
+
+TypeInformation
+---------------
+
+.. autoclass:: fastdds.TypeInformation
+    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/typeinformation.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/typeinformation.rst
@@ -6,4 +6,3 @@ TypeInformation
 ---------------
 
 .. autoclass:: fastdds.TypeInformation
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/typeobjectv1.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/typeobjectv1.rst
@@ -6,5 +6,3 @@ TypeObjectV1
 ------------
 
 .. autoclass:: fastdds.TypeObjectV1
-    :members:
-

--- a/docs/fastdds/python_api_reference/dds_pim/topic/typeobjectv1.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/typeobjectv1.rst
@@ -1,0 +1,10 @@
+.. _python_api_pim_typeobjectv1:
+
+.. rst-class:: api-ref
+
+TypeObjectV1
+------------
+
+.. autoclass:: fastdds.TypeObjectV1
+    :members:
+

--- a/docs/fastdds/python_api_reference/dds_pim/topic/typesupport.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/typesupport.rst
@@ -6,4 +6,3 @@ TypeSupport
 -----------
 
 .. autoclass:: fastdds.TypeSupport
-    :members:

--- a/docs/fastdds/python_api_reference/dds_pim/topic/typesupport.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/topic/typesupport.rst
@@ -1,0 +1,9 @@
+.. _python_api_pim_typesupport:
+
+.. rst-class:: api-ref
+
+TypeSupport
+-----------
+
+.. autoclass:: fastdds.TypeSupport
+    :members:

--- a/docs/fastdds/python_api_reference/python_api_reference.rst
+++ b/docs/fastdds/python_api_reference/python_api_reference.rst
@@ -1,0 +1,10 @@
+.. _python_api_reference:
+
+Python API Reference
+====================
+
+This section presents the most commonly used Python APIs provided by *Fast DDS*.
+
+.. toctree::
+
+   /fastdds/python_api_reference/dds_pim/dds_pim

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@
    /fastdds/use_cases/use_cases
    /fastdds/ros2/ros2
    /fastdds/api_reference/api_reference
+   /fastdds/python_api_reference/python_api_reference
 
 .. _index_gen:
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -11,6 +11,7 @@ build:
     python: "3.8"
   apt_packages:
     - plantuml
+    - swig
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
This PR adds a new section *Python API Reference*. This section shows the generated PyDoc documentation from eProsima/Fast-DDS-python, which just comes from the C++ doxygen documentation.

Also this branch was tested against RTD: https://fast-dds.docs.eprosima.com/en/feature-python-bindings/