### PR TITLE
Add mirror workflow [13785]

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,24 @@
+# .github/workflows/mirror.yml
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  mirror_job:
+    name: Mirror master branch to latest minor branch
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dest_branch:
+          - '2.5.x'
+          - '2.6.x'
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: google/mirror-branch-action@v1.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: 'master'
+        dest: ${{ matrix.dest_branch }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   mirror_job:
-    name: Mirror master branch to latest minor branch
+    name: Mirror master branch to latest minor branches
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR adds a workflow to automatically backport contributions done to `master` into an array of release branches; namely `2.5.x` and `2.6.x`

Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>