### PR TITLE
Correct CMake Windows installation from sources

### DIFF
--- a/docs/installation/sources/sources_linux.rst
+++ b/docs/installation/sources/sources_linux.rst
@@ -277,7 +277,7 @@ Local installation
        git clone https://github.com/eProsima/Fast-DDS.git
        mkdir Fast-DDS/build
        cd Fast-DDS/build
-       cmake ..  -DCMAKE_INSTALL_PREFIX=~/Fast-DDS/install -DCMAKE_PREFIX_PATH=~/Fast-DDS/install
+       cmake ..  -DCMAKE_INSTALL_PREFIX=~/Fast-DDS/install
        sudo cmake --build . --target install
 
 .. note::

--- a/docs/installation/sources/sources_windows.rst
+++ b/docs/installation/sources/sources_windows.rst
@@ -312,7 +312,10 @@ Local installation
 
 #. Clone the following dependencies and compile them using CMake_.
 
-   * `Foonathan memory <https://github.com/foonathan/memory>`_
+   * Fast DDS depends on `Foonathan memory <https://github.com/foonathan/memory>`_.
+     To ease the dependency management, *eProsima* provides a vendor package
+     `Foonathan memory vendor <https://github.com/eProsima/foonathan_memory_vendor>`_, which downloads and builds a
+     specific revision of *Foonathan memory* if the library is not found in the system.
 
      .. code-block:: bash
 
@@ -320,8 +323,7 @@ Local installation
          git clone https://github.com/eProsima/foonathan_memory_vendor.git
          cd foonathan_memory_vendor
          mkdir build && cd build
-         cmake -DCMAKE_INSTALL_PREFIX=%USERPROFILE%/Fast-DDS/install ^
-            -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
+         cmake -DCMAKE_INSTALL_PREFIX=%USERPROFILE%/Fast-DDS/install ..
          cmake --build . --target install
 
    * `Fast CDR <https://github.com/eProsima/Fast-CDR.git>`_

--- a/docs/installation/sources/sources_windows.rst
+++ b/docs/installation/sources/sources_windows.rst
@@ -321,8 +321,7 @@ Local installation
          cd foonathan_memory_vendor
          mkdir build && cd build
          cmake -DCMAKE_INSTALL_PREFIX=%USERPROFILE%/Fast-DDS/install ^
-            -DBUILD_SHARED_LIBS=OFF -DFOONATHAN_MEMORY_BUILD_TOOLS=ON ^
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DFOONATHAN_MEMORY_BUILD_TESTS=OFF ..
+            -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
          cmake --build . --target install
 
    * `Fast CDR <https://github.com/eProsima/Fast-CDR.git>`_


### PR DESCRIPTION
Correct Windows installation from sources when using CMake

* Depends on eProsima/foonathan_memory_vendor#55
* Closes #338 