### PR TITLE
[16214] Set PREALLOCATED_WITH_REALLOC as default memory policy

### DIFF
--- a/docs/docker/includes/intro.rst
+++ b/docs/docker/includes/intro.rst
@@ -2,7 +2,7 @@ eProsima provides the Fast DDS and the Fast DDS Suite Docker images for those wh
 platform.
 They can be downloaded from `eProsima's downloads page <https://eprosima.com/index.php/downloads-all>`_.
 
-This Docker images were built for Ubuntu 20.04 (Focal Fossa).
+This Docker images were built for Ubuntu 22.04 (Jammy Jellyfish).
 
 To run a container you need Docker installed. From a terminal, run:
 

--- a/docs/docker/includes/intro.rst
+++ b/docs/docker/includes/intro.rst
@@ -2,7 +2,7 @@ eProsima provides the Fast DDS and the Fast DDS Suite Docker images for those wh
 platform.
 They can be downloaded from `eProsima's downloads page <https://eprosima.com/index.php/downloads-all>`_.
 
-This Docker images were built for Ubuntu 22.04 (Focal Fossa).
+This Docker images were built for Ubuntu 20.04 (Focal Fossa).
 
 To run a container you need Docker installed. From a terminal, run:
 

--- a/docs/fastdds/use_cases/reduce_memory/reduce_memory.rst
+++ b/docs/fastdds/use_cases/reduce_memory/reduce_memory.rst
@@ -62,7 +62,7 @@ application's needs. Below is an example of a configuration for the minimum reso
 
 Set Dynamic Allocation
 ^^^^^^^^^^^^^^^^^^^^^^
-By default :ref:`memorymanagementpolicy` is set to |PREALLOCATED_MEMORY_MODE-api|, meaning that the amount of memory
+By default :ref:`memorymanagementpolicy` is set to |PREALLOCATED_WITH_REALLOC_MEMORY_MODE-api|, meaning that the amount of memory
 required by the configured :ref:`resourcelimitsqospolicy` will be allocated at initialization.
 
 Using the dynamic settings of the :ref:`rtpsendpointqos` will prevent unnecessary allocations. Lowest footprint is

--- a/docs/fastdds/use_cases/reduce_memory/reduce_memory.rst
+++ b/docs/fastdds/use_cases/reduce_memory/reduce_memory.rst
@@ -62,8 +62,8 @@ application's needs. Below is an example of a configuration for the minimum reso
 
 Set Dynamic Allocation
 ^^^^^^^^^^^^^^^^^^^^^^
-By default :ref:`memorymanagementpolicy` is set to |PREALLOCATED_WITH_REALLOC_MEMORY_MODE-api|, meaning that the amount of memory
-required by the configured :ref:`resourcelimitsqospolicy` will be allocated at initialization.
+By default :ref:`memorymanagementpolicy` is set to |PREALLOCATED_WITH_REALLOC_MEMORY_MODE-api|, meaning that the
+amount of memory required by the configured :ref:`resourcelimitsqospolicy` will be allocated at initialization.
 If some more memory has to be allocated at run time, it is reallocated.
 
 Using the dynamic settings of the :ref:`rtpsendpointqos` will prevent unnecessary allocations. Lowest footprint is

--- a/docs/fastdds/use_cases/reduce_memory/reduce_memory.rst
+++ b/docs/fastdds/use_cases/reduce_memory/reduce_memory.rst
@@ -64,6 +64,7 @@ Set Dynamic Allocation
 ^^^^^^^^^^^^^^^^^^^^^^
 By default :ref:`memorymanagementpolicy` is set to |PREALLOCATED_WITH_REALLOC_MEMORY_MODE-api|, meaning that the amount of memory
 required by the configured :ref:`resourcelimitsqospolicy` will be allocated at initialization.
+If some more memory has to be allocated at run time, it is reallocated.
 
 Using the dynamic settings of the :ref:`rtpsendpointqos` will prevent unnecessary allocations. Lowest footprint is
 achieved with |DYNAMIC_RESERVE_MEMORY_MODE-api| at the cost of higher allocation counts, in this mode memory is


### PR DESCRIPTION
## Description

This PR sets PREALLOCATED_WITH_REALLOC as the default memory policy. Also corrects a minor naming error when calling Ubuntu 22.04 Focal, which is 20.04.

This PR relates with eProsima/Fast-DDS#3102

Signed-off-by: Mario Dominguez <mariodominguez@eprosima.com>