### PR TITLE
Fix Python API generation [20261]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -271,6 +271,10 @@ if read_the_docs_build:
     os.makedirs(os.path.dirname(output_dir), exist_ok=True)
     os.makedirs(os.path.dirname(doxygen_html), exist_ok=True)
 
+    os.makedirs("{}/include/fastcdr".format(fastdds_repo_name), exist_ok=True)
+    with open("{}/include/fastcdr/config.h".format(fastdds_repo_name), "w") as config_file:
+        config_file.write("#define FASTCDR_VERSION_MAJOR 1")
+
     # Configure Doxyfile
     configure_doxyfile(
         doxyfile_in,


### PR DESCRIPTION
The inclusion of `fastcdr/config.h` in Fast DDS Python's `fastdds.i` created a regression on the RTD generated documentation, as the Python API reference generation done with `SWIG` could not find that `fastcdr/config.h` file. This PR fixes that issue by creating the expected file (in opposition to cloning Fast CDR and configuring the real `config.h`.