### PR TITLE
[13783] load XML configuration file using CLI

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -752,6 +752,28 @@
 </participant>
 <!--><-->
 
+<!-->XML-DS-CLI-XML-CONF<-->
+<participant profile_name="participant_profile_discovery_server_cli">
+    <rtps>
+        <prefix>44.53.01.5f.45.50.52.4f.53.49.4d.41</prefix>
+        <builtin>
+            <discovery_config>
+                <discoveryProtocol>SERVER</discoveryProtocol>
+            </discovery_config>
+            <metatrafficUnicastLocatorList>
+                <locator>
+                    <udpv4>
+                        <address>127.0.0.1</address>
+                        <port>14520</port>
+                    </udpv4>
+                </locator>
+            </metatrafficUnicastLocatorList>
+        </builtin>
+    </rtps>
+</participant>
+<!--><-->
+
+
 <!-->CONF-QOS-DISCOVERY-LEASEDURATION<-->
 <participant profile_name="participant_profile_qos_discovery_lease">
     <rtps>

--- a/docs/fastddscli/cli/cli.rst
+++ b/docs/fastddscli/cli/cli.rst
@@ -53,7 +53,8 @@ For more information on the different *Fast DDS* discovery mechanisms and how to
 
 .. important::
     It is possible to interconnect *servers* (or *backup* servers) instantiated with ``fastdds discovery`` using
-    environment variable ``ROS_DISCOVERY_SERVER`` (see :ref:`env_vars_ros_discovery_server`).
+    environment variable ``ROS_DISCOVERY_SERVER`` (see :ref:`env_vars_ros_discovery_server`) or a XML configuration
+    file.
 
 .. _cli_discovery_run:
 
@@ -71,8 +72,9 @@ Where the parameters are:
 +--------------------------+-------------------------------------------------------------------------------------------+
 | Option                   | Description                                                                               |
 +==========================+===========================================================================================+
-| ``-i  --server-id``      | **Mandatory** unique server identifier. Specifies zero based server position in |br|      |
-|                          | ``ROS_DISCOVERY_SERVER`` environment variable. Must be an integer in range [0, 255]       |
+| ``-i  --server-id``      | Unique server identifier. Specifies zero based server position in |br|                    |
+|                          | ``ROS_DISCOVERY_SERVER`` environment variable. Must be an integer in range [0, 255] |br|  |
+|                          | If not specified, it must be defined using a XML configuration file.                      |
 +--------------------------+-------------------------------------------------------------------------------------------+
 | ``-h  -help``            | Produce help message.                                                                     |
 +--------------------------+-------------------------------------------------------------------------------------------+
@@ -82,6 +84,10 @@ Where the parameters are:
 | ``-p  --port``           | UDP port chosen to listen the clients. Defaults to '11811'.                               |
 +--------------------------+-------------------------------------------------------------------------------------------+
 | ``-b  --backup``         | Creates a BACKUP *server* (see :ref:`discovery_protocol`)                                 |
++--------------------------+-------------------------------------------------------------------------------------------+
+| ``-x  --xml-file``       | XML configuration file (see :ref:`xml_profiles`). In this case, the default |br|          |
+|                          | configuration file is not loaded. The CLI options overrides XML configuration for |br|    |
+|                          | that specific parameter.                                                                  |
 +--------------------------+-------------------------------------------------------------------------------------------+
 
 The output is:
@@ -139,6 +145,17 @@ Examples
           Server ID:          1
           Server GUID prefix: 44.53.01.5f.45.50.52.4f.53.49.4d.41
           Server Addresses:   UDPv4:[127.0.0.1]:14520
+
+    This same output can be obtained loading the following XML configuration file ``DiscoveryServerCLI.xml``:
+
+    .. literalinclude:: /../code/XMLTester.xml
+        :language: xml
+        :start-after: <!-->XML-DS-CLI-XML-CONF<-->
+        :end-before: <!--><-->
+
+    .. code-block:: bash
+
+        fastdds discovery -x [PATH_TO_FILE]/DiscoveryServerCLI.xml
 
 3.  Launch a default server with id 2 (third on ``ROS_DISCOVERY_SERVER``)
     listening on WiFi (192.168.36.34) and Ethernet (172.20.96.1) local


### PR DESCRIPTION
Fast DDS CLI `discovery` accepts new `-x`|`--xml-file` option to load a XML configuration file that allows adding configuration to the `SERVER`|`BACKUP` launched using this tool.

This PR adds documentation for eProsima/Fast-DDS#2498

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>