### PR TITLE
[19730] Add is_sample_valid() checks, references and emphasize

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -3673,8 +3673,8 @@ void dds_dataReader_examples()
                 // Both info_seq.length() and data_seq.length() will have the number of samples returned
                 for (FooSeq::size_type n = 0; n < info_seq.length(); ++n)
                 {
-                    // Only samples for which valid_data is true should be accessed
-                    if (info_seq[n].valid_data)
+                    // Only samples for which valid_data is true and sample was not replaced should be accessed
+                    if (info_seq[n].valid_data && data_reader->is_sample_valid(&data_seq[n], &info_seq[n]))
                     {
                         // Do something with data_seq[n]
                     }
@@ -5593,7 +5593,8 @@ void dds_zero_copy_example()
 
                             ++samples;
                             std::cout << "Sample received (count=" << samples
-                                      << ") at address " << &sample << std::endl
+                                      << ") at address " << &sample
+                                      << (reader->is_sample_valid(&sample, &infos[i]) ? " is valid" : " was replaced" ) << std::endl
                                       << "  index=" << sample.index() << std::endl
                                       << "  message=" << sample.message().data() << std::endl;
                         }
@@ -5853,8 +5854,8 @@ void dds_waitset_example()
                                 // Both info_seq.length() and data_seq.length() will have the number of samples returned
                                 for (FooSeq::size_type n = 0; n < info_seq.length(); ++n)
                                 {
-                                    // Only samples for which valid_data is true should be accessed
-                                    if (info_seq[n].valid_data)
+                                    // Only samples for which valid_data is true and sample was not replaced should be accessed
+                                    if (info_seq[n].valid_data && reader->is_sample_valid(&data_seq[n], &info_seq[n]))
                                     {
                                         // Process sample on data_seq[n]
                                     }

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -3673,7 +3673,7 @@ void dds_dataReader_examples()
                 // Both info_seq.length() and data_seq.length() will have the number of samples returned
                 for (FooSeq::size_type n = 0; n < info_seq.length(); ++n)
                 {
-                    // Only samples for which valid_data is true and sample was not replaced should be accessed
+                    // Only samples with valid data should be accessed
                     if (info_seq[n].valid_data && data_reader->is_sample_valid(&data_seq[n], &info_seq[n]))
                     {
                         // Do something with data_seq[n]
@@ -5854,7 +5854,7 @@ void dds_waitset_example()
                                 // Both info_seq.length() and data_seq.length() will have the number of samples returned
                                 for (FooSeq::size_type n = 0; n < info_seq.length(); ++n)
                                 {
-                                    // Only samples for which valid_data is true and sample was not replaced should be accessed
+                                    // Only samples with valid data should be accessed
                                     if (info_seq[n].valid_data && reader->is_sample_valid(&data_seq[n], &info_seq[n]))
                                     {
                                         // Process sample on data_seq[n]

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -22,6 +22,7 @@
 .. |DataReader::take_w_condition-api| replace:: :cpp:func:`DataReader::take_w_condition()<eprosima::fastdds::dds::DataReader::take_w_condition>`
 .. |DataReader::get_first_untaken_info-api| replace:: :cpp:func:`DataReader::get_first_untaken_info()<eprosima::fastdds::dds::DataReader::get_first_untaken_info>`
 .. |DataReader::return_loan-api| replace:: :cpp:func:`DataReader::return_loan()<eprosima::fastdds::dds::DataReader::return_loan>`
+.. |DataReader::is_sample_valid-api| replace:: :cpp:func:`DataReader::is_sample_valid()<eprosima::fastdds::dds::DataReader::is_sample_valid>`
 .. |DataReader::wait_for_unread_message()| replace:: :cpp:func:`DataReader::wait_for_unread_message()<eprosima::fastdds::dds::DataReader::wait_for_unread_mesage>`
 .. |DataReaderListener-api| replace:: :cpp:class:`DataReaderListener <eprosima::fastdds::dds::DataReaderListener>`
 

--- a/docs/fastdds/dds_layer/subscriber/dataReader/readingData.rst
+++ b/docs/fastdds/dds_layer/subscriber/dataReader/readingData.rst
@@ -73,7 +73,8 @@ sequences is quite easy.
 The sequences API provides a **length()** operation returning the number of elements in the collections.
 The application code just needs to check this value and use the **[]** operator to access the corresponding elements.
 Elements on the DDS data sequence should only be accessed when the corresponding element on the SampleInfo sequence
-indicate that valid data is present.
+indicate that valid data is present and the sample is valid (i.e, not replaced,
+refer to :ref:`datareader-datawriter-history-coupling` for further information in this regard).
 
 .. literalinclude:: /../code/DDSCodeTester.cpp
    :language: c++

--- a/docs/fastdds/dds_layer/subscriber/dataReader/readingData.rst
+++ b/docs/fastdds/dds_layer/subscriber/dataReader/readingData.rst
@@ -73,7 +73,8 @@ sequences is quite easy.
 The sequences API provides a **length()** operation returning the number of elements in the collections.
 The application code just needs to check this value and use the **[]** operator to access the corresponding elements.
 Elements on the DDS data sequence should only be accessed when the corresponding element on the SampleInfo sequence
-indicate that valid data is present and the sample is valid (i.e, not replaced,
+indicate that valid data is present.
+When using Data Sharing, it is also important to check that the sample is valid (i.e, not replaced,
 refer to :ref:`datareader-datawriter-history-coupling` for further information in this regard).
 
 .. literalinclude:: /../code/DDSCodeTester.cpp

--- a/docs/fastdds/transport/datasharing.rst
+++ b/docs/fastdds/transport/datasharing.rst
@@ -159,6 +159,7 @@ Configuring a user-defined directory may be useful in some scenarios:
 * To select a file system with Huge TLB enabled for the memory-mapped files.
 * To allow data-sharing delivery between containers that mount the same container.
 
+.. _datareader-datawriter-history-coupling:
 
 DataReader and DataWriter history coupling
 ------------------------------------------
@@ -175,8 +176,10 @@ the DataReader directly accesses the data instance created by the DataWriter.
 This means that the samples in both the history of the DataReader and the DataWriter
 refer to the same object in the shared memory.
 Therefore, there is a strong coupling in the behavior of the DataReader and DataWriter histories.
-If the DataWriter reuses the same sample to publish new data,
-the DataReader loses access to the old data sample.
+
+.. important::
+    If the DataWriter reuses the same sample to publish new data,
+    the DataReader loses access to the old data sample.
 
 .. note::
     The DataWriter can remove the sample from its history,

--- a/docs/fastdds/use_cases/zero_copy/zero_copy.rst
+++ b/docs/fastdds/use_cases/zero_copy/zero_copy.rst
@@ -121,6 +121,8 @@ callback.
 The key points to be noted in this function are:
 
 *   The declaration and handling of |LoanableSequence-api|.
+*   Checking |DataReader::is_sample_valid-api| for verifying that the sample was not replaced.
+    Refer to :ref:`datareader-datawriter-history-coupling` for further information.
 *   The use of the |DataReader::return_loan-api| function to indicate to the DataReader that the application has
     finished accessing the sequence.
 


### PR DESCRIPTION
This PR corrects the code snippets where loans API was used to include the check for `is_sample_valid()`. It also adds references to the explanation, which, in turn, it has been emphasized.

If approved, we may need to backport to 2.11.x 2.10.x 2.6.x