### PR TITLE
[19780] Add interface whitelist by name

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4746,8 +4746,26 @@ void dds_transport_examples ()
         // Create a descriptor for the new transport.
         auto tcp_transport = std::make_shared<TCPv4TransportDescriptor>();
 
-        // Add loopback to the whitelist
+        // Add loopback to the whitelist by IP address
         tcp_transport->interfaceWhiteList.emplace_back("127.0.0.1");
+
+        // Link the Transport Layer to the Participant.
+        qos.transport().user_transports.push_back(tcp_transport);
+
+        // Avoid using the builtin transports
+        qos.transport().use_builtin_transports = false;
+        //!--
+    }
+
+    {
+        //WHITELIST-NAME
+        DomainParticipantQos qos;
+
+        // Create a descriptor for the new transport.
+        auto tcp_transport = std::make_shared<TCPv4TransportDescriptor>();
+
+        // Add loopback to the whitelist by interface name
+        tcp_transport->interfaceWhiteList.emplace_back("lo");
 
         // Link the Transport Layer to the Participant.
         qos.transport().user_transports.push_back(tcp_transport);

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -845,6 +845,31 @@
     </participant>
 <!--><-->
 
+<!-->WHITELIST-NAME<-->
+<!--
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+-->
+    <transport_descriptors>
+        <transport_descriptor>
+            <transport_id>CustomTcpTransport</transport_id>
+            <type>TCPv4</type>
+            <interfaceWhiteList>
+                <interface>lo</interface>
+            </interfaceWhiteList>
+        </transport_descriptor>
+    </transport_descriptors>
+
+    <participant profile_name="CustomTcpTransportParticipant">
+        <rtps>
+            <useBuiltinTransports>false</useBuiltinTransports>
+            <userTransports>
+                <transport_id>CustomTcpTransport</transport_id>
+            </userTransports>
+        </rtps>
+    </participant>
+<!--><-->
+
 <!-->CONF-TRANSPORT_METAMULTICASTLOCATOR<-->
 <!--
 <?xml version="1.0" encoding="UTF-8" ?>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -802,7 +802,7 @@
 -->
     <transport_descriptors>
         <transport_descriptor>
-            <transport_id>CustomTcpTransport</transport_id>
+            <transport_id>CustomTcpTransportWhitelistAddress</transport_id>
             <type>TCPv4</type>
             <interfaceWhiteList>
                 <address>127.0.0.1</address>
@@ -810,11 +810,11 @@
         </transport_descriptor>
     </transport_descriptors>
 
-    <participant profile_name="CustomTcpTransportParticipant">
+    <participant profile_name="CustomTcpTransportWhitelistAddressParticipant">
         <rtps>
             <useBuiltinTransports>false</useBuiltinTransports>
             <userTransports>
-                <transport_id>CustomTcpTransport</transport_id>
+                <transport_id>CustomTcpTransportWhitelistAddress</transport_id>
             </userTransports>
         </rtps>
     </participant>
@@ -827,7 +827,7 @@
 -->
     <transport_descriptors>
         <transport_descriptor>
-            <transport_id>CustomTcpTransport</transport_id>
+            <transport_id>CustomTcpTransportWhitelistName</transport_id>
             <type>TCPv4</type>
             <interfaceWhiteList>
                 <interface>lo</interface>
@@ -835,11 +835,11 @@
         </transport_descriptor>
     </transport_descriptors>
 
-    <participant profile_name="CustomTcpTransportParticipant">
+    <participant profile_name="CustomTcpTransportWhitelistNameParticipant">
         <rtps>
             <useBuiltinTransports>false</useBuiltinTransports>
             <userTransports>
-                <transport_id>CustomTcpTransport</transport_id>
+                <transport_id>CustomTcpTransportWhitelistName</transport_id>
             </userTransports>
         </rtps>
     </participant>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -820,6 +820,31 @@
     </participant>
 <!--><-->
 
+<!-->WHITELIST-NAME<-->
+<!--
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+-->
+    <transport_descriptors>
+        <transport_descriptor>
+            <transport_id>CustomTcpTransport</transport_id>
+            <type>TCPv4</type>
+            <interfaceWhiteList>
+                <interface>lo</interface>
+            </interfaceWhiteList>
+        </transport_descriptor>
+    </transport_descriptors>
+
+    <participant profile_name="CustomTcpTransportParticipant">
+        <rtps>
+            <useBuiltinTransports>false</useBuiltinTransports>
+            <userTransports>
+                <transport_id>CustomTcpTransport</transport_id>
+            </userTransports>
+        </rtps>
+    </participant>
+<!--><-->
+
 <!-->CONF-TRANSPORT_METAMULTICASTLOCATOR<-->
 <!--
 <?xml version="1.0" encoding="UTF-8" ?>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -815,7 +815,6 @@
             <useBuiltinTransports>false</useBuiltinTransports>
             <userTransports>
                 <transport_id>CustomTcpTransportWhitelistAddress</transport_id>
-                <transport_id>CustomTcpTransportWhitelistAddress</transport_id>
             </userTransports>
         </rtps>
     </participant>
@@ -841,31 +840,6 @@
             <useBuiltinTransports>false</useBuiltinTransports>
             <userTransports>
                 <transport_id>CustomTcpTransportWhitelistName</transport_id>
-            </userTransports>
-        </rtps>
-    </participant>
-<!--><-->
-
-<!-->WHITELIST-NAME<-->
-<!--
-<?xml version="1.0" encoding="UTF-8" ?>
-<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
--->
-    <transport_descriptors>
-        <transport_descriptor>
-            <transport_id>CustomTcpTransportWhitelistName</transport_id>
-            <type>TCPv4</type>
-            <interfaceWhiteList>
-                <interface>lo</interface>
-            </interfaceWhiteList>
-        </transport_descriptor>
-    </transport_descriptors>
-
-    <participant profile_name="CustomTcpTransportWhitelistNameParticipant">
-        <rtps>
-            <useBuiltinTransports>false</useBuiltinTransports>
-            <userTransports>
-                <transport_id>CustomTcpTransport</transport_id>
             </userTransports>
         </rtps>
     </participant>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -815,6 +815,7 @@
             <useBuiltinTransports>false</useBuiltinTransports>
             <userTransports>
                 <transport_id>CustomTcpTransportWhitelistAddress</transport_id>
+                <transport_id>CustomTcpTransportWhitelistAddress</transport_id>
             </userTransports>
         </rtps>
     </participant>
@@ -852,7 +853,7 @@
 -->
     <transport_descriptors>
         <transport_descriptor>
-            <transport_id>CustomTcpTransport</transport_id>
+            <transport_id>CustomTcpTransportWhitelistName</transport_id>
             <type>TCPv4</type>
             <interfaceWhiteList>
                 <interface>lo</interface>
@@ -860,7 +861,7 @@
         </transport_descriptor>
     </transport_descriptors>
 
-    <participant profile_name="CustomTcpTransportParticipant">
+    <participant profile_name="CustomTcpTransportWhitelistNameParticipant">
         <rtps>
             <useBuiltinTransports>false</useBuiltinTransports>
             <userTransports>

--- a/docs/fastdds/transport/whitelist.rst
+++ b/docs/fastdds/transport/whitelist.rst
@@ -62,9 +62,11 @@ For example:
 
 .. important::
 
-  If none of the values in the transport descriptor's whitelist match the interfaces on your machine, all the interfaces in the whitelist are filtered out and no communication will be established through that transport.
+  If none of the values in the transport descriptor's whitelist match the interfaces on your machine,
+  all the interfaces in the whitelist are filtered out and no communication will be established through that transport.
 
 .. warning::
 
   The interface whitelist feature applies to network interfaces.
   Therefore, it is only available on :ref:`transport_tcp_tcp` and :ref:`transport_udp_udp`.
+

--- a/docs/fastdds/transport/whitelist.rst
+++ b/docs/fastdds/transport/whitelist.rst
@@ -9,13 +9,14 @@ Interface Whitelist
 
 Using *Fast DDS*, it is possible to limit the network interfaces used by :ref:`transport_tcp_tcp` and
 :ref:`transport_udp_udp`.
-This is achieved by adding the interfaces' IP addresses to the |SocketTransportDescriptor::interfaceWhiteList-api|
+This is achieved by adding the interfaces to the |SocketTransportDescriptor::interfaceWhiteList-api|
 field in the :ref:`transport_tcp_transportDescriptor` or :ref:`transport_udp_transportDescriptor`.
 Thus, the communication interfaces used by the |DomainParticipants| whose |TransportDescriptorInterface-api| defines an
-|SocketTransportDescriptor::interfaceWhiteList-api| is limited to the interfaces' IP addresses defined in that list,
-therefore avoiding the use of the rest of the network interfaces available in the system.
-The values on this list should match the IPs of your machine in that networks.
+|SocketTransportDescriptor::interfaceWhiteList-api| is limited to the interfaces' addresses defined in that list,
+therefore avoiding the use of the rest of the network interfaces available in the system. It is possible to add the interfaces to |SocketTransportDescriptor::interfaceWhiteList-api| specifying the IP addresses or the interface names.
 For example:
+
+* Interface whitelist filled with IP address:
 
 .. tabs::
 
@@ -36,8 +37,33 @@ For example:
       :lines: 2-3,5-
       :append: </profiles>
 
+* Interface whitelist filled with interface names:
+
+.. tabs::
+
+  .. tab:: C++
+
+    .. literalinclude:: /../code/DDSCodeTester.cpp
+      :language: c++
+      :start-after: //WHITELIST-NAME
+      :end-before: //!--
+      :dedent: 8
+
+  .. tab:: XML
+
+    .. literalinclude:: /../code/XMLTester.xml
+      :language: xml
+      :start-after: <!-->WHITELIST-NAME
+      :end-before: <!--><-->
+      :lines: 2-3,5-
+      :append: </profiles>
+
 .. warning::
 
   The interface whitelist feature applies to network interfaces.
   Therefore, it is only available on :ref:`transport_tcp_tcp` and :ref:`transport_udp_udp`.
+
+.. warning::
+
+  The values in this list should match the IP addresses or interface names on your machine for the corresponding networks. If none of the values in the whitelist match the interfaces on your machine, all the interfaces in the whitelist are filtered out and an invalid interface is assigned.
 

--- a/docs/fastdds/transport/whitelist.rst
+++ b/docs/fastdds/transport/whitelist.rst
@@ -60,12 +60,11 @@ For example:
       :lines: 2-3,5-
       :append: </profiles>
 
+.. important::
+
+  The values in this list should match the IP addresses or interface names on your machine for the corresponding networks. If none of the values in the whitelist match the interfaces on your machine, all the interfaces in the whitelist are filtered out and an invalid interface is assigned.
+
 .. warning::
 
   The interface whitelist feature applies to network interfaces.
   Therefore, it is only available on :ref:`transport_tcp_tcp` and :ref:`transport_udp_udp`.
-
-.. warning::
-
-  The values in this list should match the IP addresses or interface names on your machine for the corresponding networks. If none of the values in the whitelist match the interfaces on your machine, all the interfaces in the whitelist are filtered out and an invalid interface is assigned.
-

--- a/docs/fastdds/transport/whitelist.rst
+++ b/docs/fastdds/transport/whitelist.rst
@@ -14,7 +14,8 @@ field in the :ref:`transport_tcp_transportDescriptor` or :ref:`transport_udp_tra
 Thus, the communication interfaces used by the |DomainParticipants| whose |TransportDescriptorInterface-api| defines an
 |SocketTransportDescriptor::interfaceWhiteList-api| is limited to the interfaces' addresses defined in that list,
 therefore avoiding the use of the rest of the network interfaces available in the system.
-The interfaces in |SocketTransportDescriptor::interfaceWhiteList-api| can be specified both by IP address or interface name.
+The interfaces in |SocketTransportDescriptor::interfaceWhiteList-api| can be specified both by IP address or interface
+name.
 For example:
 
 * Interface whitelist filled with IP address:

--- a/docs/fastdds/transport/whitelist.rst
+++ b/docs/fastdds/transport/whitelist.rst
@@ -62,7 +62,7 @@ For example:
 
 .. important::
 
-  The values in this list should match the IP addresses or interface names on your machine for the corresponding networks. If none of the values in the whitelist match the interfaces on your machine, all the interfaces in the whitelist are filtered out and an invalid interface is assigned.
+  If none of the values in the transport descriptor's whitelist match the interfaces on your machine, all the interfaces in the whitelist are filtered out and no communication will be established through that transport.
 
 .. warning::
 

--- a/docs/fastdds/transport/whitelist.rst
+++ b/docs/fastdds/transport/whitelist.rst
@@ -13,7 +13,9 @@ This is achieved by adding the interfaces to the |SocketTransportDescriptor::int
 field in the :ref:`transport_tcp_transportDescriptor` or :ref:`transport_udp_transportDescriptor`.
 Thus, the communication interfaces used by the |DomainParticipants| whose |TransportDescriptorInterface-api| defines an
 |SocketTransportDescriptor::interfaceWhiteList-api| is limited to the interfaces' addresses defined in that list,
-therefore avoiding the use of the rest of the network interfaces available in the system. It is possible to add the interfaces to |SocketTransportDescriptor::interfaceWhiteList-api| specifying the IP addresses or the interface names.
+therefore avoiding the use of the rest of the network interfaces available in the system.
+It is possible to add the interfaces to |SocketTransportDescriptor::interfaceWhiteList-api| specifying the IP addresses
+or the interface names.
 For example:
 
 * Interface whitelist filled with IP address:

--- a/docs/fastdds/transport/whitelist.rst
+++ b/docs/fastdds/transport/whitelist.rst
@@ -14,56 +14,55 @@ field in the :ref:`transport_tcp_transportDescriptor` or :ref:`transport_udp_tra
 Thus, the communication interfaces used by the |DomainParticipants| whose |TransportDescriptorInterface-api| defines an
 |SocketTransportDescriptor::interfaceWhiteList-api| is limited to the interfaces' addresses defined in that list,
 therefore avoiding the use of the rest of the network interfaces available in the system.
-It is possible to add the interfaces to |SocketTransportDescriptor::interfaceWhiteList-api| specifying the IP addresses
-or the interface names.
+The interfaces in |SocketTransportDescriptor::interfaceWhiteList-api| can be specified both by IP address or interface name.
 For example:
 
 * Interface whitelist filled with IP address:
 
-.. tabs::
+  .. tabs::
 
-  .. tab:: C++
+    .. tab:: C++
 
-    .. literalinclude:: /../code/DDSCodeTester.cpp
-      :language: c++
-      :start-after: //TRANSPORT-DESCRIPTORS
-      :end-before: //!--
-      :dedent: 8
+      .. literalinclude:: /../code/DDSCodeTester.cpp
+        :language: c++
+        :start-after: //TRANSPORT-DESCRIPTORS
+        :end-before: //!--
+        :dedent: 8
 
-  .. tab:: XML
+    .. tab:: XML
 
-    .. literalinclude:: /../code/XMLTester.xml
-      :language: xml
-      :start-after: <!-->TRANSPORT-DESCRIPTORS
-      :end-before: <!--><-->
-      :lines: 2-3,5-
-      :append: </profiles>
+      .. literalinclude:: /../code/XMLTester.xml
+        :language: xml
+        :start-after: <!-->TRANSPORT-DESCRIPTORS
+        :end-before: <!--><-->
+        :lines: 2-3,5-
+        :append: </profiles>
 
 * Interface whitelist filled with interface names:
 
-.. tabs::
+  .. tabs::
 
-  .. tab:: C++
+    .. tab:: C++
 
-    .. literalinclude:: /../code/DDSCodeTester.cpp
-      :language: c++
-      :start-after: //WHITELIST-NAME
-      :end-before: //!--
-      :dedent: 8
+      .. literalinclude:: /../code/DDSCodeTester.cpp
+        :language: c++
+        :start-after: //WHITELIST-NAME
+        :end-before: //!--
+        :dedent: 8
 
-  .. tab:: XML
+    .. tab:: XML
 
-    .. literalinclude:: /../code/XMLTester.xml
-      :language: xml
-      :start-after: <!-->WHITELIST-NAME
-      :end-before: <!--><-->
-      :lines: 2-3,5-
-      :append: </profiles>
+      .. literalinclude:: /../code/XMLTester.xml
+        :language: xml
+        :start-after: <!-->WHITELIST-NAME
+        :end-before: <!--><-->
+        :lines: 2-3,5-
+        :append: </profiles>
 
 .. important::
 
-  If none of the values in the transport descriptor's whitelist match the interfaces on your machine,
-  all the interfaces in the whitelist are filtered out and no communication will be established through that transport.
+  If none of the values in the transport descriptor's whitelist match the interfaces on the host,
+  then all the interfaces in the whitelist are filtered out and therefore no communication will be established through that transport.
 
 .. warning::
 


### PR DESCRIPTION
The feature gives users the possibility to add network interfaces to the whitelist by interface name as well, not just by their IP address.

Merge after:
- https://github.com/eProsima/Fast-DDS/pull/3973