### PR TITLE
Exclude thirdparty headers with Doxygen [13785]

### DIFF
--- a/code/doxygen-config.in
+++ b/code/doxygen-config.in
@@ -160,7 +160,7 @@ FILE_PATTERNS          = *.c \
                          *.qsf \
                          *.ice
 RECURSIVE              = YES
-EXCLUDE                =
+EXCLUDE                = "@DOXYGEN_INPUT_DIR@/thirdparty"
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       =
 EXCLUDE_SYMBOLS        =


### PR DESCRIPTION
With this PR, Doxygen ignores all the files in Fast DDS' installation `include/fastdds/thirdparty`

Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>