### PR TITLE
[20119] TCP socket send buffer limit

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -865,6 +865,17 @@ void dds_domain_examples()
             "unicast");
         //!--
     }
+
+    {
+        //DDS-TCP-NON-BLOCKING-SEND
+        DomainParticipantQos participant_qos;
+
+        // TCP transport will use non-blocking send
+        participant_qos.properties().properties().emplace_back(
+            "fastdds.tcp_transport.non_blocking_send",
+            "true");
+        //!--
+    }
 }
 
 //DOMAINPARTICIPANTLISTENER-DISCOVERY-CALLBACKS

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3592,6 +3592,21 @@
 </participant>
 <!--><-->
 
+<!-->XML-TCP-NON-BLOCKING-SEND<-->
+<participant profile_name="participant_xml_conf_tcp_non_blocking_send">
+    <rtps>
+        <propertiesPolicy>
+            <properties>
+                <property>
+                    <name>fastdds.tcp_transport.non_blocking_send</name>
+                    <value>true</value>
+                </property>
+            </properties>
+        </propertiesPolicy>
+    </rtps>
+</participant>
+<!--><-->
+
 <!-->XML_TYPELOOKUP_SERVICE_ENABLING<-->
 <participant profile_name="participant_typelookup_service_enabled">
     <rtps>

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -625,6 +625,7 @@
 .. |TCPTransportDescriptor::logical_port_range-api| replace:: :cpp:var:`logical_port_range<eprosima::fastdds::rtps::TCPTransportDescriptor::logical_port_range>`
 .. |TCPTransportDescriptor::logical_port_increment-api| replace:: :cpp:var:`logical_port_increment<eprosima::fastdds::rtps::TCPTransportDescriptor::logical_port_increment>`
 .. |TCPTransportDescriptor::enable_tcp_nodelay-api| replace:: :cpp:var:`enable_tcp_nodelay<eprosima::fastdds::rtps::TCPTransportDescriptor::enable_tcp_nodelay>`
+.. |TCPTransportDescriptor::non_blocking_send-api| replace:: :cpp:var:`non_blocking_send<eprosima::fastdds::rtps::TCPTransportDescriptor::non_blocking_send>`
 .. |TCPTransportDescriptor::calculate_crc-api| replace:: :cpp:var:`calculate_crc<eprosima::fastdds::rtps::TCPTransportDescriptor::calculate_crc>`
 .. |TCPTransportDescriptor::check_crc-api| replace:: :cpp:var:`check_crc<eprosima::fastdds::rtps::TCPTransportDescriptor::check_crc>`
 .. |TCPTransportDescriptor::apply_security-api| replace:: :cpp:var:`apply_security<eprosima::fastdds::rtps::TCPTransportDescriptor::apply_security>`

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -625,7 +625,6 @@
 .. |TCPTransportDescriptor::logical_port_range-api| replace:: :cpp:var:`logical_port_range<eprosima::fastdds::rtps::TCPTransportDescriptor::logical_port_range>`
 .. |TCPTransportDescriptor::logical_port_increment-api| replace:: :cpp:var:`logical_port_increment<eprosima::fastdds::rtps::TCPTransportDescriptor::logical_port_increment>`
 .. |TCPTransportDescriptor::enable_tcp_nodelay-api| replace:: :cpp:var:`enable_tcp_nodelay<eprosima::fastdds::rtps::TCPTransportDescriptor::enable_tcp_nodelay>`
-.. |TCPTransportDescriptor::non_blocking_send-api| replace:: :cpp:var:`non_blocking_send<eprosima::fastdds::rtps::TCPTransportDescriptor::non_blocking_send>`
 .. |TCPTransportDescriptor::calculate_crc-api| replace:: :cpp:var:`calculate_crc<eprosima::fastdds::rtps::TCPTransportDescriptor::calculate_crc>`
 .. |TCPTransportDescriptor::check_crc-api| replace:: :cpp:var:`check_crc<eprosima::fastdds::rtps::TCPTransportDescriptor::check_crc>`
 .. |TCPTransportDescriptor::apply_security-api| replace:: :cpp:var:`apply_security<eprosima::fastdds::rtps::TCPTransportDescriptor::apply_security>`

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -357,8 +357,8 @@ The behavior regarding this can be configured using the property ``fastdds.shm.e
 TCP Non-blocking send
 ^^^^^^^^^^^^^^^^^^^^^
 
-TCP transport will by default configure a :ref:`transport_tcp_tcp` with blocking send callbacks.
-When ``fastdds.tcp_transport.non_blocking_send`` property is set to ``false``, send operations will
+TCP transport will by default configure a :ref:`transport_tcp_tcp` with blocking send calls.
+When ``fastdds.tcp_transport.non_blocking_send`` property is set to ``true``, send operations will
 return immediately if the send buffer is full, but no error will be returned to the upper layer.
 This means that the application will behave as if the packet is sent and lost.
 

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -351,3 +351,47 @@ The behavior regarding this can be configured using the property ``fastdds.shm.e
            :language: xml
            :start-after: <!-->XML-SHM-ENFORCE-META-TRAFFIC
            :end-before: <!--><-->
+
+.. _property_policies_tcp_non_blocking_send:
+
+TCP Non-blocking send
+^^^^^^^^^^^^^^^^^^^^^
+
+TCP transport will by default configure a :ref:`transport_tcp_tcp` with blocking send callbacks.
+When ``fastdds.tcp_transport.non_blocking_send`` property is set to ``false``, send operations will
+return immediately if the send buffer is full, but no error will be returned to the upper layer.
+This means that the application will behave as if the packet is sent and lost.
+
+When set to ``false``, send operations will block until the network buffer has space for the
+packet.
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - PropertyPolicyQos value
+     - Description
+     - Default
+   * - ``"false"``
+     - Block on send operations when send buffer is full.
+     - ✅
+   * - ``"true"``
+     - Do not block on send operations when send buffer is full.
+     -
+
+.. tabs::
+
+    .. tab:: C++
+
+        .. literalinclude:: /../code/DDSCodeTester.cpp
+           :language: c++
+           :start-after: //DDS-TCP-NON-BLOCKING-SEND
+           :end-before: //!--
+           :dedent: 8
+
+    .. tab:: XML
+
+        .. literalinclude:: /../code/XMLTester.xml
+           :language: xml
+           :start-after: <!-->XML-TCP-NON-BLOCKING-SEND
+           :end-before: <!--><-->

--- a/docs/fastdds/rtps_layer/rtps_layer.rst
+++ b/docs/fastdds/rtps_layer/rtps_layer.rst
@@ -184,7 +184,7 @@ function of the :ref:`dds_layer_domainParticipantQos`, XML profiles (see :ref:`R
      * |TCPTransportDescriptor::calculate_crc-api|, |TCPTransportDescriptor::check_crc-api| and
        |TCPTransportDescriptor::apply_security-api| are set to false.
      * |TCPTransportDescriptor::enable_tcp_nodelay-api| is set to true.
-     * |TCPTransportDescriptor::non_blocking_send-api| is set to true.
+     * |TransportInterface-api| ``non_blocking_send`` is set to true.
      * |TCPTransportDescriptor::keep_alive_thread-api| and
        |TCPTransportDescriptor::accept_thread-api| use the default configuration.
 

--- a/docs/fastdds/rtps_layer/rtps_layer.rst
+++ b/docs/fastdds/rtps_layer/rtps_layer.rst
@@ -184,7 +184,7 @@ function of the :ref:`dds_layer_domainParticipantQos`, XML profiles (see :ref:`R
      * |TCPTransportDescriptor::calculate_crc-api|, |TCPTransportDescriptor::check_crc-api| and
        |TCPTransportDescriptor::apply_security-api| are set to false.
      * |TCPTransportDescriptor::enable_tcp_nodelay-api| is set to true.
-     * |TransportInterface-api| ``non_blocking_send`` is set to true.
+     * :ref:`property_policies_tcp_non_blocking_send` is set to true.
      * |TCPTransportDescriptor::keep_alive_thread-api| and
        |TCPTransportDescriptor::accept_thread-api| use the default configuration.
 

--- a/docs/fastdds/rtps_layer/rtps_layer.rst
+++ b/docs/fastdds/rtps_layer/rtps_layer.rst
@@ -184,6 +184,7 @@ function of the :ref:`dds_layer_domainParticipantQos`, XML profiles (see :ref:`R
      * |TCPTransportDescriptor::calculate_crc-api|, |TCPTransportDescriptor::check_crc-api| and
        |TCPTransportDescriptor::apply_security-api| are set to false.
      * |TCPTransportDescriptor::enable_tcp_nodelay-api| is set to true.
+     * |TCPTransportDescriptor::non_blocking_send-api| is set to true.
      * |TCPTransportDescriptor::keep_alive_thread-api| and
        |TCPTransportDescriptor::accept_thread-api| use the default configuration.
 

--- a/docs/fastdds/transport/tcp/tcp.rst
+++ b/docs/fastdds/transport/tcp/tcp.rst
@@ -96,10 +96,6 @@ The following table describes the common data members for both TCPv4 and TCPv6.
     - ``bool``
     - ``false``
     - Enables the TCP_NODELAY socket option.
-  * - |TCPTransportDescriptor::non_blocking_send-api|
-    - ``bool``
-    - ``false``
-    - Do not block on send operations (*).
   * - |TCPTransportDescriptor::calculate_crc-api|
     - ``bool``
     - ``true``
@@ -137,15 +133,6 @@ The following table describes the common data members for both TCPv4 and TCPv6.
 
   If |TCPTransportDescriptor::listening_ports-api| is left empty, the participant will not be able to receive incoming
   connections but will be able to connect to other participants that have configured their listening ports.
-
-.. note::
-
-   When |TCPTransportDescriptor::non_blocking_send-api| is set to true, send operations will return immediately if the
-   send buffer is full, but no error will be returned to the upper layer.
-   This means that the application will behave as if the packet is sent and lost.
-
-   When set to ``false``, send operations will block until the network buffer has space for the
-   packet.
 
 .. _transport_tcp_v4transportDescriptor:
 

--- a/docs/fastdds/transport/tcp/tcp.rst
+++ b/docs/fastdds/transport/tcp/tcp.rst
@@ -96,6 +96,10 @@ The following table describes the common data members for both TCPv4 and TCPv6.
     - ``bool``
     - ``false``
     - Enables the TCP_NODELAY socket option.
+  * - |TCPTransportDescriptor::non_blocking_send-api|
+    - ``bool``
+    - ``false``
+    - Do not block on send operations (*).
   * - |TCPTransportDescriptor::calculate_crc-api|
     - ``bool``
     - ``true``
@@ -133,6 +137,15 @@ The following table describes the common data members for both TCPv4 and TCPv6.
 
   If |TCPTransportDescriptor::listening_ports-api| is left empty, the participant will not be able to receive incoming
   connections but will be able to connect to other participants that have configured their listening ports.
+
+.. note::
+
+   When |TCPTransportDescriptor::non_blocking_send-api| is set to true, send operations will return immediately if the
+   send buffer is full, but no error will be returned to the upper layer.
+   This means that the application will behave as if the packet is sent and lost.
+
+   When set to ``false``, send operations will block until the network buffer has space for the
+   packet.
 
 .. _transport_tcp_v4transportDescriptor:
 
@@ -357,6 +370,3 @@ A TCP version of helloworld example can be found in the
 `HelloWorldExampleTCP folder <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/dds/HelloWorldExampleTCP>`_.
 It shows a publisher and a subscriber that communicate through TCP.
 The publisher is configured as *TCP server* while the Subscriber is acting as *TCP client*.
-
-
-


### PR DESCRIPTION
Add non_blocking_send to TCPTransportDescriptor.

Merge after:

- https://github.com/eProsima/Fast-DDS/pull/4237