### PR TITLE
[17130] Fix spell check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,6 @@ set(CPACK_COMPONENTS_ALL ${CPACK_COMPONENTS_ALL} doxygen)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/code/cmake" ${CMAKE_MODULE_PATH})
 find_package(Sphinx REQUIRED)
 
-set(SPHINX_SOURCE "${CMAKE_SOURCE_DIR}/docs")
-
 ####################################################################################################
 # Compile code used in documentation
 ####################################################################################################
@@ -110,6 +108,7 @@ endif()
 ####################################################################################################
 # It is possible to build and run tests without generating the documentation output. This saves time
 # while developing, since generating the documentation from the RSTs takes quite some time.
+set(SPHINX_SOURCE "${CMAKE_SOURCE_DIR}/docs")
 option(BUILD_DOCUMENTATION "Generate documentation" ON)
 if (BUILD_DOCUMENTATION)
     # Check there is Python bindings accessible and configure sphinx depending on that.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,13 @@ set(CPACK_COMPONENT_EXAMPLES_DESCRIPTION
     "eProsima Fast DDS doxygen documetation")
 set(CPACK_COMPONENTS_ALL ${CPACK_COMPONENTS_ALL} doxygen)
 
+####################################################################################################
+# Find Sphinx
+####################################################################################################
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/code/cmake" ${CMAKE_MODULE_PATH})
+find_package(Sphinx REQUIRED)
+
+set(SPHINX_SOURCE "${CMAKE_SOURCE_DIR}/docs")
 
 ####################################################################################################
 # Compile code used in documentation
@@ -101,13 +108,6 @@ endif()
 ####################################################################################################
 # Build Sphinx documentation
 ####################################################################################################
-
-# Find sphinx
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/code/cmake" ${CMAKE_MODULE_PATH})
-find_package(Sphinx REQUIRED)
-
-set(SPHINX_SOURCE "${CMAKE_SOURCE_DIR}/docs")
-
 # It is possible to build and run tests without generating the documentation output. This saves time
 # while developing, since generating the documentation from the RSTs takes quite some time.
 option(BUILD_DOCUMENTATION "Generate documentation" ON)

--- a/docs/fastdds/use_cases/request_reply/request_reply.rst
+++ b/docs/fastdds/use_cases/request_reply/request_reply.rst
@@ -52,7 +52,7 @@ The DDS communication schema will be:
     [Reply DataWriter] --> [Reply DataReader] : Reply Topic
 
 The key for making *Request-Reply* work is relating the Request with the Reply in the client's side.
-*Fast DDS* API provides |SampleIdentity-api| to achive this.
+*Fast DDS* API provides |SampleIdentity-api| to achieve this.
 
 A full example can be found in `Fast DDS repository`_.
 


### PR DESCRIPTION
#436 introduced a regression because the tests are built without finding Sphinx package previously.
Spell check depends on this package to run.
This PR fixes this issue.

**REVIEWER**: even if the CI is green, the job output has to be checked to see if the spell check has been run.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>