### PR TITLE
Remove unnecessary casts from C++ HelloWorld example

### DIFF
--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldPublisher.cpp
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldPublisher.cpp
@@ -189,12 +189,12 @@ int main(
         char** argv)
 {
     std::cout << "Starting publisher." << std::endl;
-    int samples = 10;
+    uint32_t samples = 10;
 
     HelloWorldPublisher* mypub = new HelloWorldPublisher();
     if(mypub->init())
     {
-        mypub->run(static_cast<uint32_t>(samples));
+        mypub->run(samples);
     }
 
     delete mypub;

--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldSubscriber.cpp
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldSubscriber.cpp
@@ -183,12 +183,12 @@ int main(
         char** argv)
 {
     std::cout << "Starting subscriber." << std::endl;
-    int samples = 10;
+    uint32_t samples = 10;
 
     HelloWorldSubscriber* mysub = new HelloWorldSubscriber();
     if(mysub->init())
     {
-        mysub->run(static_cast<uint32_t>(samples));
+        mysub->run(samples);
     }
 
     delete mysub;


### PR DESCRIPTION
```c++
int samples = 10;
...
mysub->run(static_cast<uint32_t>(samples));
```

If the code just declares `samples` to be `uint32_t`, this static cast is not necessary, and the code is simpler.