### PR TITLE
[20235] Fast DDS Gen flat-output-dir option usage

### DIFF
--- a/docs/fastddsgen/usage/usage.rst
+++ b/docs/fastddsgen/usage/usage.rst
@@ -63,6 +63,8 @@ Where the option choices are:
      - Enables Case Sensitivity
    * - -d <directory>
      - Sets the output directory where the generated files are created.
+   * - -flat-output-dir
+     - Ignore input files relative paths and place all generated files in the specified output directory.
    * - -default_extensibility <extensibility> |br|
        -de <extensibility>
      - Sets the default extensibility for types without the @extensibility annotation. |br|

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -88,6 +88,7 @@ deserialized
 deserializes
 destructor
 diffie
+dir
 DNS
 domainId
 domainparticipant


### PR DESCRIPTION
This PR adds the documentation for the new `fastddsgen` option `flat-output-dir` https://github.com/eProsima/Fast-DDS-Gen/pull/287