### PR TITLE
Avoid using builtin transports on whitelist snippets

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4631,6 +4631,9 @@ void dds_transport_examples ()
 
         // Link the Transport Layer to the Participant.
         qos.transport().user_transports.push_back(tcp_transport);
+
+        // Avoid using the builtin transports
+        qos.transport().use_builtin_transports = false;
         //!--
     }
 

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -616,6 +616,7 @@
 
     <participant profile_name="CustomTcpTransportParticipant">
         <rtps>
+            <useBuiltinTransports>false</useBuiltinTransports>
             <userTransports>
                 <transport_id>CustomTcpTransport</transport_id>
             </userTransports>


### PR DESCRIPTION
This PR corrects the whitelist snippets so that the actual whitelist in honored.