### PR TITLE
[18449] Remove FASTDDS_STATIC CMake option

### DIFF
--- a/docs/installation/binaries/binaries_linux.rst
+++ b/docs/installation/binaries/binaries_linux.rst
@@ -81,14 +81,15 @@ Including Fast-DDS in a CMake project
 The installer deploys *CMake config* files that simplify to incorporate **Fast-DDS** to any CMake project via
 the *find_package* CMake API.
 
-By setting the CMake variable **FASTDDS_STATIC** is possible to choose the desired linkage (dynamic or static library)
-in the CMake generator stage. If the variable is missing defaults to dynamic linking.
+By setting the CMake variable **BUILD_SHARED_LIBS** is possible to choose the desired linkage (dynamic or static
+library) in the CMake generator stage.
+If the variable is missing defaults to static linking.
 
-For example in order to build the examples statically linked to **Fast-DDS** do:
+For example in order to build the examples dynamically linked to **Fast-DDS** do:
 
    .. code-block:: bash
 
-    $ cmake -Bbuildexample -DFASTDDS_STATIC=ON .
+    $ cmake -Bbuildexample -DBUILD_SHARED_LIBS=ON .
     $ cmake --build buildexample --target install
 
 .. _uninstall_bl:

--- a/docs/installation/binaries/binaries_linux.rst
+++ b/docs/installation/binaries/binaries_linux.rst
@@ -83,7 +83,7 @@ the *find_package* CMake API.
 
 By setting the CMake variable **BUILD_SHARED_LIBS** is possible to choose the desired linkage (dynamic or static
 library) in the CMake generator stage.
-If the variable is missing defaults to static linking.
+If the variable is missing build process will default to static linking.
 
 For example in order to build the examples dynamically linked to **Fast-DDS** do:
 

--- a/docs/installation/binaries/binaries_windows.rst
+++ b/docs/installation/binaries/binaries_windows.rst
@@ -93,7 +93,7 @@ the *find_package* CMake API.
 
 By setting the CMake variable **BUILD_SHARED_LIBS** is possible to choose the desired linkage (dynamic or static
 library) in the CMake generator stage.
-If the variable is missing defaults to static linking.
+If the variable is missing the build process will default to static linking.
 
 For example in order to build the examples dynamically linked to **Fast-DDS** do:
 

--- a/docs/installation/binaries/binaries_windows.rst
+++ b/docs/installation/binaries/binaries_windows.rst
@@ -91,12 +91,13 @@ Including Fast-DDS in a CMake project
 The installer deploys *CMake config* files that simplify to incorporate **Fast-DDS** to any CMake project via
 the *find_package* CMake API.
 
-By setting the CMake variable **FASTDDS_STATIC** is possible to choose the desired linkage (dynamic or static library)
-in the CMake generator stage. If the variable is missing defaults to dynamic linking.
+By setting the CMake variable **BUILD_SHARED_LIBS** is possible to choose the desired linkage (dynamic or static
+library) in the CMake generator stage.
+If the variable is missing defaults to static linking.
 
-For example in order to build the examples statically linked to **Fast-DDS** do:
+For example in order to build the examples dynamically linked to **Fast-DDS** do:
 
    .. code-block:: console
 
-    > cmake -Bbuildexample -DFASTDDS_STATIC=ON .
+    > cmake -Bbuildexample -DBUILD_SHARED_LIBS=ON .
     > cmake --build buildexample --target install


### PR DESCRIPTION
eProsima/Fast-DDS#3134 removed `FASTDDS_STATIC` CMake option and documentation was not updated correspondingly. This PR fixes it.