### PR TITLE
Move DNS information from DS to Locators section [13611]

### DIFF
--- a/docs/fastdds/discovery/discovery_server.rst
+++ b/docs/fastdds/discovery/discovery_server.rst
@@ -328,30 +328,7 @@ Configure Discovery Server locators using names
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All the examples provided in :ref:`discovery_server` use IPv4 addresses to specify the servers' listening locators.
-However, *Fast DDS* also allows to specify locator addresses using names.
-When an address is specified by a name, *Fast DDS* will query the known hosts and available DNS servers to try to
-resolve the IP address.
-This address will in turn be used to create the listening locator in the case of *server*, or as the address of the
-remote *server* in the case of *clients* (and *servers* that connect to other *servers*).
-
-+---------------------------------------------------------------------+
-| **C++**                                                             |
-+---------------------------------------------------------------------+
-| .. literalinclude:: /../code/DDSCodeTester.cpp                      |
-|    :language: c++                                                   |
-|    :start-after: //CONF_SERVER_DNS_LOCATORS                         |
-|    :end-before: //!--                                               |
-|    :dedent: 8                                                       |
-|                                                                     |
-+---------------------------------------------------------------------+
-| **XML**                                                             |
-+---------------------------------------------------------------------+
-| .. literalinclude:: /../code/XMLTester.xml                          |
-|    :language: xml                                                   |
-|    :start-after: <!-->CONF_SERVER_DNS_LOCATORS<-->                  |
-|    :end-before: <!--><-->                                           |
-|    :dedent: 28                                                      |
-+---------------------------------------------------------------------+
+However, *Fast DDS* also allows to :ref:`specify locator addresses using names <transport_transportApi_ipLocator>`.
 
 .. _DS_full_example:
 

--- a/docs/fastdds/transport/transport_api.rst
+++ b/docs/fastdds/transport/transport_api.rst
@@ -190,6 +190,35 @@ However, :class:`IPLocator` allows to manage them if needed.
     :end-before: //!--
     :dedent: 8
 
+*Fast DDS* also allows to specify locator addresses using names.
+When an address is specified by a name, *Fast DDS* will query the known hosts and available DNS servers to try to
+resolve the IP address.
+This address will in turn be used to create the listening locator in the case of *server*, or as the address of the
+remote *server* in the case of *clients* (and *servers* that connect to other *servers*).
+
++---------------------------------------------------------------------+
+| **C++**                                                             |
++---------------------------------------------------------------------+
+| .. literalinclude:: /../code/DDSCodeTester.cpp                      |
+|    :language: c++                                                   |
+|    :start-after: //CONF_SERVER_DNS_LOCATORS                         |
+|    :end-before: //!--                                               |
+|    :dedent: 8                                                       |
+|                                                                     |
++---------------------------------------------------------------------+
+| **XML**                                                             |
++---------------------------------------------------------------------+
+| .. literalinclude:: /../code/XMLTester.xml                          |
+|    :language: xml                                                   |
+|    :start-after: <!-->CONF_SERVER_DNS_LOCATORS<-->                  |
+|    :end-before: <!--><-->                                           |
+|    :dedent: 28                                                      |
++---------------------------------------------------------------------+
+
+.. warning::
+
+    Currently, XML only supports loading IP addresses by name for UDP transport.
+
 .. _transport_transportApi_chaining:
 
 Chaining of transports


### PR DESCRIPTION
Discovery Server settings included the feature of specifying the locators address by name directly. This feature is not only for Discovery Server but for all locators. This PR moves the feature information to the locators section leaving a reference in the Discovery Server settings.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>