### PR TITLE
[13966] Documentation for content filter related allocation limits

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4461,6 +4461,10 @@ void dds_usecase_examples()
         // This will effectively preallocate the memory during initialization
         qos.writer_resource_limits().matched_subscriber_allocation =
                 eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+        // Fix the size of writer side content filters to 1
+        // This will effectively preallocate the memory during initialization
+        qos.writer_resource_limits().reader_filters_allocation =
+                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
         //!--
     }
 

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -3329,6 +3329,11 @@ void dds_qos_examples()
         participant_limits.data_limits.max_user_data = 256u;
         //Set the maximum size of the properties data to 512
         participant_limits.data_limits.max_properties = 512u;
+        //Set the preallocated filter expression size to 512
+        participant_limits.content_filter.expression_initial_size = 512u;
+        //Set the maximum number of expression parameters to 4 and its allocation configuration to fixed size
+        participant_limits.content_filter.expression_parameters =
+            eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(4u);
         //!--
     }
 

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4514,15 +4514,21 @@ void dds_usecase_examples()
         participant_qos.allocation().data_limits.max_user_data = 256u;
         // We know the maximum size of properties data
         participant_qos.allocation().data_limits.max_properties = 512u;
-
+        
+        // Content filtering is not being used
+        participant_qos.allocation().content_filter.expression_initial_size = 0u;
+        participant_qos.allocation().content_filter.expression_parameters =
+                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(0u);
 
         // DataWriter configuration for Topic 1
         ///////////////////////////////////////
         DataWriterQos writer1_qos;
 
-        // We know we will only have three matching subscribers
+        // We know we will only have three matching subscribers, and no content filters
         writer1_qos.writer_resource_limits().matched_subscriber_allocation =
                 eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+        writer1_qos.writer_resource_limits().reader_filters_allocation =
+                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(0u);
 
         // DataWriter configuration for Topic 2
         ///////////////////////////////////////
@@ -4531,6 +4537,8 @@ void dds_usecase_examples()
         // We know we will only have two matching subscribers
         writer2_qos.writer_resource_limits().matched_subscriber_allocation =
                 eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
+        writer2_qos.writer_resource_limits().reader_filters_allocation =
+                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(0u);
 
 
         // DataReader configuration for both Topics

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4458,6 +4458,11 @@ void dds_usecase_examples()
         qos.allocation().data_limits.max_partitions = 256u;
         // Fix the size of the complete properties field to 512 octets
         qos.allocation().data_limits.max_properties = 512u;
+        // Set the preallocated filter expression size to 512 characters
+        qos.allocation().content_filter.expression_initial_size = 512u;
+        // Set the maximum number of expression parameters to 4 and its allocation configuration to fixed size
+        qos.allocation().content_filter.expression_parameters =
+            eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(4u);
         //!--
     }
 

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -3372,6 +3372,9 @@ void dds_qos_examples()
         //Set the maximum size for reader matched resource limits collection to 3 and its allocation configuration to fixed size
         writer_limits.matched_subscriber_allocation =
                 eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+        // Set the maximum number of writer side content filters to 1 and its allocation configuration to fixed size
+        writer_limits.reader_filters_allocation =
+                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
         //!--
     }
 

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3942,6 +3942,8 @@
         <maximum>3</maximum>
         <increment>0</increment>
     </matchedSubscribersAllocation>
+    
+    <!-- reader_filters_allocation cannot be configured using XML (yet) -->
 </data_writer>
 <!--><-->
 

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -2002,6 +2002,8 @@
                 <max_partitions>256</max_partitions>
                 <max_user_data>256</max_user_data>
                 <max_properties>512</max_properties>
+                
+                <!-- content_filter cannot be configured using XML (yet) -->
             </allocation>
         </rtps>
     </participant>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -1397,6 +1397,8 @@
     <max_user_data>256</max_user_data>
 
     <max_properties>512</max_properties>
+
+    <!-- content_filter cannot be configured using XML (yet) -->
 </allocation>
 <!--><-->
 </rtps>
@@ -1596,6 +1598,8 @@
                 <maximum>0</maximum>
                 <increment>1</increment>
             </matchedSubscribersAllocation>
+
+            <!-- reader_filters_allocation cannot be configured using XML (yet) -->
         </data_writer>
 <!-->
     </profiles>
@@ -1938,6 +1942,8 @@
                 <max_partitions>256</max_partitions>
                 <max_user_data>256</max_user_data>
                 <max_properties>512</max_properties>
+
+                <!-- content_filter cannot be configured using XML (yet) -->
             </allocation>
         </rtps>
     </participant>
@@ -1955,6 +1961,8 @@
             <maximum>3</maximum>
             <increment>0</increment>
         </matchedSubscribersAllocation>
+        
+        <!-- reader_filters_allocation cannot be configured using XML (yet) -->
     </data_writer>
 <!--><-->
 
@@ -2002,7 +2010,7 @@
                 <max_partitions>256</max_partitions>
                 <max_user_data>256</max_user_data>
                 <max_properties>512</max_properties>
-                
+
                 <!-- content_filter cannot be configured using XML (yet) -->
             </allocation>
         </rtps>
@@ -2015,6 +2023,8 @@
             <maximum>3</maximum>
             <increment>0</increment>
         </matchedSubscribersAllocation>
+
+        <!-- reader_filters_allocation cannot be configured using XML (yet) -->
     </data_writer>
 
     <data_writer profile_name="alloc_qos_example_pub_for_topic_2">
@@ -2024,6 +2034,8 @@
             <maximum>2</maximum>
             <increment>0</increment>
         </matchedSubscribersAllocation>
+
+        <!-- reader_filters_allocation cannot be configured using XML (yet) -->
     </data_writer>
 
     <data_reader profile_name="alloc_qos_example_sub">
@@ -3312,6 +3324,7 @@
                 <max_partitions>256</max_partitions>
                 <max_user_data>256</max_user_data>
                 <max_properties>512</max_properties>
+                <!-- content_filter cannot be configured using XML (yet) -->
             </allocation>
 
             <port>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -2017,7 +2017,7 @@
     </participant>
 
     <data_writer profile_name="alloc_qos_example_pub_for_topic_1">
-        <!-- we know we will have three matching subscribers -->
+        <!-- we know we will have three matching subscribers and no content filter -->
         <matchedSubscribersAllocation>
             <initial>3</initial>
             <maximum>3</maximum>
@@ -2028,7 +2028,7 @@
     </data_writer>
 
     <data_writer profile_name="alloc_qos_example_pub_for_topic_2">
-        <!-- we know we will have two matching subscribers -->
+        <!-- we know we will have two matching subscribers and no content filter -->
         <matchedSubscribersAllocation>
             <initial>2</initial>
             <maximum>2</maximum>

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -550,6 +550,7 @@
 
 .. |WriterResourceLimitsQos-api| replace:: :cpp:class:`WriterResourceLimitsQos<eprosima::fastdds::dds::WriterResourceLimitsQos>`
 .. |WriterResourceLimitsQos::matched_subscriber_allocation-api| replace:: :cpp:member:`matched_subscriber_allocation<eprosima::fastdds::dds::WriterResourceLimitsQos::matched_subscriber_allocation>`
+.. |WriterResourceLimitsQos::reader_filters_allocation-api| replace:: :cpp:member:`reader_filters_allocation<eprosima::fastdds::dds::WriterResourceLimitsQos::reader_filters_allocation>`
 
 .. |DataRepresentationQosPolicy-api| replace:: :cpp:class:`DataRepresentationQosPolicy<eprosima::fastdds::dds::DataRepresentationQosPolicy>`
 .. |DataRepresentationQosPolicy::m_value-api| replace:: :cpp:member:`m_value<eprosima::fastdds::dds::DataRepresentationQosPolicy::m_value>`

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -459,6 +459,7 @@
 .. |ParticipantResourceLimitsQos::writers-api| replace:: :cpp:member:`writers<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::writers>`
 .. |ParticipantResourceLimitsQos::send_buffers-api| replace:: :cpp:member:`send_buffers<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::send_buffers>`
 .. |ParticipantResourceLimitsQos::data_limits-api| replace:: :cpp:member:`data_limits<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::data_limits>`
+.. |ParticipantResourceLimitsQos::content_filter-api| replace:: :cpp:member:`content_filter<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::content_filter>`
 
 .. |RemoteLocatorsAllocationAttributes-api| replace:: :cpp:struct:`RemoteLocatorsAllocationAttributes<eprosima::fastrtps::rtps::RemoteLocatorsAllocationAttributes>`
 .. |RemoteLocatorsAllocationAttributes::max_unicast_locators-api| replace:: :cpp:member:`max_unicast_locators<eprosima::fastrtps::rtps::RemoteLocatorsAllocationAttributes::max_unicast_locators>`
@@ -486,6 +487,10 @@
 .. |VariableLengthDataLimits::max_user_data-api| replace:: :cpp:member:`max_user_data<eprosima::fastrtps::rtps::VariableLengthDataLimits::max_user_data>`
 .. |VariableLengthDataLimits::max_properties-api| replace:: :cpp:member:`max_properties<eprosima::fastrtps::rtps::VariableLengthDataLimits::max_properties>`
 .. |VariableLengthDataLimits::max_partitions-api| replace:: :cpp:member:`max_partitions<eprosima::fastrtps::rtps::VariableLengthDataLimits::max_partitions>`
+
+.. |ContentFilterProperty::AllocationConfiguration-api| replace:: :cpp:struct:`ContentFilterProperty::AllocationConfiguration<eprosima::fastdds::rtps::ContentFilterProperty::AllocationConfiguration>`
+.. |ContentFilterProperty::AllocationConfiguration::expression_initial_size-api| replace:: :cpp:member:`expression_initial_size<eprosima::fastdds::rtps::ContentFilterProperty::AllocationConfiguration::expression_initial_size>`
+.. |ContentFilterProperty::AllocationConfiguration::expression_parameters-api| replace:: :cpp:member:`expression_parameters<eprosima::fastdds::rtps::ContentFilterProperty::AllocationConfiguration::expression_parameters>`
 
 .. |PropertyPolicyQos-api| replace:: :cpp:type:`PropertyPolicyQos<eprosima::fastdds::dds::PropertyPolicyQos>`
 .. |RequestedDeadlineMissedStatus-api| replace:: :cpp:type:`RequestedDeadlineMissedStatus<eprosima::fastdds::dds::RequestedDeadlineMissedStatus>`

--- a/docs/fastdds/api_reference/rtps/builtin/data/ContentFilterProperty.rst
+++ b/docs/fastdds/api_reference/rtps/builtin/data/ContentFilterProperty.rst
@@ -1,0 +1,8 @@
+.. rst-class:: api-ref
+
+ContentFilterProperty
+---------------------
+
+.. doxygenclass:: eprosima::fastdds::rtps::ContentFilterProperty
+    :project: FastDDS
+    :members:

--- a/docs/fastdds/api_reference/rtps/builtin/data/data.rst
+++ b/docs/fastdds/api_reference/rtps/builtin/data/data.rst
@@ -1,0 +1,8 @@
+.. _api_rtps_builtin_data:
+
+Builtin data
+============
+
+.. toctree::
+
+    /fastdds/api_reference/rtps/builtin/data/ContentFilterProperty

--- a/docs/fastdds/api_reference/rtps/rtps.rst
+++ b/docs/fastdds/api_reference/rtps/rtps.rst
@@ -9,6 +9,7 @@ RTPS
 
 
     /fastdds/api_reference/rtps/attributes/attributes
+    /fastdds/api_reference/rtps/builtin/data/data
     /fastdds/api_reference/rtps/common/common
     /fastdds/api_reference/rtps/Endpoint
     /fastdds/api_reference/rtps/exceptions/exceptions

--- a/docs/fastdds/api_reference/spelling_wordlist.txt
+++ b/docs/fastdds/api_reference/spelling_wordlist.txt
@@ -65,6 +65,7 @@ InconsistentTopicStatus
 infos
 initialAcknackDelay
 initialHeartbeatDelay
+inlined
 instanceHandle
 InstanceHandle
 LatencyBudgetQosPolicy

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1039,6 +1039,8 @@ List of QoS Policy data members:
 +=============================================================================+========================================+
 | |WriterResourceLimitsQos::matched_subscriber_allocation-api|                | :ref:`resourcelimitedcontainerconfig`  |
 +-----------------------------------------------------------------------------+----------------------------------------+
+| |WriterResourceLimitsQos::reader_filters_allocation-api|                    | :ref:`resourcelimitedcontainerconfig`  |
++-----------------------------------------------------------------------------+----------------------------------------+
 
 .. note::
      This QoS Policy concerns to DataWriter entities.

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -258,6 +258,8 @@ List of QoS Policy data members:
 +--------------------------------------------------------------------------+-------------------------------------------+
 | |ParticipantResourceLimitsQos::data_limits-api|                          | :ref:`variablelengthdatalimits`           |
 +--------------------------------------------------------------------------+-------------------------------------------+
+| |ParticipantResourceLimitsQos::content_filter-api|                       | :ref:`contentfilterlimits`                |
++--------------------------------------------------------------------------+-------------------------------------------+
 
 * |ParticipantResourceLimitsQos::locators-api|:
   Defines the limits for collections of remote locators.
@@ -274,6 +276,8 @@ List of QoS Policy data members:
   Defines the allocation behavior and limits for the send buffer manager.
 * |ParticipantResourceLimitsQos::data_limits-api|:
   States the limits for variable-length data.
+* |ParticipantResourceLimitsQos::content_filter-api|:
+  States the limits for content-filter discovery information.
 
 .. note::
      This QoS Policy concerns to |DomainParticipant| entities.
@@ -388,6 +392,35 @@ List of structure members:
   Establishes the maximum size, in octets, of the user data in the local or remote participant.
 * |VariableLengthDataLimits::max_partitions-api|:
   States the maximum size, in octets, of the partitions data in the local or remote participant.
+
+.. _contentfilterlimits:
+
+ContentFilterProperty::AllocationConfiguration
+""""""""""""""""""""""""""""""""""""""""""""""
+
+This structure holds the limits for content-filter related discovery information.
+See |ContentFilterProperty::AllocationConfiguration-api|.
+
+List of structure members:
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - Member Name
+     - Type
+     - Default Value
+   * - |ContentFilterProperty::AllocationConfiguration::expression_initial_size-api|
+     - ``size_t``
+     - 0
+   * - |ContentFilterProperty::AllocationConfiguration::expression_parameters-api|
+     - :ref:`resourcelimitedcontainerconfig`
+     - ``{0, 100, 1}``
+
+* |ContentFilterProperty::AllocationConfiguration::expression_initial_size-api|:
+  Preallocated size of the filter expression.
+* |ContentFilterProperty::AllocationConfiguration::expression_parameters-api|:
+  Allocation configuration for the list of expression parameters.
 
 Example
 """""""

--- a/docs/fastdds/use_cases/realtime/allocations.rst
+++ b/docs/fastdds/use_cases/realtime/allocations.rst
@@ -110,7 +110,7 @@ to configure the allocation behavior of custom parameters:
   of octets.
 * |VariableLengthDataLimits::max_partitions-api| limits the size of :ref:`propertypolicyqos` to the given number
   of octets.
-  
+
 If these sizes are configured to something different than zero, enough memory will be allocated for them
 for each participant and endpoint.
 A value of zero implies no size limitation, and memory will be dynamically allocated as needed.

--- a/docs/fastdds/use_cases/realtime/allocations.rst
+++ b/docs/fastdds/use_cases/realtime/allocations.rst
@@ -284,7 +284,7 @@ Given a system with the following topology:
 * All the DataReaders
   match exactly with 1 DataWriter.
 
-We will also limit the size of the parameters:
+We will assume that content filtering is not being used, and will also limit the size of the parameters:
 
 * Maximum :ref:`partitionqospolicy` size: 256
 * Maximum :ref:`userdataqospolicy` size: 256

--- a/docs/fastdds/use_cases/realtime/allocations.rst
+++ b/docs/fastdds/use_cases/realtime/allocations.rst
@@ -158,7 +158,7 @@ the memory allocation behavior on the DataWriter.
 and |WriterResourceLimitsQos::reader_filters_allocation-api|
 of type :ref:`resourcelimitedcontainerconfig` that allow configuring
 the maximum expected size of the collection of matched DataReader,
-and the collecion of writer side content filters,
+and the collection of writer side content filters,
 so they can be preallocated during the initialization of the DataWriter,
 as shown in the example below.
 Please, refer to :ref:`resourcelimitedcontainerconfig` for a complete description of additional configuration

--- a/docs/fastdds/use_cases/realtime/allocations.rst
+++ b/docs/fastdds/use_cases/realtime/allocations.rst
@@ -146,21 +146,23 @@ By default, a full dynamic behavior is used.
 Parameters on the DataWriter
 ----------------------------
 
-Every DataWriter holds an internal collection with information about every
+Every DataWriter holds internal collections with information about every
 DataReader to which it matches.
-By default, this collection is fully dynamic, meaning that new memory is allocated when a new
+By default, these collections are fully dynamic, meaning that new memory is allocated when a new
 DataReader is matched.
 However, :ref:`dds_layer_publisher_dataWriterQos` has a data member |DataWriterQos::writer_resource_limits-api|,
 of type :ref:`writerresourcelimitsqos`, that allows configuring
 the memory allocation behavior on the DataWriter.
 
-:ref:`writerresourcelimitsqos` provides a data member |WriterResourceLimitsQos::matched_subscriber_allocation-api|
-of type :ref:`resourcelimitedcontainerconfig` that allows configuring
+:ref:`writerresourcelimitsqos` provides data members |WriterResourceLimitsQos::matched_subscriber_allocation-api|
+and |WriterResourceLimitsQos::reader_filters_allocation-api|
+of type :ref:`resourcelimitedcontainerconfig` that allow configuring
 the maximum expected size of the collection of matched DataReader,
-so that it can be preallocated during the initialization of the DataWriter,
+and the collecion of writer side content filters,
+so they can be preallocated during the initialization of the DataWriter,
 as shown in the example below.
 Please, refer to :ref:`resourcelimitedcontainerconfig` for a complete description of additional configuration
-alternatives given by this data member.
+alternatives given by these data members.
 
 
 +--------------------------------------------------------+

--- a/docs/fastdds/use_cases/realtime/allocations.rst
+++ b/docs/fastdds/use_cases/realtime/allocations.rst
@@ -110,11 +110,21 @@ to configure the allocation behavior of custom parameters:
   of octets.
 * |VariableLengthDataLimits::max_partitions-api| limits the size of :ref:`propertypolicyqos` to the given number
   of octets.
-
+  
 If these sizes are configured to something different than zero, enough memory will be allocated for them
 for each participant and endpoint.
 A value of zero implies no size limitation, and memory will be dynamically allocated as needed.
 By default, a full dynamic behavior is used.
+
+|ParticipantResourceLimitsQos::content_filter-api| inside :ref:`participantresourcelimitsqos` provides members
+to configure the allocation behavior of content filter discovery information:
+
+* |ContentFilterProperty::AllocationConfiguration::expression_initial_size-api| sets the preallocated size of
+  the filter expression.
+* |ContentFilterProperty::AllocationConfiguration::expression_parameters-api| controls the allocation behavior
+  for the list of expression parameters. Refer to :ref:`resourcelimitedcontainerconfig` for a complete description
+  of the alternatives. Receiving information about a content filter with more parameters than the maximum
+  configured here, will make the filtering happen on the reader side.
 
 +--------------------------------------------------------+
 | **C++**                                                |

--- a/docs/fastdds/use_cases/realtime/allocations.rst
+++ b/docs/fastdds/use_cases/realtime/allocations.rst
@@ -122,9 +122,10 @@ to configure the allocation behavior of content filter discovery information:
 * |ContentFilterProperty::AllocationConfiguration::expression_initial_size-api| sets the preallocated size of
   the filter expression.
 * |ContentFilterProperty::AllocationConfiguration::expression_parameters-api| controls the allocation behavior
-  for the list of expression parameters. Refer to :ref:`resourcelimitedcontainerconfig` for a complete description
-  of the alternatives. Receiving information about a content filter with more parameters than the maximum
-  configured here, will make the filtering happen on the reader side.
+  for the list of expression parameters.
+  Refer to :ref:`resourcelimitedcontainerconfig` for a complete description of the alternatives.
+  Receiving information about a content filter with more parameters than the maximum configured here, will make
+  the filtering happen on the reader side.
 
 +--------------------------------------------------------+
 | **C++**                                                |


### PR DESCRIPTION
This PR adds documentation for the allocation limits introduced on eProsima/Fast-DDS#2552