### PR TITLE
[19038] Endpoint configurable ignore_local_endpoints feature

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -778,11 +778,29 @@ void dds_domain_examples()
     }
 
     {
-        // IGNORE_LOCAL_ENDPOINTS_DOMAINPARTICIPANT
+        // IGNORE_LOCAL_ENDPOINTS
+        // DomainParticipant level: every local endpoint is not matched with
+        // any other local endpoint.
         DomainParticipantQos participant_qos;
 
         // Avoid local matching of this participant's endpoints
         participant_qos.properties().properties().emplace_back(
+            "fastdds.ignore_local_endpoints",
+            "true");
+
+        // Endpoint level: DataWriter ignores any other local endpoint
+        DataWriterQos datawriter_qos;
+
+        // Avoid local matching with any other local endpoint
+        datawriter_qos.properties().properties().emplace_back(
+            "fastdds.ignore_local_endpoints",
+            "true");
+
+        // Endpoint level: DataReader ignores any other local endpoint
+        DataReaderQos datareader_qos;
+
+        // Avoid local matching with any other local endpoint
+        datareader_qos.properties().properties().emplace_back(
             "fastdds.ignore_local_endpoints",
             "true");
         //!--

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -2587,7 +2587,7 @@
 </data_writer>
 <!--><-->
 
-<!-->IGNORE_LOCAL_ENDPOINTS_DOMAINPARTICIPANT<-->
+<!-->IGNORE_LOCAL_ENDPOINTS<-->
 <!--
 <?xml version="1.0" encoding="UTF-8" ?>
 <dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
@@ -2606,6 +2606,31 @@
                 </propertiesPolicy>
             </rtps>
         </participant>
+
+        <data_writer profile_name="ignore_local_endpoints_datawriter_xml_profile">
+            <propertiesPolicy>
+                <properties>
+                    <!-- Avoid local matching with any other local DataReader in the participant -->
+                    <property>
+                        <name>fastdds.ignore_local_endpoints</name>
+                        <value>true</value>
+                    </property>
+                </properties>
+            <propertiesPolicy>
+        </data_writer>
+
+        <data_reader profile_name="ignore_local_endpoints_datareader_xml_profile">
+            <propertiesPolicy>
+                <properties>
+                    <!-- Avoid local matching with any other local DataWriter in the participant -->
+                    <property>
+                        <name>fastdds.ignore_local_endpoints</name>
+                        <value>true</value>
+                    </property>
+                </properties>
+            <propertiesPolicy>
+        </data_reader>
+
 <!--
     </profiles>
 </dds>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -2616,7 +2616,7 @@
                         <value>true</value>
                     </property>
                 </properties>
-            <propertiesPolicy>
+            </propertiesPolicy>
         </data_writer>
 
         <data_reader profile_name="ignore_local_endpoints_datareader_xml_profile">
@@ -2628,7 +2628,7 @@
                         <value>true</value>
                     </property>
                 </properties>
-            <propertiesPolicy>
+            </propertiesPolicy>
         </data_reader>
 
 <!--

--- a/docs/fastdds/property_policies/ignore_local_endpoints.rst
+++ b/docs/fastdds/property_policies/ignore_local_endpoints.rst
@@ -15,7 +15,17 @@ from a |DataWriter| belonging to the same |DomainParticipant| on the |DataReader
 |GuidPrefix_t-api|), this entails for a data sample to go all the way to the |DataReaderListener| just to be discarded
 by an overcomplicated application business logic.
 For this reason, Fast DDS offers the possibility of instructing the |DomainParticipant| to avoid the matching of local
-endpoints through the following property:
+endpoints through the PropertyPolicyQos.
+The property can be configured both at the DomainParticipant level as at the endpoint level:
+
+* When configured in the DomainParticipant, no local endpoint will be matched.
+* When configured in a specific endpoint, that specific endpoint will not be matched with any local one, but any other
+  local endpoint will be, unless trying to match with an endpoint with the property set.
+
+.. note::
+
+  If the property is set at both the DomainParticipant and endpoint level, the DomainParticipant configuration takes
+  precedence as it is more restrictive.
 
 .. list-table::
    :header-rows: 1
@@ -34,7 +44,7 @@ endpoints through the following property:
 
         .. literalinclude:: /../code/DDSCodeTester.cpp
             :language: c++
-            :start-after: // IGNORE_LOCAL_ENDPOINTS_DOMAINPARTICIPANT
+            :start-after: // IGNORE_LOCAL_ENDPOINTS
             :end-before: //!--
             :dedent: 8
 
@@ -42,7 +52,7 @@ endpoints through the following property:
 
         .. literalinclude:: /../code/XMLTester.xml
             :language: xml
-            :start-after: <!-->IGNORE_LOCAL_ENDPOINTS_DOMAINPARTICIPANT<-->
+            :start-after: <!-->IGNORE_LOCAL_ENDPOINTS<-->
             :end-before: <!--><-->
             :lines: 2-4,6-18,20-21
 

--- a/docs/fastdds/property_policies/ignore_local_endpoints.rst
+++ b/docs/fastdds/property_policies/ignore_local_endpoints.rst
@@ -54,7 +54,7 @@ The property can be configured both at the DomainParticipant level as at the end
             :language: xml
             :start-after: <!-->IGNORE_LOCAL_ENDPOINTS<-->
             :end-before: <!--><-->
-            :lines: 2-4,6-18,20-21
+            :lines: 2-4,6-41,43-44
 
 .. note::
     An invalid value of ``fastdds.ignore_local_endpoints`` results in the default behaviour.

--- a/docs/fastdds/property_policies/ignore_local_endpoints.rst
+++ b/docs/fastdds/property_policies/ignore_local_endpoints.rst
@@ -19,8 +19,8 @@ endpoints through the PropertyPolicyQos.
 The property can be configured both at the DomainParticipant level as at the endpoint level:
 
 * When configured in the DomainParticipant, no local endpoint will be matched.
-* When configured in a specific endpoint, that specific endpoint will not be matched with any local one, but any other
-  local endpoint will be, unless trying to match with an endpoint with the property set.
+* When configured in a specific endpoint, that specific endpoint will not be matched with any local one, independently
+  if the other endpoint has or not the property enabled.
 
 .. note::
 


### PR DESCRIPTION
#485 introduced a feature to ignore every local endpoint within a DomainParticipant. This PR extends #485 allowing the configuration at endpoint level allowing some local endpoints to be locally matched and others to ignore local endpoints achieving more granularity for the user.