### PR TITLE
Refs #14543: Renamings in examples directories

### DIFF
--- a/docs/docker/docker_demo/fast_dds_suite.rst
+++ b/docs/docker/docker_demo/fast_dds_suite.rst
@@ -78,7 +78,7 @@ This is a minimal example that will perform a Publisher/Subscriber match and sta
 .. code-block:: bash
 
  $ goToExamples
- $ cd HelloWorldExample/bin
+ $ cd dds/HelloWorldExample/bin
  $ tmux new-session "./HelloWorldExample publisher 0 1000" \; \
  split-window "./HelloWorldExample subscriber" \; \
  select-layout even-vertical
@@ -89,7 +89,7 @@ container to check the communication between them by running the following from 
 .. code-block:: bash
 
  $ goToExamples
- $ cd HelloWorldExample/bin
+ $ cd dds/HelloWorldExample/bin
  $ ./HelloWorldExample publisher
 
 or
@@ -97,7 +97,7 @@ or
 .. code-block:: bash
 
  $ goToExamples
- $ cd HelloWorldExample/bin
+ $ cd dds/HelloWorldExample/bin
  $ ./HelloWorldExample subscriber
 
 Benchmark Example
@@ -111,7 +111,7 @@ On the subscriber side, run:
 .. code-block:: bash
 
  $ goToExamples
- $ cd Benchmark/bin
+ $ cd dds/Benchmark/bin
  $ ./Benchmark subscriber udp
 
 On the publisher side, run:
@@ -119,7 +119,7 @@ On the publisher side, run:
 .. code-block:: bash
 
  $ goToExamples
- $ cd Benchmark/bin
+ $ cd dds/Benchmark/bin
  $ ./Benchmark publisher udp
 
 .. _fast_dds_suite_shapes_demo:
@@ -175,7 +175,7 @@ DDS Router communicating both Domains.
 .. code-block:: bash
 
     goToExamples
-    cd DDS/BasicConfigurationExample/bin
+    cd dds/BasicConfigurationExample/bin
     tmux new-session \
         "ddsrouter --config-path /config.yml" \; \
         split-window -h "./BasicConfigurationExample publisher --domain 0 --interval 1000 --transport udp" \; \

--- a/docs/fastdds/api_reference/spelling_wordlist.txt
+++ b/docs/fastdds/api_reference/spelling_wordlist.txt
@@ -78,6 +78,7 @@ LoanableTypedCollection
 loc
 LocatorList
 locatorN
+LocatorWithMask
 logError
 logInfo
 logWarning

--- a/docs/fastdds/discovery/static.rst
+++ b/docs/fastdds/discovery/static.rst
@@ -67,7 +67,7 @@ and DataReaders) must be statically specified, which is done using dedicated XML
 A |DomainParticipant| may load several of such configuration files so that the information about different entities can
 be contained in one file, or split into different files to keep it more organized.
 *Fast DDS*  provides a
-`Static Discovery example <https://github.com/eProsima/Fast-DDS/blob/master/examples/C%2B%2B/DDS/StaticHelloWorldExample>`_
+`Static Discovery example <https://github.com/eProsima/Fast-DDS/blob/master/examples/cpp/dds/StaticHelloWorldExample>`_
 that implements this EDP discovery protocol.
 
 The following table describes all the possible elements of a STATIC EDP XML configuration file.

--- a/docs/fastdds/dynamic_types/examples.rst
+++ b/docs/fastdds/dynamic_types/examples.rst
@@ -16,7 +16,7 @@ DynamicHelloWorldExample
 ------------------------
 
 This example is in folder
-`examples/C++/DynamicHelloWorldExample <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/DynamicHelloWorldExample>`_
+`examples/cpp/dds/DynamicHelloWorldExample <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/dds/DynamicHelloWorldExample>`_
 of the `Fast DDS GitHub repository`_.
 It shows the use of DynamicType generation to provide the |TopicDataType|.
 This example is compatible with the classic HelloWorldExample.
@@ -34,7 +34,7 @@ DDSDynamicHelloWorldExample
 ---------------------------
 
 This example uses the DDS API, and can be retrieve from folder
-`examples/C++/DDS/DynamicHelloWorldExample <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/DDS/DynamicHelloWorldExample>`_
+`examples/cpp/dds/DynamicHelloWorldExample <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/dds/DynamicHelloWorldExample>`_
 of the `Fast DDS GitHub repository`_.
 It shows a publisher that loads a type from an XML file, and shares it during discovery.
 The subscriber discovers the type using :ref:`discovery-time-data-typing`, and registers the
@@ -44,7 +44,7 @@ TypeLookupService
 -----------------
 
 This example uses the DDS API, and it is located in folder
-`examples/C++/DDS/TypeLookupService <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/DDS/TypeLookupService>`_
+`examples/cpp/dds/TypeLookupService <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/dds/TypeLookupService>`_
 of the `Fast DDS GitHub repository`_.
 It is very similar to DDSDynamicHelloWorldExample, but the shared type is complex enough to require the
 TypeLookup Service due to the dependency of inner struct types.

--- a/docs/fastdds/getting_started/simple_app/includes/sum_and_next_steps.rst
+++ b/docs/fastdds/getting_started/simple_app/includes/sum_and_next_steps.rst
@@ -10,4 +10,4 @@ Next steps
 
 In the *eProsima Fast DDS* Github repository you will find more complex examples that implement DDS communication for
 a multitude of use cases and scenarios. You can find them
-`here <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/DDS>`_.
+`here <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/dds>`_.

--- a/docs/fastdds/rtps_layer/rtps_layer.rst
+++ b/docs/fastdds/rtps_layer/rtps_layer.rst
@@ -40,8 +40,8 @@ explaining the new features it presents.
 We recommend you to look at the two examples describing how to use the RTPS layer that come with the distribution
 while reading this section.
 They are located in
-`examples/C++/RTPSTest_as_socket <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/RTPSTest_as_socket>`_ and
-`examples/C++/RTPSTest_registered <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/RTPSTest_registered>`_
+`examples/cpp/rtps/AsSocket <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/rtps/AsSocket>`_ and
+`examples/cpp/rtps/Registered <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/rtps/Registered>`_
 
 Managing the Participant
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
+++ b/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
@@ -109,7 +109,7 @@ The following is an example of the Domain Governance XML file contents.
 
 The `Governance XSD file <https://github.com/eProsima/Fast-DDS/blob/master/resources/xsd/governance.xsd>`_ and
 the
-`Governance XML example <https://github.com/eProsima/Fast-DDS/blob/master/examples/C%2B%2B/SecureHelloWorldExample/certs/governance.xml>`_
+`Governance XML example <https://github.com/eProsima/Fast-DDS/blob/master/examples/cpp/dds/SecureHelloWorldExample/certs/governance.xml>`_
 can also be downloaded from the `eProsima Fast DDS Github repository <https://github.com/eProsima/Fast-DDS>`_.
 
 Domain Rules
@@ -429,7 +429,7 @@ The following is an example of the DomainParticipant Permissions XML file conten
 
 The `Permissions XSD file <https://github.com/eProsima/Fast-DDS/blob/master/resources/xsd/governance.xsd>`_ and
 the
-`Permissions XML example <https://github.com/eProsima/Fast-DDS/blob/master/examples/C%2B%2B/SecureHelloWorldExample/certs/governance.xml>`_
+`Permissions XML example <https://github.com/eProsima/Fast-DDS/blob/master/examples/cpp/dds/SecureHelloWorldExample/certs/governance.xml>`_
 can also be downloaded from the `eProsima Fast DDS Github repository <https://github.com/eProsima/Fast-DDS>`_.
 
 Grant Section

--- a/docs/fastdds/transport/shared_memory/shared_memory.rst
+++ b/docs/fastdds/transport/shared_memory/shared_memory.rst
@@ -223,5 +223,5 @@ HelloWorldExampleSharedMem
 --------------------------
 
 A Shared Memory version of helloworld example can be found in the
-`HelloWorldExampleSharedMem folder <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/DDS/HelloWorldExampleSharedMem>`_.
+`HelloWorldExampleSharedMem folder <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/dds/HelloWorldExampleSharedMem>`_.
 It shows a publisher and a subscriber that communicate through Shared Memory.

--- a/docs/fastdds/transport/tcp/tcp.rst
+++ b/docs/fastdds/transport/tcp/tcp.rst
@@ -294,7 +294,7 @@ HelloWorldExampleTCP
 --------------------
 
 A TCP version of helloworld example can be found in the
-`HelloWorldExampleTCP folder <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/DDS/HelloWorldExampleTCP>`_.
+`HelloWorldExampleTCP folder <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/dds/HelloWorldExampleTCP>`_.
 It shows a publisher and a subscriber that communicate through TCP.
 The publisher is configured as *TCP server* while the Subscriber is acting as *TCP client*.
 

--- a/docs/fastdds/use_cases/well_known_deployments/well_known_deployments.rst
+++ b/docs/fastdds/use_cases/well_known_deployments/well_known_deployments.rst
@@ -48,7 +48,7 @@ each other, so they can start sharing user data right away, avoiding the EDP pha
 
 A complete description of the feature can be found at :ref:`discovery_static`.
 There is also a fully functional helloworld example implementing STATIC EDP in the
-`examples/C++/DDS/StaticHelloWorldExample <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/DDS/StaticHelloWorldExample>`_
+`examples/cpp/dds/StaticHelloWorldExample <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/dds/StaticHelloWorldExample>`_
 folder.
 
 The following subsections present an example configuration where a Publisher in

--- a/docs/fastdds/use_cases/zero_copy/zero_copy.rst
+++ b/docs/fastdds/use_cases/zero_copy/zero_copy.rst
@@ -158,4 +158,4 @@ Next steps
 
 The *eProsima Fast DDS* Github repository contains the complete example discussed in this section, as well as
 multiple other examples for different use cases. The example implementing Zero-Copy transfers can be found
-`here <https://github.com/eProsima/Fast-DDS/tree/master/examples/C%2B%2B/DDS/ZeroCopyExample>`_.
+`here <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/dds/ZeroCopyExample>`_.


### PR DESCRIPTION
This PR refers to #14543 and updates directories names of examples according to the parent task #14539.

This PR must be approved **only after** PR #2675 in Fast-DDS is approved to maintain consistency across Fast-DDS and Fast-DDS-docs repos.