### PR TITLE
[16795] Remove warning no longer applying

### DIFF
--- a/docs/fastdds/dds_layer/publisher/dataWriterListener/dataWriterListener.rst
+++ b/docs/fastdds/dds_layer/publisher/dataWriterListener/dataWriterListener.rst
@@ -25,10 +25,6 @@ Callbacks that are not overridden will maintain their empty implementation.
   It will be called for each deadline period and data instance for which the
   DataWriter failed to provide data.
 
-.. warning::
-   Currently *on_offered_deadline_missed* is not implemented (it will never be called), and will be implemented
-   on a future release of Fast DDS.
-
 * |DataWriterListener::on_offered_incompatible_qos-api|: The DataWriter has found a
   DataReader that matches the Topic and has
   a common partition, but with a requested QoS that is incompatible with the one defined on the

--- a/docs/fastdds/dds_layer/subscriber/dataReaderListener/dataReaderListener.rst
+++ b/docs/fastdds/dds_layer/subscriber/dataReaderListener/dataReaderListener.rst
@@ -36,11 +36,6 @@ DataReaderListener defines the following callbacks:
   It will be called for each deadline period and data instance for which the
   DataReader missed data.
 
-.. warning::
-   Currently
-   |DataReaderListener::on_requested_deadline_missed-api|
-   is not implemented (it will never be called), and will be implemented on a future release of Fast DDS.
-
 * |DataReaderListener::on_requested_incompatible_qos-api|:
   The DataReader has found a
   DataWriter that matches the Topic and has


### PR DESCRIPTION
Since Fast DDS v2.1.0 `DataReaderListener::on_requested_deadline_missed` and `DataWriterListener::on_offered_deadline_missed` are implemented.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>