### PR TITLE
[17206] Restore participant domainID tag in XML profile

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -828,6 +828,7 @@
 <profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
 -->
     <participant profile_name="domainparticipant_profile_name">
+        <domainId>4</domainId>
         <rtps>
             <name>DomainParticipant Name</name>
 
@@ -955,7 +956,6 @@
 </participant>
 
 <participant profile_name="part_builtin_example">
-<domainId>4</domainId> <!-- uint32 -->
 <rtps>
 <!-->XML-BUILTIN<-->
 <builtin>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -955,6 +955,7 @@
 </participant>
 
 <participant profile_name="part_builtin_example">
+<domainId>4</domainId> <!-- uint32 -->
 <rtps>
 <!-->XML-BUILTIN<-->
 <builtin>

--- a/code/XMLTesterExample.xml
+++ b/code/XMLTesterExample.xml
@@ -73,6 +73,7 @@
         </transport_descriptors>
 
         <participant profile_name="participant_profile_example">
+            <domainId>4</domainId>
             <rtps>
                 <name>Participant Name</name> <!-- String -->
 

--- a/docs/fastdds/xml_configuration/domainparticipant.rst
+++ b/docs/fastdds/xml_configuration/domainparticipant.rst
@@ -36,7 +36,7 @@ The ``<participant>`` element has two attributes defined: ``profile_name`` and `
        DomainParticipant's creation.
      - Optional
 
-.. _domainparticipantconfig:
+.. _domainparticipantconfig: 
 
 DomainParticipant configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/fastdds/xml_configuration/domainparticipant.rst
+++ b/docs/fastdds/xml_configuration/domainparticipant.rst
@@ -36,12 +36,12 @@ The ``<participant>`` element has two attributes defined: ``profile_name`` and `
        DomainParticipant's creation.
      - Optional
 
-.. _domainparticipantconfig: 
+.. _domainparticipantconfig:
 
 DomainParticipant configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``<participant>`` element has two child elements: ``<domain_id>`` and ``<rtps>``.
+The ``<participant>`` element has two child elements: ``<domainId>`` and ``<rtps>``.
 All the DomainParticipant configuration options belong to the ``<rtps>`` element, except for the DDS |DomainId-api|
 which is defined by the ``<domainId>`` element.
 Below a list with the configuration XML elements is presented:
@@ -184,7 +184,7 @@ These elements allow the user to define the DomainParticipant configuration.
     :language: xml
     :start-after: <!-->XML-PARTICIPANT<-->
     :end-before: <!--><-->
-    :lines: 2-3, 5-87, 89
+    :lines: 2-3, 5-88, 90
 
 .. note::
 

--- a/docs/fastdds/xml_configuration/domainparticipant.rst
+++ b/docs/fastdds/xml_configuration/domainparticipant.rst
@@ -41,8 +41,26 @@ The ``<participant>`` element has two attributes defined: ``profile_name`` and `
 DomainParticipant configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``<participant>`` element has as child element ``<rtps>`` under which all the DomainParticipant configuration
-options belong.
+The ``<participant>`` element has two child elements: ``<domain_id>`` and ``<rtps>``.
+All the DomainParticipant configuration options belong to the ``<rtps>`` element, except for the DDS |DomainId-api|
+which is defined by the ``<domainId>`` element.
+Below a list with the configuration XML elements is presented:
+
++----------------+----------------------------------------------------------------------------+--------------+---------+
+| Name           | Description                                                                | Values       | Default |
++================+============================================================================+==============+=========+
+| ``<domainId>`` | DomainId to be used by the DomainParticipant.                              | ``uint32_t`` | 0       |
+|                | See :ref:`dds_layer_domainParticipant_creation_profile`.                   |              |         |
++----------------+----------------------------------------------------------------------------+--------------+---------+
+| ``<rtps>``     | *Fast DDS* DomainParticipant configurations. |br|                          |  :ref:`RTPS` |         |
+|                | See :ref:`RTPS`.                                                           |              |         |
++----------------+----------------------------------------------------------------------------+--------------+---------+
+
+.. _RTPS:
+
+RTPS element type
+"""""""""""""""""
+
 The following is a list with all the possible child XML elements of the ``<rtps>`` element.
 These elements allow the user to define the DomainParticipant configuration.
 


### PR DESCRIPTION
- Restore `<domainId>` tag in documentation
- Restore tag in ALL documentation XMLs

Rebased #455 

**This pull request should be merged right after #455 gets merged**