### PR TITLE
[16489] Fix default Statistics DataWriter QoS

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3166,11 +3166,12 @@
 
         <!-- Generic profile for all the statistics DataWriter -->
         <data_writer profile_name="GENERIC_STATISTICS_PROFILE">
-            <!-- Configure History QoS as KEEP_LAST 10 -->
+            <!-- Configure History QoS as KEEP_LAST 20 -->
+            <!-- History depth depends on the user application constraints (publication rate for instance) -->
             <topic>
                 <historyQos>
                     <kind>KEEP_LAST</kind>
-                    <depth>10</depth>
+                    <depth>20</depth>
                 </historyQos>
             </topic>
             <!-- Enable pull mode -->
@@ -3225,11 +3226,12 @@
 
         <!-- Generic profile for a specific statistics DataWriters -->
         <data_writer profile_name="HISTORY_LATENCY_TOPIC">
-            <!-- Configure History QoS as KEEP_LAST 10 -->
+            <!-- Configure History QoS as KEEP_LAST 20 -->
+            <!-- History depth depends on the user application constraints (publication rate for instance) -->
             <topic>
                 <historyQos>
                     <kind>KEEP_LAST</kind>
-                    <depth>10</depth>
+                    <depth>20</depth>
                 </historyQos>
             </topic>
             <!-- Enable pull mode -->

--- a/docs/fastdds/statistics/dds_layer/qos.rst
+++ b/docs/fastdds/statistics/dds_layer/qos.rst
@@ -43,7 +43,7 @@ The recommended profile can be accessed through the constant |STATISTICS_DATAWRI
    * - |HistoryQosPolicyKind-api|
      - |KEEP_LAST_HISTORY_QOS-api|
    * - |history_depth-api|
-     - 1
+     - 10
    * - |PropertyPolicyQos-api| name = value
      - ``"fastdds.push_mode"`` = ``"false"``
 

--- a/docs/fastdds/statistics/dds_layer/troubleshooting.rst
+++ b/docs/fastdds/statistics/dds_layer/troubleshooting.rst
@@ -15,17 +15,17 @@ Sometimes, especially in the case of monitoring large applications with many Dat
 that the application monitoring Fast DDS statistics does not receive any data.
 This is generally caused by the default configuration of the statistics DataWriters, which includes the
 :class:`push_mode` set to :class:`false` (i.e. :class:`pull_mode`), the History Kind set to :class:`KEEP_LAST`, and the
-History Depth set to :class:`1`.
+History Depth set to :class:`10`.
 With this configuration, the following may happen:
 
-1. Fast DDS adds a new sample to one of the statistics DataWriters.
-2. The DataWriter notifies the DataReader of the availability of said sample.
-3. The DataReader sends a request to the DataWriter to "pull" that sample.
-4. Before the request arrives to the DataWriter, a new statistics sample is added to that same DataWriter, which causes
-   the previous sample to be overwritten.
-5. Once the DataReader request arrives to the DataWriter, since the requested sample has been overwritten, it is not
-   available any more, so the DataWriter send a notification to the DataReader informing of the presence of the newer
-   sample instead.
+1. Fast DDS adds new samples to one of the statistics DataWriters.
+2. The DataWriter notifies the DataReader of the availability of said samples.
+3. The DataReader sends a request to the DataWriter to "pull" those samples.
+4. Before the request arrives to the DataWriter, some new statistics samples are added to that same DataWriter, which
+   causes the previous samples to be overwritten.
+5. Once the DataReader request arrives to the DataWriter, since the requested samples have been overwritten, they are
+   not available any more, so the DataWriter send a notification to the DataReader informing of the presence of the
+   newer samples instead.
 6. The loop starts again.
 
 The easiest fix to overcome this situation is to simply increase the History Depth of the DataWriter to create Some
@@ -39,7 +39,7 @@ buffer to answer to requests:
             :language: xml
             :start-after: <!-->FASTDDS_STATISTICS_TROUBLESHOOTING_GENERIC<-->
             :end-before: <!--><-->
-            :lines: 2-4, 6-52, 54-55
+            :lines: 2-4, 6-53, 55-56
 
   .. tab:: Specific profile
 
@@ -47,7 +47,7 @@ buffer to answer to requests:
             :language: xml
             :start-after: <!-->FASTDDS_STATISTICS_TROUBLESHOOTING_SINGLE_TOPIC<-->
             :end-before: <!--><-->
-            :lines: 2-4, 6-52, 54-55
+            :lines: 2-4, 6-53, 55-56
 
 .. note::
     Increasing the History Depth of the statistics DataWriters has an impact on memory usage, as sufficient space is


### PR DESCRIPTION
eProsima/Fast-DDS#2998 changed the default Statistics DataWriter QoS but documentation was not updated accordingly.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>