### PR TITLE
[13780] Clarify scope and caveats of dynamic network interfaces

### DIFF
--- a/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
+++ b/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
@@ -60,5 +60,4 @@ Find below a brief snippet of how to use this feature:
 
 .. important::
 
-   This feature is still under development and currently it is only officially supported for UDPv4 Transport without
-   whitelisting.
+   This feature is still under development and only officially supported for UDPv4 Transport without whitelisting.

--- a/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
+++ b/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
@@ -32,6 +32,12 @@ Consequently, both |BuiltinAttributes::metatrafficUnicastLocatorList-api| and
 These attributes are set within the `builtin` member of |DomainParticipantQos::wire_protocol-api| contained in the
 |DomainParticipantQos-api| (please refer to :ref:`dds_layer_domainParticipantQos`).
 
+.. note::
+
+   Be aware of the remote locators' collections limits set within the |DomainParticipantQoS| (please refer to
+   :ref:`remotelocatorsallocationattributes`).
+   It is recommended to use the highest number of local addresses found on all the systems belonging to the same domain.
+
 Notify *Fast DDS*
 ^^^^^^^^^^^^^^^^^
 
@@ -51,3 +57,8 @@ Find below a brief snippet of how to use this feature:
    :start-after: //DYNAMIC_NETWORK_INTERFACES_USE_CASE
    :end-before: //!--
    :dedent: 8
+
+.. important::
+
+   This feature is still under development and currently it is only officially supported for UDPv4 Transport without
+   whitelisting.


### PR DESCRIPTION
Fast DDS v2.5.0 introduced the dynamic network interfaces feature. However, in this version the feature is only officially supported in some specific cases that are clarified in this PR. This PR is related to eProsima/Fast-DDS#2468.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>