### PR TITLE
Unset LARGE_DATA non-blocking-send parameter

### DIFF
--- a/docs/fastdds/rtps_layer/rtps_layer.rst
+++ b/docs/fastdds/rtps_layer/rtps_layer.rst
@@ -184,7 +184,6 @@ function of the :ref:`dds_layer_domainParticipantQos`, XML profiles (see :ref:`R
      * |TCPTransportDescriptor::calculate_crc-api|, |TCPTransportDescriptor::check_crc-api| and
        |TCPTransportDescriptor::apply_security-api| are set to false.
      * |TCPTransportDescriptor::enable_tcp_nodelay-api| is set to true.
-     * :ref:`property_policies_tcp_non_blocking_send` is set to true.
      * |TCPTransportDescriptor::keep_alive_thread-api| and
        |TCPTransportDescriptor::accept_thread-api| use the default configuration.
 


### PR DESCRIPTION
LARGE_DATA builtin transport no longer sets TCP `non_blocking_send` to true.