### PR TITLE
Correct Python example downloaded file name

### DIFF
--- a/docs/fastdds/getting_started/simple_python_app/includes/subscriber.rst
+++ b/docs/fastdds/getting_started/simple_python_app/includes/subscriber.rst
@@ -1,11 +1,11 @@
 Write the Fast DDS subscriber
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-From the workspace, run the following command to download the HelloWorldPublisher.py file.
+From the workspace, run the following command to download the HelloWorldSubscriber.py file.
 
 .. code-block:: bash
 
-    wget -O HelloWorldPublisher.py \
+    wget -O HelloWorldSubscriber.py \
         https://raw.githubusercontent.com/eProsima/Fast-RTPS-docs/master/code/Examples/Python/HelloWorld/HelloWorldSubscriber.py
 
 This is the Python source code for the subscriber application.


### PR DESCRIPTION
The `HelloWorldSubscriber.py` was being downloaded as `HelloWorldPublisher.py`

Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>