### PR TITLE
Fix property name for access control plugin

### DIFF
--- a/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
+++ b/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
@@ -36,7 +36,7 @@ in detail below.
 
 The DDS\:Access\:Permissions authentication plugin, can be activated setting the |DomainParticipantQos|
 |DomainParticipantQos::properties-api|
-``dds.sec.auth.plugin`` with the value ``builtin.Access-Permissions``.
+``dds.sec.access.plugin`` with the value ``builtin.Access-Permissions``.
 The following table outlines the properties used for the DDS\:Access\:Permissions plugin configuration.
 
 .. list-table::


### PR DESCRIPTION
The property name was copy.pasted from previous section.