### PR TITLE
[16904] Fix jinja2 dependency to avoid build error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,12 @@
-sphinx==3.0.3
 breathe==4.18.0
+colcon-common-extensions==0.2.1
+colcon-mixin==0.1.8
 doc8==0.8.0
+GitPython==3.1.1
+jinja2==3.0.3
+setuptools==46.1.3
+sphinx==3.0.3
 sphinx_rtd_theme==0.4.3
 sphinxcontrib.spelling==5.0.0
 sphinxcontrib-imagehelper==1.1.1
-colcon-common-extensions==0.2.1
-colcon-mixin==0.1.8
 vcstool==0.2.7
-GitPython==3.1.1
-setuptools==46.1.3


### PR DESCRIPTION
By default, pip installs the lates version of jinja2 package (3.1) which issues an error in Readthedocs (readthedocs/readthedocs.org#9038).

This PR fixes the dependency version to avoid this issue and sorts the dependencies alphabetically.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>