### PR TITLE
[20527] Ignore FASTDDS_TODO_BEFORE macro on doxygen generation

### DIFF
--- a/code/doxygen-config.in
+++ b/code/doxygen-config.in
@@ -2257,7 +2257,8 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = HAVE_SECURITY=1 \
                          DOXYGEN_DOCUMENTATION=1 \
                          DOXYGEN_SHOULD_SKIP_THIS \
-                         RTPS_DllAPI=
+                         RTPS_DllAPI= \
+                         FASTDDS_TODO_BEFORE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR predefines `FASTDDS_TODO_BEFORE` to empty so it is substitute with nothing on the pre-processing step of Doxygen documentation generation, and thus Doxygen does not complain about it.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_: Code snippets related to the added documentation have been provided.
- _N/A_: Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
