### PR TITLE
[15014] XML Configuration for statistics DataWriters QoS

### DIFF
--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -950,6 +950,7 @@
 
 .. |StatisticsDomainParticipant-api| replace:: :cpp:class:`DomainParticipant <eprosima::fastdds::statistics::dds::DomainParticipant>`
 .. |enable_statistics_datawriter| replace:: :cpp:func:`enable_statistics_datawriter() <eprosima::fastdds::statistics::dds::DomainParticipant::enable_statistics_datawriter>`
+.. |enable_statistics_datawriter_with_profile| replace:: :cpp:func:`enable_statistics_datawriter_with_profile() <eprosima::fastdds::statistics::dds::DomainParticipant::enable_statistics_datawriter_with_profile>`
 .. |disable_statistics_datawriter| replace:: :cpp:func:`disable_statistics_datawriter() <eprosima::fastdds::statistics::dds::DomainParticipant::disable_statistics_datawriter>`
 .. |statistics_narrow| replace:: :cpp:func:`narrow() <eprosima::fastdds::statistics::dds::DomainParticipant::narrow>`
 

--- a/docs/fastdds/statistics/dds_layer/domainParticipant.rst
+++ b/docs/fastdds/statistics/dds_layer/domainParticipant.rst
@@ -139,8 +139,8 @@ Be aware that automatically enabling the statistics DataWriters using all these 
 QoS profile |STATISTICS_DATAWRITER_QOS-api|. For more information, please refer to :ref:`statistics_datawriter_qos`.
 However, if an XML profile is defined, the QoS applied are those defined in the profile,
 and for those QoS that are not specified in that profile, the default library QoS are applied
-(see :ref:`dds_layer_publisher_dataWriterQos` for the standard eProsima's DataWriter QoS)
-, and not the recommended QoS for the Statistics DataWriters.
+(see :ref:`dds_layer_publisher_dataWriterQos` for the standard eProsima's DataWriter QoS),
+and not the recommended QoS for the Statistics DataWriters.
 
 For the creation of an automatically enabled Datawriter, the priority for setting its QoS is the following:
 

--- a/docs/fastdds/statistics/dds_layer/domainParticipant.rst
+++ b/docs/fastdds/statistics/dds_layer/domainParticipant.rst
@@ -156,4 +156,7 @@ For the creation of an automatically enabled Datawriter, the priority for settin
     `GENERIC_STATISTICS_PROFILE`.
 
     The specific DataWriter profile defined in the `FASTRTPS_DEFAULT_PROFILES_FILE` XML needs to be named using the
-    statistic topic alias (see :ref:`statistics_topic_names` for the alias corresponding to each statistic topic).
+    same statistic topic alias or name (see :ref:`statistics_topic_names` for the alias corresponding to each statistic
+    topic) that has been used in the |DomainParticipantQos| |DomainParticipantQos::properties-api| ``fastdds.statistics``
+    or the :ref:`env_vars_fastdds_statistics` environment variable, where the enabling of the corresponding statistics
+    topic has been set.

--- a/docs/fastdds/statistics/dds_layer/domainParticipant.rst
+++ b/docs/fastdds/statistics/dds_layer/domainParticipant.rst
@@ -20,11 +20,34 @@ For this purpose, *Fast DDS Statistics module* exposes an extended DDS |Statisti
 Enable statistics DataWriters
 -----------------------------
 
-Statistics DataWriters are enabled using the method |enable_statistics_datawriter|.
-This method requires as parameters:
+Statistics DataWriters can be enabled in different ways.
+First, the built-in creation option, by which, if a statistics topic is defined either on the `fastdds.statistics`
+property policy, or on the `FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE` environment variable.
+If a statistics topic is defined on either of those ways, when creating a DomainParticipant with `auto-enable` option,
+the associate DataWriters will automatically be enabled, with the recommended statistic QoS.
+It is possible to define specific desired QoS trough DataWriter profile on the `FASTRTPS_DEFAULT_PROFILES_FILE`
+(see :ref:`xml_profiles`).
+
+Statistics DataWriters can be enabled at run time using one of two methods: |enable_statistics_datawriter| or
+|enable_statistics_datawriter_with_profile|.
+
+|enable_statistics_datawriter| method requires as parameters:
 
 * Name of the statistics topic to be enabled (see :ref:`statistics_topic_names` for the statistics topic list).
 * DataWriter QoS profile (see :ref:`statistics_datawriter_qos` for the recommended profile).
+
+|enable_statistics_datawriter_with_profile| method enables a DataWriter by searching a specific DataWriter XML profile.
+On that profile, specific QoS can be set for each statistics DataWriter.
+The method requires as parameter:
+
+* Name for the profile to be used. (see :ref:`statistics_topic_names` for the statistics topic list).
+
+.. note::
+
+    When defined on property policy or on environment variable, the statistics DataWriters are created with recommended statistics QoS.
+
+    Instead, when a statistics DataWriter is activated through an XML profile, desired QoS can be set,
+    but the default QoS used are the eProsima's default QoS, not the recommended statistics QoS.
 
 Disable statistics DataWriters
 ------------------------------

--- a/docs/fastdds/statistics/dds_layer/domainParticipant.rst
+++ b/docs/fastdds/statistics/dds_layer/domainParticipant.rst
@@ -30,7 +30,7 @@ Alternatively, Statistics DataWriters can be enabled at run time using one of tw
 * Name of the statistics topic to be enabled (see :ref:`statistics_topic_names` for the statistics topic list).
 * DataWriter QoS profile (see :ref:`statistics_datawriter_qos` for the recommended profile).
 
-It is possible to define specific desired QoS trough DataWriter profile on the `FASTRTPS_DEFAULT_PROFILES_FILE`
+It is possible to define specific desired QoS through DataWriter profile on the `FASTRTPS_DEFAULT_PROFILES_FILE`
 (see :ref:`xml_profiles`).
 |enable_statistics_datawriter_with_profile| method enables a DataWriter by searching a specific DataWriter XML profile.
 On those profiles, specific QoS can be set.
@@ -135,12 +135,14 @@ The following examples show how to use all the previous methods:
 
         HISTORY_LATENCY_TOPIC;NETWORK_LATENCY_TOPIC;PUBLICATION_THROUGHPUT_TOPIC;SUBSCRIPTION_THROUGHPUT_TOPIC;RTPS_SENT_TOPIC;RTPS_LOST_TOPIC;HEARTBEAT_COUNT_TOPIC;ACKNACK_COUNT_TOPIC;NACKFRAG_COUNT_TOPIC;GAP_COUNT_TOPIC;DATA_COUNT_TOPIC;RESENT_DATAS_TOPIC;SAMPLE_DATAS_TOPIC;PDP_PACKETS_TOPIC;EDP_PACKETS_TOPIC;DISCOVERY_TOPIC;PHYSICAL_DATA_TOPIC
 
-Be aware that automatically enabling the statistics DataWriters using all these methods implies using the recommended
-QoS profile |STATISTICS_DATAWRITER_QOS-api|. For more information, please refer to :ref:`statistics_datawriter_qos`.
-However, if an XML profile is defined, the QoS applied are those defined in the profile,
-and for those QoS that are not specified in that profile, the default library QoS are applied
-(see :ref:`dds_layer_publisher_dataWriterQos` for the standard eProsima's DataWriter QoS),
-and not the recommended QoS for the Statistics DataWriters.
+.. note::
+
+    Be aware that automatically enabling the statistics DataWriters using all these methods implies using the recommended
+    QoS profile |STATISTICS_DATAWRITER_QOS-api|. For more information, please refer to :ref:`statistics_datawriter_qos`.
+    However, if an XML profile is defined, the QoS applied are those defined in the profile,
+    and for those QoS that are not specified in that profile, the default library QoS are applied
+    (see :ref:`dds_layer_publisher_dataWriterQos` for the standard eProsima's DataWriter QoS),
+    and not the recommended QoS for the Statistics DataWriters.
 
 For the creation of an automatically enabled Datawriter, the priority for setting its QoS is the following:
 

--- a/docs/fastdds/statistics/dds_layer/domainParticipant.rst
+++ b/docs/fastdds/statistics/dds_layer/domainParticipant.rst
@@ -32,19 +32,8 @@ Alternatively, Statistics DataWriters can be enabled at run time using one of tw
 
 It is possible to define specific desired QoS trough DataWriter profile on the `FASTRTPS_DEFAULT_PROFILES_FILE`
 (see :ref:`xml_profiles`).
-|enable_statistics_datawriter_with_profile| method enables a DataWriter by searching a specific DataWriter XML profile,
-or a generic statistics DataWriter profile.
+|enable_statistics_datawriter_with_profile| method enables a DataWriter by searching a specific DataWriter XML profile.
 On those profiles, specific QoS can be set.
-For the creation of a Datawriter, the priority for setting its QoS is the following:
-
-* First, if a specific profile exists for the statistics topic, that one is applied.
-* If that is not the case but a generic profile for statistics DataWriters exists, that one is applied.
-* If no profile is defined in XML file, the recommended statistics QoS are applied.
-
-.. note::
-
-    The generic DataWriter profile defined in the `FASTRTPS_DEFAULT_PROFILES_FILE` XML needs to be named as
-    `GENERIC_STATISTICS_PROFILE`.
 
 |enable_statistics_datawriter_with_profile| method requires as parameters:
 
@@ -152,3 +141,14 @@ However, if an XML profile is defined, the QoS applied are those defined in the 
 and for those QoS that are not specified in that profile, the default library QoS are applied
 (see :ref:`dds_layer_publisher_dataWriterQos` for the standard eProsima's DataWriter QoS)
 , and not the recommended QoS for the Statistics DataWriters.
+
+For the creation of an automatically enabled Datawriter, the priority for setting its QoS is the following:
+
+* First, if a specific profile exists for the statistics topic, that one is applied.
+* If that is not the case but a generic profile for statistics DataWriters exists, that one is applied.
+* If no profile is defined in XML file, the recommended statistics QoS are applied.
+
+.. note::
+
+    The generic DataWriter profile defined in the `FASTRTPS_DEFAULT_PROFILES_FILE` XML needs to be named as
+    `GENERIC_STATISTICS_PROFILE`.

--- a/docs/fastdds/statistics/dds_layer/domainParticipant.rst
+++ b/docs/fastdds/statistics/dds_layer/domainParticipant.rst
@@ -158,5 +158,6 @@ For the creation of an automatically enabled Datawriter, the priority for settin
     The specific DataWriter profile defined in the `FASTRTPS_DEFAULT_PROFILES_FILE` XML needs to be named using the
     same statistic topic alias or name (see :ref:`statistics_topic_names` for the alias corresponding to each statistic
     topic) that has been used in the |DomainParticipantQos| |DomainParticipantQos::properties-api| ``fastdds.statistics``
-    or the :ref:`env_vars_fastdds_statistics` environment variable, where the enabling of the corresponding statistics
+    (see :ref:`property_policies_statistics`) or the :ref:`env_vars_fastdds_statistics` environment variable,
+    where the enabling of the corresponding statistics
     topic has been set.

--- a/docs/fastdds/statistics/dds_layer/domainParticipant.rst
+++ b/docs/fastdds/statistics/dds_layer/domainParticipant.rst
@@ -154,3 +154,6 @@ For the creation of an automatically enabled Datawriter, the priority for settin
 
     The generic DataWriter profile defined in the `FASTRTPS_DEFAULT_PROFILES_FILE` XML needs to be named as
     `GENERIC_STATISTICS_PROFILE`.
+
+    The specific DataWriter profile defined in the `FASTRTPS_DEFAULT_PROFILES_FILE` XML needs to be named using the
+    statistic topic alias (see :ref:`statistics_topic_names` for the alias corresponding to each statistic topic).

--- a/docs/fastdds/statistics/dds_layer/domainParticipant.rst
+++ b/docs/fastdds/statistics/dds_layer/domainParticipant.rst
@@ -21,33 +21,35 @@ Enable statistics DataWriters
 -----------------------------
 
 Statistics DataWriters can be enabled in different ways.
-First, the built-in creation option, by which, if a statistics topic is defined either on the `fastdds.statistics`
-property policy, or on the `FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE` environment variable.
-If a statistics topic is defined on either of those ways, when creating a DomainParticipant with `auto-enable` option,
-the associate DataWriters will automatically be enabled, with the recommended statistic QoS.
-It is possible to define specific desired QoS trough DataWriter profile on the `FASTRTPS_DEFAULT_PROFILES_FILE`
-(see :ref:`xml_profiles`).
-
-Statistics DataWriters can be enabled at run time using one of two methods: |enable_statistics_datawriter| or
-|enable_statistics_datawriter_with_profile|.
+It can be done automatically (see :ref:`auto_enabling_statistics_datawriters`).
+Alternatively, Statistics DataWriters can be enabled at run time using one of two methods:
+|enable_statistics_datawriter| or |enable_statistics_datawriter_with_profile|.
 
 |enable_statistics_datawriter| method requires as parameters:
 
 * Name of the statistics topic to be enabled (see :ref:`statistics_topic_names` for the statistics topic list).
 * DataWriter QoS profile (see :ref:`statistics_datawriter_qos` for the recommended profile).
 
-|enable_statistics_datawriter_with_profile| method enables a DataWriter by searching a specific DataWriter XML profile.
-On that profile, specific QoS can be set for each statistics DataWriter.
-The method requires as parameter:
+It is possible to define specific desired QoS trough DataWriter profile on the `FASTRTPS_DEFAULT_PROFILES_FILE`
+(see :ref:`xml_profiles`).
+|enable_statistics_datawriter_with_profile| method enables a DataWriter by searching a specific DataWriter XML profile,
+or a generic statistics DataWriter profile.
+On those profiles, specific QoS can be set.
+For the creation of a Datawriter, the priority for setting its QoS is the following:
 
-* Name for the profile to be used. (see :ref:`statistics_topic_names` for the statistics topic list).
+* First, if a specific profile exists for the statistics topic, that one is applied.
+* If that is not the case but a generic profile for statistics DataWriters exists, that one is applied.
+* If no profile is defined in XML file, the recommended statistics QoS are applied.
 
 .. note::
 
-    When defined on property policy or on environment variable, the statistics DataWriters are created with recommended statistics QoS.
+    The generic DataWriter profile defined in the `FASTRTPS_DEFAULT_PROFILES_FILE` XML needs to be named as
+    `GENERIC_STATISTICS_PROFILE`.
 
-    Instead, when a statistics DataWriter is activated through an XML profile, desired QoS can be set,
-    but the default QoS used are the eProsima's default QoS, not the recommended statistics QoS.
+|enable_statistics_datawriter_with_profile| method requires as parameters:
+
+* Name of the XML profile to use to fill the QoS structure of the DataWriter.
+* Name of the statistics topic name to be enabled. (see :ref:`statistics_topic_names` for the statistics topic list).
 
 Disable statistics DataWriters
 ------------------------------
@@ -146,3 +148,7 @@ The following examples show how to use all the previous methods:
 
 Be aware that automatically enabling the statistics DataWriters using all these methods implies using the recommended
 QoS profile |STATISTICS_DATAWRITER_QOS-api|. For more information, please refer to :ref:`statistics_datawriter_qos`.
+However, if an XML profile is defined, the QoS applied are those defined in the profile,
+and for those QoS that are not specified in that profile, the default library QoS are applied
+(see :ref:`dds_layer_publisher_dataWriterQos` for the standard eProsima's DataWriter QoS)
+, and not the recommended QoS for the Statistics DataWriters.


### PR DESCRIPTION
Further explanation on enabling statistics DataWriters and QoS editing.
Relates to FastDDS branch: [feature/XML_configuration_statistics_QoS](https://github.com/eProsima/Fast-DDS/tree/feature/XML_configuration_statistics_QoS)

Signed-off-by: Mikel Rico <mikelrico@eprosima.com>