### PR TITLE
[14485] Hotfix: clarify `-python` Fast DDS-Gen option

### DIFF
--- a/docs/fastddsgen/usage/usage.rst
+++ b/docs/fastddsgen/usage/usage.rst
@@ -76,7 +76,7 @@ Where the option choices are:
 +---------------------+------------------------------------------------------------------------------------------------+
 | -python             | Generates source code and a CMake solution to compile a library containing the data types |br| |
 |                     | Python bindings required to run a *Fast DDS* Python-based application. This option is    |br|  |
-|                     | incompatible with the `-example` one. Only Ubuntu support is guaranteed.                       |
+|                     | incompatible with the `-example` and `-typeobject` ones.                                       |
 +---------------------+------------------------------------------------------------------------------------------------+
 | -cs                 | Enables Case Sensitivity                                                                       |
 +---------------------+------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This PR clarifies that:

* Fast DDS-Gen option `-typeobject` does not support generation of Python bindings when using at the same time option `-python` (eProsima/Fast-DDS-Gen#114)
* `-python` option is supported officially in more platforms than Windows currently.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>