### PR TITLE
[15161] Release v2.5.2

### DIFF
--- a/docs/notes/notes.rst
+++ b/docs/notes/notes.rst
@@ -38,6 +38,7 @@ Previous versions
 
 .. include:: previous_versions/v2.6.1.rst
 .. include:: previous_versions/v2.6.0.rst
+.. include:: previous_versions/v2.5.2.rst
 .. include:: previous_versions/v2.5.1.rst
 .. include:: previous_versions/v2.5.0.rst
 .. include:: previous_versions/v2.4.2.rst

--- a/docs/notes/previous_versions/v2.5.0.rst
+++ b/docs/notes/previous_versions/v2.5.0.rst
@@ -1,5 +1,5 @@
-Version 2.5.0
-^^^^^^^^^^^^^
+Version 2.5.0 (EOL)
+^^^^^^^^^^^^^^^^^^^
 
 This minor release is API compatible with the previous minor release, but introduces **ABI breaks** on
 two of the three public APIs:

--- a/docs/notes/previous_versions/v2.5.1.rst
+++ b/docs/notes/previous_versions/v2.5.1.rst
@@ -1,5 +1,5 @@
-Version 2.5.1
-^^^^^^^^^^^^^
+Version 2.5.1 (EOL)
+^^^^^^^^^^^^^^^^^^^
 
 This release includes the following **improvements**:
 

--- a/docs/notes/previous_versions/v2.5.2.rst
+++ b/docs/notes/previous_versions/v2.5.2.rst
@@ -1,0 +1,20 @@
+Version 2.5.2 (EOL)
+^^^^^^^^^^^^^^^^^^^
+This release includes the following **improvements**:
+
+1. Support lowercase keywords and hexadecimal values on SQL filter.
+2. Support for GCC 12.
+
+This release includes the following **bugfixes**:
+
+1. Fix MatchedStatus `last_*_handle`.
+2. Fix recommended statistics DataReaderQos to enable backwards compatibility.
+3. Fix deadlocks and data races.
+4. Fix empty partition validation checks.
+5. Fix corner case with reliable writers and samples with a huge number of fragments.
+6. Other minor fixes and improvements.
+
+.. note::
+  If you are upgrading from a version older than 1.7.0, it is **required** to regenerate generated source from IDL
+  files using *fastddsgen*.
+  If you are upgrading from any older version, regenerating the code is *highly recommended*.


### PR DESCRIPTION
This PR adds the Fast DDS v2.5.2 release notes.

After being merged, please backport to `2.5.x`.