### PR TITLE
[20244] Update requirements.txt dependencies for sphinx 4.3.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,8 +8,13 @@ setuptools==67.6.0
 sphinx_rtd_theme==0.5.2
 sphinx-tabs==3.2.0
 sphinx==4.3.1
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-imagehelper==1.1.1
 sphinxcontrib-plantuml==0.22
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib.spelling==7.2.1
 vcstool==0.3.0
 xmlschema==2.1.1


### PR DESCRIPTION
This PR updates the `requirements.txt` file for setting up a correct virtual environment. The changes fix the package versions of some dependencies to require a `sphinx` version lower than  `5.0`.