### PR TITLE
Refs #20019: Add TCP listening port behavior when set to 0

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -5997,7 +5997,7 @@ void tcp_use_cases()
 
         // TCPv4 transport for EDP and application data (The listening port must to be unique for
         // each participant in the same host)
-        constexpr uint16_t tcp_listening_port = 12345;
+        constexpr uint16_t tcp_listening_port = 0;
         auto data_transport = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
         data_transport->add_listener_port(tcp_listening_port);
         pqos.transport().user_transports.push_back(data_transport);

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3676,7 +3676,7 @@
                     This needs to be unique for each participant in the host
                 -->
                 <listening_ports>
-                    <port>12345</port>
+                    <port>0</port>
                 </listening_ports>
             </transport_descriptor>
         </transport_descriptors>

--- a/docs/fastdds/transport/tcp/tcp.rst
+++ b/docs/fastdds/transport/tcp/tcp.rst
@@ -71,7 +71,7 @@ The following table describes the common data members for both TCPv4 and TCPv6.
   * - |TCPTransportDescriptor::listening_ports-api|
     - ``vector<uint16_t>``
     - Empty vector
-    - List of ports to listen as *server*.
+    - List of ports to listen as *server*. If a port is set to 0, an available port will be automatically assigned.
   * - |TCPTransportDescriptor::keep_alive_frequency_ms-api|
     - ``uint32_t``
     - 5000

--- a/docs/fastdds/xml_configuration/transports.rst
+++ b/docs/fastdds/xml_configuration/transports.rst
@@ -94,7 +94,9 @@ A more detailed explanation of each of these elements can be found in :ref:`comm
 +-------------------------------+----------------------------------------------------+----------------------+----------+
 | ``<listening_ports>``         | Local port to work as TCP acceptor for input |br|  | ``List <uint16_t>``  |          |
 |                               | connections. If not set, the transport will |br|   |                      |          |
-|                               | work as TCP client only (**TCP only**).            |                      |          |
+|                               | work as TCP client only. If set to 0, an |br|      |                      |          |
+|                               | available port will be automatically assigned |br| |                      |          |
+|                               | (**TCP only**).                                    |                      |          |
 +-------------------------------+----------------------------------------------------+----------------------+----------+
 | ``<tls>``                     | Allows to define TLS related parameters and |br|   | :ref:`tcp-tls`       |          |
 |                               | options (**TCP only**).                            |                      |          |


### PR DESCRIPTION
Add behavior of TCP transport when listening port is set to 0.
Documentation for PR: https://github.com/eProsima/Fast-DDS/pull/4061 (PR)