### PR TITLE
[20176] Downgrade cmake version 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.20)
 
 # Get version from sphinx's conf.py so that the cmake and the sphinx versions match
 file(STRINGS

--- a/code/Examples/C++/DDSHelloWorld/CMakeLists.txt
+++ b/code/Examples/C++/DDSHelloWorld/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 project(DDSHelloWorld)
 


### PR DESCRIPTION
Reduce CMake minimum version required for Fast DDS compatibility against RHEL 9.