### PR TITLE
[17294] allow_unauthenticated_participants flag compliant premises

### DIFF
--- a/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
+++ b/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
@@ -215,6 +215,8 @@ The ``<domains>`` element can contain:
 
 Or a combination of both, a list of domain identifiers and ranges of domain identifiers.
 
+.. _allow_unauthenticated_section:
+
 Allow Unauthenticated Participants
 **********************************
 
@@ -227,6 +229,12 @@ The possible values for this element are:
 *  ``true``: the DomainParticipant shall allow matching other DomainParticipants (event if the remote
    DomainParticipant cannot authenticate) as long as there is not an already valid authentication with the same
    DomainParticipant's GUID.
+
+In accordance with the `DDS Security specification <https://www.omg.org/spec/DDS-SECURITY/>`_, the following premises should be considered:
+
+*  In order to match an entity with an unauthenticated DomainParticipant, all the :ref:`topic_rules` attributes must be either ``false`` or ``NONE``.
+*  If :ref:`rtps_protection_kind_section` is not ``NONE`` and :ref:`allow_unauthenticated_section` is enabled, the entity creation will fail with an error.
+*  Despite ``<allow_unauthenticated_participants>`` is enabled, authentication is always attempted first.
 
 Enable Join Access Control
 **************************
@@ -260,6 +268,8 @@ The possible values are:
 *  ``NONE``: the secure channel shall not be protected.
 *  ``SIGN``: the secure channel shall be protected by MAC.
 *  ``ENCRYPT``: the secure channel shall be encrypted.
+
+.. _rtps_protection_kind_section:
 
 RTPS Protection Kind
 ********************
@@ -316,6 +326,7 @@ The rule applies to any |DataReader| or |DataWriter| associated with a |Topic| w
 name.
 The topic access rules are evaluated in the same order as they appear within the ``<topic_access_rules>`` section.
 If multiple rules match, the first rule that matches is the only one that applies.
+If no matching ``<topic_rule>`` is found, the entity creation will fail.
 
 .. _Topic expression:
 


### PR DESCRIPTION
This PR adds the premises in which eProsima/Fast-DDS/pull/3385 is based on regarding the <allow_unauthenticated_participants> governance security flag.