### PR TITLE
[18066] Monitor Service Documentation

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -647,6 +647,34 @@ void dds_domain_examples()
         //!--
     }
     {
+        // FASTDDS_MONITOR_SERVICE_PROPERTY
+        DomainParticipantQos pqos;
+
+        // Activate Fast DDS Monitor Service through properties
+        pqos.properties().properties().emplace_back("fastdds.enable_monitor_service",
+                "true");
+
+        DomainParticipant* participant_with_mon_srv = DomainParticipantFactory::get_instance()->create_participant(0,
+                        pqos);
+
+        //!--
+    }
+    {
+        // FASTDDS_MONITOR_SERVICE_API
+
+        DomainParticipant* participant_with_mon_srv = DomainParticipantFactory::get_instance()->create_participant(0,
+                        PARTICIPANT_QOS_DEFAULT);
+
+        // Enable Fast DDS Monitor Service through API
+        participant_with_mon_srv->enable_monitor_service();
+
+        // Disable Fast DDS Monitor Service through API
+        participant_with_mon_srv->enable_monitor_service();
+
+
+        //!--
+    }
+    {
         // FASTDDS_PHYSICAL_PROPERTIES
         /* Create participant which announces default physical properties */
         DomainParticipantQos pqos_default_physical;

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -2609,6 +2609,26 @@
 </participant>
 <!--><-->
 
+<!-->DDS_MONITOR_SERVICE<-->
+<!--
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+-->
+<participant profile_name="monitor_service_participant_xml_profile">
+    <rtps>
+        <propertiesPolicy>
+            <properties>
+                <!-- Activate Monitor Service -->
+                <property>
+                    <name>fastdds.enable_monitor_service</name>
+                    <value>true</value>
+                </property>
+            </properties>
+        </propertiesPolicy>
+    </rtps>
+</participant>
+<!--><-->
+
 <!-->PULL_MODE_DATAWRITER<-->
 <!--
 <?xml version="1.0" encoding="UTF-8" ?>

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -145,6 +145,9 @@
 .. |DomainParticipant::create_topic_with_profile-api| replace:: :cpp:func:`create_topic_with_profile()<eprosima::fastdds::dds::DomainParticipant::create_topic_with_profile>`
 .. |DomainParticipant::find_topic| replace:: :cpp:func:`find_topic()<eprosima::fastdds::dds::DomainParticipant::find_topic>`
 .. |DomainParticipant::ignore_participant-api| replace:: :cpp:func:`ignore_participant()<eprosima::fastdds::dds::DomainParticipant::ignore_participant>`
+.. |DomainParticipant::enable-monitor-service-api| replace:: :cpp:func:`enable_monitor_service()<eprosima::fastdds::dds::DomainParticipant::enable_monitor_service>`
+.. |DomainParticipant::disable-monitor-service-api| replace:: :cpp:func:`disable_monitor_service()<eprosima::fastdds::dds::DomainParticipant::disable_monitor_service>`
+.. |DomainParticipant::check-compatible-qos-api| replace:: :cpp:func:`check_compatible_qos()<eprosima::fastdds::dds::DomainParticipant::check_compatible_qos>`
 
 .. |DomainParticipantFactory-api| replace:: :cpp:class:`DomainParticipantFactory<eprosima::fastdds::dds::DomainParticipantFactory>`
 .. |DomainParticipantFactory::create_participant_with_profile-api| replace:: :cpp:func:`create_participant_with_profile()<eprosima::fastdds::dds::DomainParticipantFactory::create_participant_with_profile>`

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -147,7 +147,6 @@
 .. |DomainParticipant::ignore_participant-api| replace:: :cpp:func:`ignore_participant()<eprosima::fastdds::dds::DomainParticipant::ignore_participant>`
 .. |DomainParticipant::enable-monitor-service-api| replace:: :cpp:func:`enable_monitor_service()<eprosima::fastdds::dds::DomainParticipant::enable_monitor_service>`
 .. |DomainParticipant::disable-monitor-service-api| replace:: :cpp:func:`disable_monitor_service()<eprosima::fastdds::dds::DomainParticipant::disable_monitor_service>`
-.. |DomainParticipant::check-compatible-qos-api| replace:: :cpp:func:`check_compatible_qos()<eprosima::fastdds::dds::DomainParticipant::check_compatible_qos>`
 
 .. |DomainParticipantFactory-api| replace:: :cpp:class:`DomainParticipantFactory<eprosima::fastdds::dds::DomainParticipantFactory>`
 .. |DomainParticipantFactory::create_participant_with_profile-api| replace:: :cpp:func:`create_participant_with_profile()<eprosima::fastdds::dds::DomainParticipantFactory::create_participant_with_profile>`

--- a/docs/fastdds/monitor_service/intro.rst
+++ b/docs/fastdds/monitor_service/intro.rst
@@ -15,20 +15,21 @@ The :ref:`monitor_service` can be particularly useful in the following scenarios
 
 *  To retrieve an entity graph of a |domain|, overcoming situations
    in which a sub-set of |DomainParticipants| are not directly visible, for instance, because they
-   have multicast traffic disabled, discoverying each other using an initial peers list.
+   have multicast traffic disabled, discovering each other using an initial peers list.
    By means of the :ref:`monitor_service` it is possible to recover the information
    of those |DomainParticipants| and their entities (given that there is at least one
    |DomainParticipant| bridging the unicast and multicast groups).
 *  Troubleshooting issues regarding discovery or entity-matching, leveraging the information
    of the current locators in use, for example.
 *  Checking whether the Quality of Service *QoS* attributes of a pair of known entities (Reader, Writer)
-   are compatible, or not, using the service in conjuction with the |DomainParticipant::check-compatible-qos-api|.
+   are compatible, or not, using the service in conjunction with the |DomainParticipant::check-compatible-qos-api|.
 
 Enabling the service makes each |DomainParticipant| publish the collection of
 entities known through discovery.
 In addition, a Remote Procedural Call *RPC* Server is provided so that information of a requested entity
 can be retrieved.
-An RPC server works in a kind of client/server model where the RPC server provides a service to remotely connected RPC clients.
+An RPC server works in a kind of client/server model where the RPC server provides
+a service to remotely connected RPC clients.
 The RPC Client sends a request, the RPC Server processes it, returning a response back to the client.
 
 The :ref:`monitor_service` is disabled by default, as it may entail a performance cost.

--- a/docs/fastdds/monitor_service/intro.rst
+++ b/docs/fastdds/monitor_service/intro.rst
@@ -9,34 +9,49 @@ Monitor Service
 The *Fast DDS* Monitor Service is an extension of Fast DDS that
 grants user the ability to collect data about the entities existing within
 a particular |domain| (i.e |DomainParticipants|, |DataReaders|, |DataWriters|)
-as well as the capability of predicting possible misconfigurations among them.
+as well as the capability of detecting possible misconfigurations among them.
 
-The :ref:`monitor_service` can be particularly useful in the following scenarios:
+Keywords
+^^^^^^^^
+* **Request/Response service or RPC**: An RPC is initiated by the client, which sends a request message to a
+  known remote server to execute a specified procedure with supplied parameters.
+  Then, the remote server sends a response back to the client, and the application continues its process.
 
-*  Querying a remote |DomainParticipant| for information targetting any of its local
-   entities in order to extend the default discovery information about it.
-*  Retrieving remote entities information in situations in which a sub-set of |DomainParticipants|
-   are not directly visible, for instance, because they have multicast traffic disabled,
-   discovering each other using an initial peers list.
-   By means of the :ref:`monitor_service` it is possible to recover the information
-   of those |DomainParticipants| and their entities (given that there is at least one
-   |DomainParticipant| bridging the unicast and multicast groups).
-*  Troubleshooting issues regarding discovery or entity-matching, leveraging the information
-   of the current locators in use, for example.
-*  Checking whether the Quality of Service *QoS* attributes of a pair of known entities (Reader, Writer)
-   are compatible, or not, using the service in conjunction with the |DomainParticipant::check-compatible-qos-api|.
+* **Proxy**: An entity that acts on behalf of another entity.
 
-Enabling the service makes each |DomainParticipant| publish the collection of
-entities known through discovery.
-In addition, a Remote Procedural Call *RPC* Server is provided so that information of a requested entity
+* **Proxy Data**: The way in which a Proxy can be described.
+
+* **Monitoring Information**: The collection of different sources of information and statuses of an entity,
+  including: the Proxy Data, incompatible_qos, connections, liveliness, deadlines missed, inconsistent
+  topics and sample lost status.
+
+Description
+^^^^^^^^^^^
+
+Enabling the service makes each |DomainParticipant| publish the collection of its local entities.
+In addition, a Remote Procedural Call *RPC* Server is provided so that information of a requested local entity
 can be retrieved.
-An RPC server works in a kind of client/server model where the RPC server provides
-a service to remotely connected RPC clients.
-The RPC Client sends a request, the RPC Server processes it, returning a response back to the client.
 
 The :ref:`monitor_service` is disabled by default, as it may entail a performance cost.
 Further information on the :ref:`monitor_service` topics and how to configure it, is described
-in the following sections:
+in the following sections.
+
+The :ref:`monitor_service` is available in both the :ref:`DDS Layer <dds_layer>` and :ref:`RTPS Layer <rtps_layer>`.
+
+.. note::
+
+   If the service is activated within a :ref:`RTPS <rtps_layer>` context, not all the information requested could
+   be returned by the service.
+
+Use Cases
+^^^^^^^^^^^
+
+The :ref:`monitor_service` can be particularly useful in the following scenarios:
+
+*  Querying a remote |DomainParticipant| for its ``Monitoring Information`` targetting any of its local
+   entities in order to extend the default discovery information (see :ref:`discovery`) about it.
+*  Troubleshooting issues regarding discovery or entity-matching, leveraging the information
+   of the current locators in use, for example.
 
 .. toctree::
     :titlesonly:

--- a/docs/fastdds/monitor_service/intro.rst
+++ b/docs/fastdds/monitor_service/intro.rst
@@ -13,9 +13,11 @@ as well as the capability of predicting possible misconfigurations among them.
 
 The :ref:`monitor_service` can be particularly useful in the following scenarios:
 
-*  To retrieve an entity graph of a |domain|, overcoming situations
-   in which a sub-set of |DomainParticipants| are not directly visible, for instance, because they
-   have multicast traffic disabled, discovering each other using an initial peers list.
+*  Querying a remote |DomainParticipant| for information targetting any of its local
+   entities in order to extend the default discovery information about it.
+*  Retrieving remote entities information in situations in which a sub-set of |DomainParticipants|
+   are not directly visible, for instance, because they have multicast traffic disabled,
+   discovering each other using an initial peers list.
    By means of the :ref:`monitor_service` it is possible to recover the information
    of those |DomainParticipants| and their entities (given that there is at least one
    |DomainParticipant| bridging the unicast and multicast groups).

--- a/docs/fastdds/monitor_service/intro.rst
+++ b/docs/fastdds/monitor_service/intro.rst
@@ -1,0 +1,42 @@
+.. include:: ../../03-exports/aliases.include
+.. include:: ../../03-exports/aliases-api.include
+
+.. _monitor_service:
+
+Monitor Service
+===============
+
+The *Fast DDS* Monitor Service is an extension of Fast DDS that
+grants user the ability to collect data about the entities existing within
+a particular |domain| (i.e |DomainParticipants|, |DataReaders|, |DataWriters|)
+as well as the capability of predicting possible misconfigurations among them.
+
+The :ref:`monitor_service` can be particularly useful in the following scenarios:
+
+*  To retrieve an entity graph of a |domain|, overcoming situations
+   in which a sub-set of |DomainParticipants| are not directly visible, for instance, because they
+   have multicast traffic disabled, discoverying each other using an initial peers list.
+   By means of the :ref:`monitor_service` it is possible to recover the information
+   of those |DomainParticipants| and their entities (given that there is at least one
+   |DomainParticipant| bridging the unicast and multicast groups).
+*  Troubleshooting issues regarding discovery or entity-matching, leveraging the information
+   of the current locators in use, for example.
+*  Checking whether the Quality of Service *QoS* attributes of a pair of known entities (Reader, Writer)
+   are compatible, or not, using the service in conjuction with the |DomainParticipant::check-compatible-qos-api|.
+
+Enabling the service makes each |DomainParticipant| publish the collection of
+entities known through discovery.
+In addition, a Remote Procedural Call *RPC* Server is provided so that information of a requested entity
+can be retrieved.
+An RPC server works in a kind of client/server model where the RPC server provides a service to remotely connected RPC clients.
+The RPC Client sends a request, the RPC Server processes it, returning a response back to the client.
+
+The :ref:`monitor_service` is disabled by default, as it may entail a performance cost.
+Further information on the :ref:`monitor_service` topics and how to configure it, is described
+in the following sections:
+
+.. toctree::
+    :titlesonly:
+
+    /fastdds/monitor_service/monitor_service_topics
+    /fastdds/monitor_service/monitor_service_configuration

--- a/docs/fastdds/monitor_service/intro.rst
+++ b/docs/fastdds/monitor_service/intro.rst
@@ -4,7 +4,7 @@
 Introduction
 ============
 
-The ``Monitor Service`` targets any application implementing the suscription side,
+The ``Monitor Service`` targets any application implementing the subscription side,
 giving the possibility of retrieving the :ref:`Monitoring Information <monitor_service_keywords>`
 of the local entities of remote matched ``DomainParticipants`` (incompatible QoS, deadlines missed,
 active connections,...).
@@ -44,7 +44,7 @@ Use Cases
 
 The :ref:`monitor_service` can be particularly useful in the following scenarios:
 
-*  Collecting the ``Monitoring Information`` of any local entitiy of a remote |DomainParticipant|
+*  Collecting the ``Monitoring Information`` of any local entity of a remote |DomainParticipant|
    in order to extend the default discovery information (see :ref:`discovery`) about it.
 *  Troubleshooting issues regarding discovery or entity-matching, leveraging the information
    of the current locators in use, for example.

--- a/docs/fastdds/monitor_service/intro.rst
+++ b/docs/fastdds/monitor_service/intro.rst
@@ -1,60 +1,51 @@
 .. include:: ../../03-exports/aliases.include
 .. include:: ../../03-exports/aliases-api.include
 
-.. _monitor_service:
+Introduction
+============
 
-Monitor Service
-===============
+The ``Monitor Service`` targets any application implementing the suscription side,
+giving the possibility of retrieving the :ref:`Monitoring Information <monitor_service_keywords>`
+of the local entities of remote matched ``DomainParticipants`` (incompatible QoS, deadlines missed,
+active connections,...).
 
-The *Fast DDS* Monitor Service is an extension of Fast DDS that
-grants user the ability to collect data about the entities existing within
-a particular |domain| (i.e |DomainParticipants|, |DataReaders|, |DataWriters|)
-as well as the capability of detecting possible misconfigurations among them.
+.. _monitor_service_keywords:
 
 Keywords
 ^^^^^^^^
-* **Request/Response service or RPC**: An RPC is initiated by the client, which sends a request message to a
-  known remote server to execute a specified procedure with supplied parameters.
-  Then, the remote server sends a response back to the client, and the application continues its process.
 
 * **Proxy**: An entity that acts on behalf of another entity.
 
 * **Proxy Data**: The way in which a Proxy can be described.
 
 * **Monitoring Information**: The collection of different sources of information and statuses of an entity,
-  including: the Proxy Data, incompatible_qos, connections, liveliness, deadlines missed, inconsistent
-  topics and sample lost status.
+  including: the Proxy Data, incompatible qos, connections, liveliness, deadlines missed, inconsistent
+  topics and lost sample status.
 
 Description
 ^^^^^^^^^^^
 
-Enabling the service makes each |DomainParticipant| publish the collection of its local entities.
-In addition, a Remote Procedural Call *RPC* Server is provided so that information of a requested local entity
-can be retrieved.
+Enabling the service makes each |DomainParticipant| publish its local entities, each one with its related
+``Monitoring Information``.
 
 The :ref:`monitor_service` is disabled by default, as it may entail a performance cost.
-Further information on the :ref:`monitor_service` topics and how to configure it, is described
+Further information on the :ref:`monitor_service` topics and how to configure it is described
 in the following sections.
 
 The :ref:`monitor_service` is available in both the :ref:`DDS Layer <dds_layer>` and :ref:`RTPS Layer <rtps_layer>`.
 
 .. note::
 
-   If the service is activated within a :ref:`RTPS <rtps_layer>` context, not all the information requested could
-   be returned by the service.
+   If the service is activated within a :ref:`RTPS <rtps_layer>` context, not all the ``Monitoring Information``
+   may be published by the service.
 
 Use Cases
-^^^^^^^^^^^
+^^^^^^^^^
 
 The :ref:`monitor_service` can be particularly useful in the following scenarios:
 
-*  Querying a remote |DomainParticipant| for its ``Monitoring Information`` targetting any of its local
-   entities in order to extend the default discovery information (see :ref:`discovery`) about it.
+*  Collecting the ``Monitoring Information`` of any local entitiy of a remote |DomainParticipant|
+   in order to extend the default discovery information (see :ref:`discovery`) about it.
 *  Troubleshooting issues regarding discovery or entity-matching, leveraging the information
    of the current locators in use, for example.
-
-.. toctree::
-    :titlesonly:
-
-    /fastdds/monitor_service/monitor_service_topics
-    /fastdds/monitor_service/monitor_service_configuration
+*  Recreating an entity graph of a certain domain given that all participants are able to discover each other.

--- a/docs/fastdds/monitor_service/intro.rst
+++ b/docs/fastdds/monitor_service/intro.rst
@@ -4,9 +4,10 @@
 Introduction
 ============
 
-The ``Monitor Service`` targets any application implementing the subscription side,
+The ``Monitor Service`` targets any application implementing the subscription side of
+the :ref:`Monitor Service Status Topic <monitor_service_topics>`,
 giving the possibility of retrieving the :ref:`Monitoring Information <monitor_service_keywords>`
-of the local entities of remote matched ``DomainParticipants`` (incompatible QoS, deadlines missed,
+of the local entities (incompatible QoS, deadlines missed,
 active connections,...).
 
 .. _monitor_service_keywords:
@@ -33,6 +34,9 @@ Further information on the :ref:`monitor_service` topics and how to configure it
 in the following sections.
 
 The :ref:`monitor_service` is available in both the :ref:`DDS Layer <dds_layer>` and :ref:`RTPS Layer <rtps_layer>`.
+
+
+.. _monitor_service_in_rtps_note:
 
 .. note::
 

--- a/docs/fastdds/monitor_service/monitor_service.rst
+++ b/docs/fastdds/monitor_service/monitor_service.rst
@@ -6,7 +6,7 @@
 Monitor Service
 ===============
 
-The *Fast DDS* Monitor Service is an extension of Fast DDS that
+The *Fast DDS* Monitor Service is an feature of Fast DDS that
 grants the user the ability to collect data about the entities existing within
 a particular |domain| (i.e |DomainParticipants|, |DataReaders|, |DataWriters|)
 as well as the capability of detecting possible misconfigurations among them.

--- a/docs/fastdds/monitor_service/monitor_service.rst
+++ b/docs/fastdds/monitor_service/monitor_service.rst
@@ -1,0 +1,19 @@
+.. include:: ../../03-exports/aliases.include
+.. include:: ../../03-exports/aliases-api.include
+
+.. _monitor_service:
+
+Monitor Service
+===============
+
+The *Fast DDS* Monitor Service is an extension of Fast DDS that
+grants the user the ability to collect data about the entities existing within
+a particular |domain| (i.e |DomainParticipants|, |DataReaders|, |DataWriters|)
+as well as the capability of detecting possible misconfigurations among them.
+
+.. toctree::
+    :titlesonly:
+
+    /fastdds/monitor_service/intro
+    /fastdds/monitor_service/monitor_service_topics
+    /fastdds/monitor_service/monitor_service_configuration

--- a/docs/fastdds/monitor_service/monitor_service_configuration.rst
+++ b/docs/fastdds/monitor_service/monitor_service_configuration.rst
@@ -13,57 +13,56 @@ for the purpose: ``fastdds.enable_monitor_service``.
 
 The following table depicts the different ways in which the monitor service can be enabled or disabled:
 
-Property Policy
-^^^^^^^^^^^^^^^
 
-.. tabs::
-
-  .. tab:: C++ API
-
-    .. literalinclude:: ../../../code/DDSCodeTester.cpp
-       :language: c++
-       :dedent: 8
-       :start-after: // FASTDDS_MONITOR_SERVICE_API
-       :end-before: //!
-
-  .. tab:: C++ Property
-
-    .. literalinclude:: ../../../code/DDSCodeTester.cpp
-       :language: c++
-       :dedent: 8
-       :start-after: // FASTDDS_MONITOR_SERVICE_PROPERTY
-       :end-before: //!
-
-  .. tab:: XML
-
-    .. literalinclude:: ../../../code/XMLTester.xml
-       :language: xml
-       :start-after: <!-->DDS_MONITOR_SERVICE
-       :end-before: <!--><-->
++----------------------------------------------------------+
+| **C++ API**                                              |
++----------------------------------------------------------+
+| .. literalinclude:: ../../../code/DDSCodeTester.cpp      |
+|        :language: c++                                    |
+|        :dedent: 8                                        |
+|        :start-after: // FASTDDS_MONITOR_SERVICE_API      |
+|        :end-before: //!                                  |
++----------------------------------------------------------+
+| **C++ Property**                                         |
++----------------------------------------------------------+
+| .. literalinclude:: ../../../code/DDSCodeTester.cpp      |
+|        :language: c++                                    |
+|        :dedent: 8                                        |
+|        :start-after: // FASTDDS_MONITOR_SERVICE_PROPERTY |
+|        :end-before: //!                                  |
++----------------------------------------------------------+
+| **XML**                                                  |
++----------------------------------------------------------+
+| .. literalinclude:: /../code/XMLTester.xml               |
+|    :language: xml                                        |
+|    :start-after: <!-->DDS_MONITOR_SERVICE<-->            |
+|    :end-before: <!--><-->                                |
++----------------------------------------------------------+
+| **Environment Variable Linux**                           |
++----------------------------------------------------------+
+| .. code-block:: bash                                     |
+|                                                          |
+|    export FASTDDS_STATISTICS="MONITOR_SERVICE_TOPIC"     |
++----------------------------------------------------------+
+| **Environment Variable Windows**                         |
++----------------------------------------------------------+
+| .. code-block:: bash                                     |
+|                                                          |
+|    set FASTDDS_STATISTICS=MONITOR_SERVICE_TOPIC          |
++----------------------------------------------------------+
 
 Endpoints QoS
 ^^^^^^^^^^^^^
 
-For any client of the :ref:`monitor_service`, the following endpoints' QoS for each
-of the :ref:`monitor_service_topics` should be taken into consideration:
+For any consumer application of the :ref:`monitor_service`, the following endpoint QoS
+of the :ref:`monitor_service_status_topic` should be taken into consideration:
 
 +-------------------------+-------------------------------+------------------------------------+
 |       **Endpoint**      |          **QoS**              |  **Value**                         |
 +-------------------------+-------------------------------+------------------------------------+
-|     MONITOR_EV_WRITER   | |ReliabilityQosPolicyKind-api|||RELIABLE_RELIABILITY_QOS-api|      |
+|  MONITOR_STATUS_WRITER  | |ReliabilityQosPolicyKind-api|||RELIABLE_RELIABILITY_QOS-api|      |
 |                         +-------------------------------+------------------------------------+
 |                         | |HistoryQosPolicyKind-api|    ||KEEP_LAST_HISTORY_QOS-api| 1       |
 |                         +-------------------------------+------------------------------------+
 |                         | |DurabilityQosPolicyKind-api| ||TRANSIENT_LOCAL_DURABILITY_QOS-api||
 +-------------------------+-------------------------------+------------------------------------+
-|     MONITOR_REQ_READER  | |ReliabilityQosPolicyKind-api|||RELIABLE_RELIABILITY_QOS-api|      |
-|                         +-------------------------------+------------------------------------+
-|                         | |DurabilityQosPolicyKind-api| ||TRANSIENT_LOCAL_DURABILITY_QOS-api||
-+-------------------------+-------------------------------+------------------------------------+
-|     MONITOR_RES_WRITER  | |ReliabilityQosPolicyKind-api|||RELIABLE_RELIABILITY_QOS-api|      |
-|                         +-------------------------------+------------------------------------+
-|                         | |DurabilityQosPolicyKind-api| ||TRANSIENT_LOCAL_DURABILITY_QOS-api||
-+-------------------------+-------------------------------+------------------------------------+
-
-
-

--- a/docs/fastdds/monitor_service/monitor_service_configuration.rst
+++ b/docs/fastdds/monitor_service/monitor_service_configuration.rst
@@ -55,7 +55,7 @@ Endpoints QoS
 ^^^^^^^^^^^^^
 
 For any consumer application of the :ref:`monitor_service`, the following endpoint QoS
-of the :ref:`monitor_service_status_topic` should be taken into consideration:
+of the :ref:`monitor_service_status_topic` DataWriter should be taken into consideration:
 
 +-------------------------+-------------------------------+------------------------------------+
 |       **Endpoint**      |          **QoS**              |  **Value**                         |

--- a/docs/fastdds/monitor_service/monitor_service_configuration.rst
+++ b/docs/fastdds/monitor_service/monitor_service_configuration.rst
@@ -6,11 +6,12 @@
 Monitor Service Configuration
 =============================
 
-The :ref:`monitor_service` can be programatically enabled in both :ref:`dds_layer` and :ref:`rtps_layer`
+The :ref:`monitor_service` can be programmatically enabled in both :ref:`dds_layer` and :ref:`rtps_layer`
 through the |DomainParticipant::enable-monitor-service-api| and |DomainParticipant::disable-monitor-service-api| calls.
-In addition, leveraging the |PropertyPolicyQos-api| there is new ``Property`` defined for the purpose: ``fastdds.enable_monitor_service``.
+In addition, leveraging the |PropertyPolicyQos-api| there is new ``Property`` defined
+for the purpose: ``fastdds.enable_monitor_service``.
 
-The following table depicts the different ways in which the monitor service can be enabled or disbled:
+The following table depicts the different ways in which the monitor service can be enabled or disabled:
 
 Property Policy
 ^^^^^^^^^^^^^^^

--- a/docs/fastdds/monitor_service/monitor_service_configuration.rst
+++ b/docs/fastdds/monitor_service/monitor_service_configuration.rst
@@ -1,0 +1,68 @@
+.. include:: ../../03-exports/aliases.include
+.. include:: ../../03-exports/aliases-api.include
+
+.. _monitor_service_configuration:
+
+Monitor Service Configuration
+=============================
+
+The :ref:`monitor_service` can be programatically enabled in both :ref:`dds_layer` and :ref:`rtps_layer`
+through the |DomainParticipant::enable-monitor-service-api| and |DomainParticipant::disable-monitor-service-api| calls.
+In addition, leveraging the |PropertyPolicyQos-api| there is new ``Property`` defined for the purpose: ``fastdds.enable_monitor_service``.
+
+The following table depicts the different ways in which the monitor service can be enabled or disbled:
+
+Property Policy
+^^^^^^^^^^^^^^^
+
+.. tabs::
+
+  .. tab:: C++ API
+
+    .. literalinclude:: ../../../code/DDSCodeTester.cpp
+       :language: c++
+       :dedent: 8
+       :start-after: // FASTDDS_MONITOR_SERVICE_API
+       :end-before: //!
+
+  .. tab:: C++ Property
+
+    .. literalinclude:: ../../../code/DDSCodeTester.cpp
+       :language: c++
+       :dedent: 8
+       :start-after: // FASTDDS_MONITOR_SERVICE_PROPERTY
+       :end-before: //!
+
+  .. tab:: XML
+
+    .. literalinclude:: ../../../code/XMLTester.xml
+       :language: xml
+       :start-after: <!-->DDS_MONITOR_SERVICE
+       :end-before: <!--><-->
+
+Endpoints QoS
+^^^^^^^^^^^^^
+
+For any client of the :ref:`monitor_service`, the following endpoints' QoS for each
+of the :ref:`monitor_service_topics` should be taken into consideration:
+
++-------------------------+-------------------------------+------------------------------------+
+|       **Endpoint**      |          **QoS**              |  **Value**                         |
++-------------------------+-------------------------------+------------------------------------+
+|     MONITOR_EV_WRITER   | |ReliabilityQosPolicyKind-api|||RELIABLE_RELIABILITY_QOS-api|      |
+|                         +-------------------------------+------------------------------------+
+|                         | |HistoryQosPolicyKind-api|    ||KEEP_LAST_HISTORY_QOS-api| 1       |
+|                         +-------------------------------+------------------------------------+
+|                         | |DurabilityQosPolicyKind-api| ||TRANSIENT_LOCAL_DURABILITY_QOS-api||
++-------------------------+-------------------------------+------------------------------------+
+|     MONITOR_REQ_READER  | |ReliabilityQosPolicyKind-api|||RELIABLE_RELIABILITY_QOS-api|      |
+|                         +-------------------------------+------------------------------------+
+|                         | |DurabilityQosPolicyKind-api| ||TRANSIENT_LOCAL_DURABILITY_QOS-api||
++-------------------------+-------------------------------+------------------------------------+
+|     MONITOR_RES_WRITER  | |ReliabilityQosPolicyKind-api|||RELIABLE_RELIABILITY_QOS-api|      |
+|                         +-------------------------------+------------------------------------+
+|                         | |DurabilityQosPolicyKind-api| ||TRANSIENT_LOCAL_DURABILITY_QOS-api||
++-------------------------+-------------------------------+------------------------------------+
+
+
+

--- a/docs/fastdds/monitor_service/monitor_service_topics.rst
+++ b/docs/fastdds/monitor_service/monitor_service_topics.rst
@@ -19,8 +19,9 @@ The following table depicts the properties of the topics within the :ref:`monito
 Monitor Service Status Topic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``Monitor Service Status Topic`` carries information about the :ref:`monitoring information <monitor_service_keywords>`
-of the local entities of a particular |DomainParticipant|.
+The ``Monitor Service Status Topic`` carries information about the
+:ref:`monitoring information <monitor_service_keywords>` of the local entities of a
+particular |DomainParticipant|.
 The :ref:`monitoring information <monitor_service_keywords>` can be divided into different statuses
 identified by a ``StatusKind``.
 The possible values are described in the following table:
@@ -102,8 +103,8 @@ The actual field names for the different values are described below:
 
 * *incompatible_qos_status:* Status of the Incompatible QoS of that entity.
 
-	* |DataWriter| Incompatible QoS Offered.
-	* |DataReader| Incompatible QoS Requested.
+  * |DataWriter| Incompatible QoS Offered.
+  * |DataReader| Incompatible QoS Requested.
 
 * *inconsistent_topic_status:* Status of Inconsistent topics of the topic of that entity.
   Asked to the topic of the requested entity.

--- a/docs/fastdds/monitor_service/monitor_service_topics.rst
+++ b/docs/fastdds/monitor_service/monitor_service_topics.rst
@@ -49,13 +49,18 @@ The possible values are described in the following table:
 |  5      |   ``LivelinessChangedInfo`` | Tracks the status of the number of times|
 |         |                             | the liveliness changed in a reader.     |
 +---------+-----------------------------+-----------------------------------------+
-|  6      |  ``DeadlineMissedInfo``     |  The Status of the number of deadlines  |
-|         |                             |  missed of a sample for that entity.    |
+|  6      |  ``DeadlineMissedInfo``     | The Status of the number of deadlines   |
+|         |                             | missed of a sample for that entity.     |
 +---------+-----------------------------+-----------------------------------------+
-|  7      |     ``SampleLostInfo``      | Tracks the number of times this entity  |
-|         |                             | lost samples.                           |
+|  7      |     ``SampleLostInfo``      | Tracks the status of the number of times|
+|         |                             | this entity lost samples.               |
 +---------+-----------------------------+-----------------------------------------+
 
+.. note::
+
+    If the service is enabled in a :ref:`RTPS layer <rtps_layer>` context, :ref:`not all
+    the statuses will be published <monitor_service_in_rtps_note>`,
+    only the ``ProxyInfo`` and ``ConnectionList``.
 
 The ``Monitor Service Status Topic`` publishes new data when new updates are received from any
 of the |DomainParticipant|'s local entities (on-event driven) with a minimum waiting time between

--- a/docs/fastdds/monitor_service/monitor_service_topics.rst
+++ b/docs/fastdds/monitor_service/monitor_service_topics.rst
@@ -6,32 +6,29 @@
 Monitor Service Topics
 ======================
 
-The following table depicts a summary of the available topics in the :ref:`monitor_service`:
+The following table depicts the properties of the topics within the :ref:`monitor_service`:
 
 +---------------------------------------+-------------------------+---------------------------------------+
 |**Topic name**                         |**Topic Alias**          | **TopicDataType**                     |
 +---------------------------------------+-------------------------+---------------------------------------+
-| ``_fastdds_monitor_service_events``   |     MONITOR_EV_TOPIC    | :ref:`monitor_service_events_data`    |
-+---------------------------------------+-------------------------+---------------------------------------+
-|``_fastdds_monitor_service_request``   |     MONITOR_REQ_TOPIC   | :ref:`monitor_service_request_data`   |
-+---------------------------------------+-------------------------+---------------------------------------+
-| ``_fastdds_monitor_service_response`` |     MONITOR_RES_TOPIC   | :ref:`monitor_service_response_data`  |
+| ``fastrtps_monitor_service_status``   | MONITOR_SERVICE_TOPIC   | :ref:`monitor_service_status_data`    |
 +---------------------------------------+-------------------------+---------------------------------------+
 
-.. _monitor_service_events_topic:
+.. _monitor_service_status_topic:
 
-Monitor Service Events Topic
+Monitor Service Status Topic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Monitor Service Event's Topic carries information about all the local entities of a particular
-|DomainParticipant|, storing a collection of |Guid_t-api| identifying each entity alongside with a
-sequence of statuses' version (an incremental counter), each one identified by an index.
-These statuses' indexes are described in the following table:
+The ``Monitor Service Status Topic`` carries information about the :ref:`monitoring information <monitor_service_keywords>`
+of the local entities of a particular |DomainParticipant|.
+The :ref:`monitoring information <monitor_service_keywords>` can be divided into different statuses
+identified by a ``StatusKind``.
+The possible values are described in the following table:
 
 .. _monitoring_statuses:
 
 +---------+-----------------------------+-----------------------------------------+
-|**Index**|          **Name**           | **Description**                         |
+|**Value**|          **Name**           | **Description**                         |
 +---------+-----------------------------+-----------------------------------------+
 |  0      |     ``ProxyInfo``           | Collection of Parameters describing the |
 |         |                             | ``Proxy Data`` of that entity           |
@@ -45,90 +42,56 @@ These statuses' indexes are described in the following table:
 |  3      | ``InconsistentTopicInfo``   | Status of Inconsistent topics that the  |
 |         |                             | topic of that entity has.               |
 +---------+-----------------------------+-----------------------------------------+
-|  4      |   ``DeadlineMissedInfo``    | The Status of the number of deadlines   |
-|         |                             | missed for that entity                  |
+|  4      |   ``LivelinessLostInfo``    | Tracks the status of the number of times|
+|         |                             | a writer lost liveliness.               |
 +---------+-----------------------------+-----------------------------------------+
-|  5      |   ``LivelinessLostInfo``    | Tracks the status of the number of times|
-|         |                             | a writer lost liveliness                |
-+---------+-----------------------------+-----------------------------------------+
-|  6      |  ``LivelinessChangedInfo``  | Tracks the status of the number of times|
+|  5      |   ``LivelinessChangedInfo`` | Tracks the status of the number of times|
 |         |                             | the liveliness changed in a reader.     |
++---------+-----------------------------+-----------------------------------------+
+|  6      |  ``DeadlineMissedInfo``     |  The Status of the number of deadlines  |
+|         |                             |  missed of a sample for that entity.    |
 +---------+-----------------------------+-----------------------------------------+
 |  7      |     ``SampleLostInfo``      | Tracks the number of times this entity  |
 |         |                             | lost samples.                           |
 +---------+-----------------------------+-----------------------------------------+
 
-The ``Monitor Service`` Event's Topic publishes new data when new updates are received from any
-of the |DomainParticipant|'s local entities (on-event driven) at a certain limited rate.
-In addition, it is in charge of notifying about any dispose or liveliness lost.
 
-.. _monitor_service_events_data:
+The ``Monitor Service Status Topic`` publishes new data when new updates are received from any
+of the |DomainParticipant|'s local entities (on-event driven) with a minimum waiting time between
+publications.
+In addition, it is in charge of notifying about any disposal or liveliness lost.
 
-Monitor Service Event Data
---------------------------
+.. _monitor_service_status_data:
 
-The ``MonitorServiceEventData`` data structure comprises the following fields:
+Monitor Service Status Data
+---------------------------
 
-* *source_participant:* The GUID of the participant that knows the entity.
-* *entity_guid:* Guid of a known entity.
-* *status_info:* Most recent :ref:`statuses<monitoring_statuses>` available for that entity.
+The ``MonitorServiceStatusData`` data structure comprises the following fields:
+
+* *local_entity:* |Guid_t-api| of the local entity.
+* *status_kind:* :ref:`StatusKind <monitoring_statuses>` enumeration identifying the status.
+* *value:* The value of the status.
 
 .. code-block:: bash
 
-    GUID_t source_participant @key
-    GUID_t entity_guid @key
-    InfoVersionStatus status_info
+    MonitorServiceStatusData
+      @Key GUID local_entity
+      @Key StatusKind status_kind
+      Data value
 
 .. note::
 
-    The *source_participant* and *entity_guid* are keyed fields, hence making use of instances (see :ref:`dds_layer_topic_instances`).
-    In this case, the pair <*source_participant, entity_guid*> conforms a unique instance.
+    The *local_entity* and *status_kind* are keyed fields, hence making use of instances (see :ref:`dds_layer_topic_instances`).
+    In this case, the pair <*local_entity, status_kind*> identifies a unique instance.
 
-Monitor Service RPC Topics
-^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A |DomainParticipant| with an enabled ``Monitor Service`` provides a RPC mechanism
-for querying another |DomainParticipant| about its local entities.
-This is achieved by means of the ``Monitor Service`` Request/Response topics,
-in which the client side writes the request specifying the :ref:`statuses<monitoring_statuses>` of
-interest (in a mask) and the ``Monitor Service`` of the requested |DomainParticipant| collects
-the requested data to later return the corresponding response.
+Each of the ``StatusKind`` enumeration values maps to a corresponding ``Data`` value.
+The actual field names for the different values are described below:
 
-The actual data types and fields of the aforementioned topics are described below:
+* *entity_proxy:* Collection of the serialized Quality of Service Parameters in the form of a ``ParameterList``.
 
-.. _monitor_service_request_data:
-
-Monitor Service Request Data
-----------------------------
-
-The ``MonitorServiceRequestData`` data structure has the following fields:
-
-* *requested_participant:* It refers to the |Guid_t-api| of the participant of interest.
-* *entity_guid:* The particular entity_id to get the information from.
-* *request_mask:* The mask indicating what ``Monitoring Information`` should be
-  returned in the response.
-
-.. code-block:: bash
-
-    GUID_t requested_participant @Key
-    GUID_t entity_guid @Key
-    RequestMask request_mask
-
-.. _monitor_service_response_data:
-
-Monitor Service Response Data
------------------------------
-
-The ``MonitorServiceResponseData`` data structure consists on the following fields:
-
-* *event_data:* The current event data of the queried entity, this should be congruent
-  with last MonitorServiceEventData published in the Monitor Service Event's Topic.
-  This field is always returned in the response.
-* *entity_proxy:* Collection of the Quality of Service Parameters in the form of a ParameterList.
-  This field can be optionally returned[^5].
 * *connection_list:* Defines how is this entity communicating with its matched entities.
   Each of the elements is of Connection type (depicted below).
-  This field can be optionally returned.
 
 .. code-block:: bash
 
@@ -138,37 +101,49 @@ The ``MonitorServiceResponseData`` data structure consists on the following fiel
       LocatorList used_locators
 
 * *incompatible_qos_status:* Status of the Incompatible QoS of that entity.
-  |DataWriter| Offered |DataReader| Requested.
-  This field can be optionally returned.
+
+	* |DataWriter| Incompatible QoS Offered.
+	* |DataReader| Incompatible QoS Requested.
+
 * *inconsistent_topic_status:* Status of Inconsistent topics of the topic of that entity.
   Asked to the topic of the requested entity.
-  This field can be optionally returned.
+
 * *liveliness_lost_status:* Tracks the status of the number of times that liveliness was lost by a
   |DataWriter|.
-  This field can be optionally returned.
+
 * *liveliness_changed_status:* Tracks the status of the number of times that liveliness was lost
   by a |DataReader|.
-  This field can be optionally returned.
+
 * *deadline_status:* The Status of the number of deadlines missed that were registered in that entity.
-  This field can be optionally returned.
+
 * *sample_lost_status:* The number of samples that entity lost.
-  This field can be optionally returned.
 
-.. code-block:: bash
+The following table depicts the relation between each of the ``StatusKind`` values and the ``Data`` field:
 
-    MonitorServiceEventData event_data
-    vector<uint8_t> entity_proxy
-    vector<vector<Connection>> connection_list
-    vector<IncompatibleQoSStatus> incompatible_qos_status
-    vector<InconsistentTopicStatus> inconsistent_topic_status
-    vector<LivelinessLostStatus> liveliness_lost_status
-    vector<LivelinessChangedStatus> liveliness_changed_status
-    vector<DeadlineMissedStatus> deadline_status
-    vector<SampleLostStatus> sample_lost_status
-
-.. note::
-
-    Note that each optional field can be returned, or not.
-    This depends on the :ref:`RequestMask<monitor_service_request_data>` and if
-    the service is announced within a :ref:`DDS<dds_layer>` or :ref:`RTPS<rtps_layer>` |domain|.
-    A vector with a maximum size of 1 is used to denote the optionality.
++---------------------+---------------------------+---------------------------+---------------------------+
+|**StatusKind Value** |     **StatusKind Name**   | **Data field Name**       | **IDL Data field Type**   |
++---------------------+---------------------------+---------------------------+---------------------------+
+|  0                  |     ``ProxyInfo``         | entity_proxy              | sequence<octet>           |
+|                     |                           |                           |                           |
++---------------------+---------------------------+---------------------------+---------------------------+
+|  1                  |     ``ConnectionList``    | connection_list           | sequence<Connection>      |
+|                     |                           |                           |                           |
++---------------------+---------------------------+---------------------------+---------------------------+
+|  2                  |  ``IncompatibleQoSInfo``  | incompatible_qos_status   | IncompatibleQoSStatus     |
+|                     |                           |                           |                           |
++---------------------+---------------------------+---------------------------+---------------------------+
+|  3                  | ``InconsistentTopicInfo`` | inconsistent_topic_status | InconsistentTopicStatus   |
+|                     |                           |                           |                           |
++---------------------+---------------------------+---------------------------+---------------------------+
+|  4                  |   ``LivelinessLostInfo``  | liveliness_lost_status    | LivelinessLostStatus      |
+|                     |                           |                           |                           |
++---------------------+---------------------------+---------------------------+---------------------------+
+|  5                  |   ``LivelinessLostInfo``  | liveliness_changed_status | LivelinessChangedStatus   |
+|                     |                           |                           |                           |
++---------------------+---------------------------+---------------------------+---------------------------+
+|  6                  |  ``DeadlineMissedInfo``   | deadline_missed_status    | DeadlineMissedStatus      |
+|                     |                           |                           |                           |
++---------------------+---------------------------+---------------------------+---------------------------+
+|  7                  |     ``SampleLostInfo``    | sample_lost_status        | SampleLostStatus          |
+|                     |                           |                           |                           |
++---------------------+---------------------------+---------------------------+---------------------------+

--- a/docs/fastdds/monitor_service/monitor_service_topics.rst
+++ b/docs/fastdds/monitor_service/monitor_service_topics.rst
@@ -6,7 +6,7 @@
 Monitor Service Topics
 ======================
 
-The following table depicts a summary of the availble topics in the :ref:`monitor_service`:
+The following table depicts a summary of the available topics in the :ref:`monitor_service`:
 
 +---------------------------------------+-------------------------+---------------------------------------+
 |**Topic name**                         |**Topic Alias**          | **TopicDataType**                     |
@@ -56,8 +56,10 @@ The ``MonitorServiceEventData`` data structure comprises the following fields:
 Monitor Service RPC Topics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A |DomainParticipant| with an enabled ``Monitor Service`` provides a RPC mechanism for querying another |DomainParticipant| about its known entities.
-This is achieved by means of the ``Monitor Service`` Request/Response topics, in which the client side writes the request and the ``Monitor Service``
+A |DomainParticipant| with an enabled ``Monitor Service`` provides a RPC mechanism
+for querying another |DomainParticipant| about its known entities.
+This is achieved by means of the ``Monitor Service`` Request/Response topics,
+in which the client side writes the request and the ``Monitor Service``
 of the requested |DomainParticipant| replies with the corresponding response.
 
 The actual data types and fields of the aforementioned topics are described below:
@@ -92,8 +94,8 @@ The ``MonitorServiceResponseData`` data structure consists on the following fiel
 * *param_list:* ParameterList consisting on a set of parameters for describing a WriterProxy, ReaderProxy or ParticipantProxy.
   See `DDS Interoperability Wire Protocol <https://www.omg.org/spec/DDSI-RTPS/>`_ for further information on these structures.
 * *locator_list:* Current |LocatorList_t-api| in use with that entity.
-  It is an additional informative field for the DDS Monitor to know which locators a particular entity is using for communicating with other
-  entity from other participant.
+  It is an additional informative field for the DDS Monitor to know which locators a particular entity is using
+  for communicating with other entity from other participant.
 
 .. code-block:: bash
 

--- a/docs/fastdds/monitor_service/monitor_service_topics.rst
+++ b/docs/fastdds/monitor_service/monitor_service_topics.rst
@@ -23,10 +23,43 @@ The following table depicts a summary of the available topics in the :ref:`monit
 Monitor Service Events Topic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Monitor Service Event's Topic carries information about all the entities known (|Guid_t-api|) by a particular
-|DomainParticipant|.
+The Monitor Service Event's Topic carries information about all the local entities of a particular
+|DomainParticipant|, storing a collection of |Guid_t-api| identifying each entity alongside with a
+sequence of statuses' version (an incremental counter), each one identified by an index.
+These statuses' indexes are described in the following table:
+
+.. _monitoring_statuses:
+
++---------+-----------------------------+-----------------------------------------+
+|**Index**|          **Name**           | **Description**                         |
++---------+-----------------------------+-----------------------------------------+
+|  0      |     ``ProxyInfo``           | Collection of Parameters describing the |
+|         |                             | ``Proxy Data`` of that entity           |
++---------+-----------------------------+-----------------------------------------+
+|  1      |     ``ConnectionList``      | List of connections that this entity is |
+|         |                             | using with its matched remote entities. |
++---------+-----------------------------+-----------------------------------------+
+|  2      |  ``IncompatibleQoSInfo``    | Status of the Incompatible QoS          |
+|         |                             | of that entity.                         |
++---------+-----------------------------+-----------------------------------------+
+|  3      | ``InconsistentTopicInfo``   | Status of Inconsistent topics that the  |
+|         |                             | topic of that entity has.               |
++---------+-----------------------------+-----------------------------------------+
+|  4      |   ``DeadlineMissedInfo``    | The Status of the number of deadlines   |
+|         |                             | missed for that entity                  |
++---------+-----------------------------+-----------------------------------------+
+|  5      |   ``LivelinessLostInfo``    | Tracks the status of the number of times|
+|         |                             | a writer lost liveliness                |
++---------+-----------------------------+-----------------------------------------+
+|  6      |  ``LivelinessChangedInfo``  | Tracks the status of the number of times|
+|         |                             | the liveliness changed in a reader.     |
++---------+-----------------------------+-----------------------------------------+
+|  7      |     ``SampleLostInfo``      | Tracks the number of times this entity  |
+|         |                             | lost samples.                           |
++---------+-----------------------------+-----------------------------------------+
+
 The ``Monitor Service`` Event's Topic publishes new data when new updates are received from any
-of the |DomainParticipant|'s known entities (on-event driven).
+of the |DomainParticipant|'s local entities (on-event driven) at a certain limited rate.
 In addition, it is in charge of notifying about any dispose or liveliness lost.
 
 .. _monitor_service_events_data:
@@ -38,15 +71,13 @@ The ``MonitorServiceEventData`` data structure comprises the following fields:
 
 * *source_participant:* The GUID of the participant that knows the entity.
 * *entity_guid:* Guid of a known entity.
-* *seq_num:* Most recent sequence number for that entity.
-  Sequence number might be invalid {-1,0} when the  Monitor Service
-  is replying to a request and the requested entity is not known by the Monitor Service.
+* *status_info:* Most recent :ref:`statuses<monitoring_statuses>` available for that entity.
 
 .. code-block:: bash
 
     GUID_t source_participant @key
     GUID_t entity_guid @key
-    SequenceNumber_t seq_num
+    InfoVersionStatus status_info
 
 .. note::
 
@@ -57,10 +88,11 @@ Monitor Service RPC Topics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A |DomainParticipant| with an enabled ``Monitor Service`` provides a RPC mechanism
-for querying another |DomainParticipant| about its known entities.
+for querying another |DomainParticipant| about its local entities.
 This is achieved by means of the ``Monitor Service`` Request/Response topics,
-in which the client side writes the request and the ``Monitor Service``
-of the requested |DomainParticipant| replies with the corresponding response.
+in which the client side writes the request specifying the :ref:`statuses<monitoring_statuses>` of
+interest (in a mask) and the ``Monitor Service`` of the requested |DomainParticipant| collects
+the requested data to later return the corresponding response.
 
 The actual data types and fields of the aforementioned topics are described below:
 
@@ -73,11 +105,14 @@ The ``MonitorServiceRequestData`` data structure has the following fields:
 
 * *requested_participant:* It refers to the |Guid_t-api| of the participant of interest.
 * *entity_guid:* The particular entity_id to get the information from.
+* *request_mask:* The mask indicating what ``Monitoring Information`` should be
+  returned in the response.
 
 .. code-block:: bash
 
-    GUID_t requested_participant
-    GUID_t entity_guid
+    GUID_t requested_participant @Key
+    GUID_t entity_guid @Key
+    RequestMask request_mask
 
 .. _monitor_service_response_data:
 
@@ -86,22 +121,54 @@ Monitor Service Response Data
 
 The ``MonitorServiceResponseData`` data structure consists on the following fields:
 
-
 * *event_data:* The current event data of the queried entity, this should be congruent
-  with last MonitorServiceEventData published in the :ref:`monitor_service_events_topic`.
-  In this case, the second |Guid_t-api| can be a known or an unknown entity for the queried participant, reflected
-  with an invalid {-1,0} SequenceNumber_t in case of being unknown.
-* *param_list:* ParameterList consisting on a set of parameters for describing a WriterProxy, ReaderProxy or ParticipantProxy.
-  See `DDS Interoperability Wire Protocol <https://www.omg.org/spec/DDSI-RTPS/>`_ for further information on these structures.
-* *locator_list:* Current |LocatorList_t-api| in use with that entity.
-  It is an additional informative field for the DDS Monitor to know which locators a particular entity is using
-  for communicating with other entity from other participant.
+  with last MonitorServiceEventData published in the Monitor Service Event's Topic.
+  This field is always returned in the response.
+* *entity_proxy:* Collection of the Quality of Service Parameters in the form of a ParameterList.
+  This field can be optionally returned[^5].
+* *connection_list:* Defines how is this entity communicating with its matched entities.
+  Each of the elements is of Connection type (depicted below).
+  This field can be optionally returned.
+
+.. code-block:: bash
+
+    Connection
+      uint32_t mode //INTRAPROCESS, DATASHARING, TRANSPORT
+      LocatorList announced_locators
+      LocatorList used_locators
+
+* *incompatible_qos_status:* Status of the Incompatible QoS of that entity.
+  |DataWriter| Offered |DataReader| Requested.
+  This field can be optionally returned.
+* *inconsistent_topic_status:* Status of Inconsistent topics of the topic of that entity.
+  Asked to the topic of the requested entity.
+  This field can be optionally returned.
+* *liveliness_lost_status:* Tracks the status of the number of times that liveliness was lost by a
+  |DataWriter|.
+  This field can be optionally returned.
+* *liveliness_changed_status:* Tracks the status of the number of times that liveliness was lost
+  by a |DataReader|.
+  This field can be optionally returned.
+* *deadline_status:* The Status of the number of deadlines missed that were registered in that entity.
+  This field can be optionally returned.
+* *sample_lost_status:* The number of samples that entity lost.
+  This field can be optionally returned.
 
 .. code-block:: bash
 
     MonitorServiceEventData event_data
-    ParameterList param_list
-    LocatorList locator_list
+    vector<uint8_t> entity_proxy
+    vector<vector<Connection>> connection_list
+    vector<IncompatibleQoSStatus> incompatible_qos_status
+    vector<InconsistentTopicStatus> inconsistent_topic_status
+    vector<LivelinessLostStatus> liveliness_lost_status
+    vector<LivelinessChangedStatus> liveliness_changed_status
+    vector<DeadlineMissedStatus> deadline_status
+    vector<SampleLostStatus> sample_lost_status
 
+.. note::
 
-
+    Note that each optional field can be returned, or not.
+    This depends on the :ref:`RequestMask<monitor_service_request_data>` and if
+    the service is announced within a :ref:`DDS<dds_layer>` or :ref:`RTPS<rtps_layer>` |domain|.
+    A vector with a maximum size of 1 is used to denote the optionality.

--- a/docs/fastdds/monitor_service/monitor_service_topics.rst
+++ b/docs/fastdds/monitor_service/monitor_service_topics.rst
@@ -1,0 +1,105 @@
+.. include:: ../../03-exports/aliases.include
+.. include:: ../../03-exports/aliases-api.include
+
+.. _monitor_service_topics:
+
+Monitor Service Topics
+======================
+
+The following table depicts a summary of the availble topics in the :ref:`monitor_service`:
+
++---------------------------------------+-------------------------+---------------------------------------+
+|**Topic name**                         |**Topic Alias**          | **TopicDataType**                     |
++---------------------------------------+-------------------------+---------------------------------------+
+| ``_fastdds_monitor_service_events``   |     MONITOR_EV_TOPIC    | :ref:`monitor_service_events_data`    |
++---------------------------------------+-------------------------+---------------------------------------+
+|``_fastdds_monitor_service_request``   |     MONITOR_REQ_TOPIC   | :ref:`monitor_service_request_data`   |
++---------------------------------------+-------------------------+---------------------------------------+
+| ``_fastdds_monitor_service_response`` |     MONITOR_RES_TOPIC   | :ref:`monitor_service_response_data`  |
++---------------------------------------+-------------------------+---------------------------------------+
+
+.. _monitor_service_events_topic:
+
+Monitor Service Events Topic
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Monitor Service Event's Topic carries information about all the entities known (|Guid_t-api|) by a particular
+|DomainParticipant|.
+The ``Monitor Service`` Event's Topic publishes new data when new updates are received from any
+of the |DomainParticipant|'s known entities (on-event driven).
+In addition, it is in charge of notifying about any dispose or liveliness lost.
+
+.. _monitor_service_events_data:
+
+Monitor Service Event Data
+--------------------------
+
+The ``MonitorServiceEventData`` data structure comprises the following fields:
+
+* *source_participant:* The GUID of the participant that knows the entity.
+* *entity_guid:* Guid of a known entity.
+* *seq_num:* Most recent sequence number for that entity.
+  Sequence number might be invalid {-1,0} when the  Monitor Service
+  is replying to a request and the requested entity is not known by the Monitor Service.
+
+.. code-block:: bash
+
+    GUID_t source_participant @key
+    GUID_t entity_guid @key
+    SequenceNumber_t seq_num
+
+.. note::
+
+    The *source_participant* and *entity_guid* are keyed fields, hence making use of instances (see :ref:`dds_layer_topic_instances`).
+    In this case, the pair <*source_participant, entity_guid*> conforms a unique instance.
+
+Monitor Service RPC Topics
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A |DomainParticipant| with an enabled ``Monitor Service`` provides a RPC mechanism for querying another |DomainParticipant| about its known entities.
+This is achieved by means of the ``Monitor Service`` Request/Response topics, in which the client side writes the request and the ``Monitor Service``
+of the requested |DomainParticipant| replies with the corresponding response.
+
+The actual data types and fields of the aforementioned topics are described below:
+
+.. _monitor_service_request_data:
+
+Monitor Service Request Data
+----------------------------
+
+The ``MonitorServiceRequestData`` data structure has the following fields:
+
+* *requested_participant:* It refers to the |Guid_t-api| of the participant of interest.
+* *entity_guid:* The particular entity_id to get the information from.
+
+.. code-block:: bash
+
+    GUID_t requested_participant
+    GUID_t entity_guid
+
+.. _monitor_service_response_data:
+
+Monitor Service Response Data
+-----------------------------
+
+The ``MonitorServiceResponseData`` data structure consists on the following fields:
+
+
+* *event_data:* The current event data of the queried entity, this should be congruent
+  with last MonitorServiceEventData published in the :ref:`monitor_service_events_topic`.
+  In this case, the second |Guid_t-api| can be a known or an unknown entity for the queried participant, reflected
+  with an invalid {-1,0} SequenceNumber_t in case of being unknown.
+* *param_list:* ParameterList consisting on a set of parameters for describing a WriterProxy, ReaderProxy or ParticipantProxy.
+  See `DDS Interoperability Wire Protocol <https://www.omg.org/spec/DDSI-RTPS/>`_ for further information on these structures.
+* *locator_list:* Current |LocatorList_t-api| in use with that entity.
+  It is an additional informative field for the DDS Monitor to know which locators a particular entity is using for communicating with other
+  entity from other participant.
+
+.. code-block:: bash
+
+    MonitorServiceEventData event_data
+    ParameterList param_list
+    LocatorList locator_list
+
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,10 +45,11 @@
    /fastdds/persistence/persistence
    /fastdds/security/security
    /fastdds/logging/intro
-   /fastdds/statistics/statistics
    /fastdds/xml_configuration/xml_configuration
    /fastdds/env_vars/env_vars
    /fastdds/property_policies/property_policies
+   /fastdds/statistics/statistics
+   /fastdds/monitor_service/intro
    /fastdds/dynamic_types/dynamic_types
    /fastdds/use_cases/use_cases
    /fastdds/ros2/ros2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@
    /fastdds/env_vars/env_vars
    /fastdds/property_policies/property_policies
    /fastdds/statistics/statistics
-   /fastdds/monitor_service/intro
+   /fastdds/monitor_service/monitor_service
    /fastdds/dynamic_types/dynamic_types
    /fastdds/use_cases/use_cases
    /fastdds/ros2/ros2

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -165,6 +165,7 @@ nupkg
 offsetd
 oneway
 OpenSSL
+optionality
 optionparser
 OSS
 overcomplicated

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -223,6 +223,7 @@ submodule
 submodules
 superset
 takeNextData
+targetting
 TCP
 tcpdump
 thirdparty

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -144,6 +144,7 @@ mandatorily
 md
 metatraffic
 middleware
+misconfigurations
 modularity
 multicast
 multicasting


### PR DESCRIPTION
This PR adds the proper documentation for `Fast DDS` [feature/monitor-service/high-level-empty-api](https://github.com/eProsima/Fast-DDS/tree/feature/monitor-service/high-level-empty-api)

This PR should be merged after the `v2.11.x` brach out is done!