### PR TITLE
Remove fastrtps fixed_size_string.hpp references

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -227,7 +227,7 @@ public:
     void on_type_discovery(
             DomainParticipant* participant,
             const eprosima::fastrtps::rtps::SampleIdentity& request_sample_id,
-            const eprosima::fastrtps::string_255& topic,
+            const eprosima::fastcdr::string_255& topic,
             const eprosima::fastrtps::types::TypeIdentifier* identifier,
             const eprosima::fastrtps::types::TypeObject* object,
             eprosima::fastrtps::types::DynamicType_ptr dyn_type) override
@@ -255,8 +255,8 @@ public:
 
     void on_type_information_received(
             DomainParticipant* participant,
-            const eprosima::fastrtps::string_255 topic_name,
-            const eprosima::fastrtps::string_255 type_name,
+            const eprosima::fastcdr::string_255 topic_name,
+            const eprosima::fastcdr::string_255 type_name,
             const eprosima::fastrtps::types::TypeInformation& type_information) override
     {
         static_cast<void>(participant);
@@ -971,7 +971,7 @@ class DiscoveryDomainParticipantListener : public DomainParticipantListener
     void on_type_discovery(
             DomainParticipant* participant,
             const eprosima::fastrtps::rtps::SampleIdentity& request_sample_id,
-            const eprosima::fastrtps::string_255& topic,
+            const eprosima::fastcdr::string_255& topic,
             const eprosima::fastrtps::types::TypeIdentifier* identifier,
             const eprosima::fastrtps::types::TypeObject* object,
             eprosima::fastrtps::types::DynamicType_ptr dyn_type) override


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Remove fastrtps fixed_size_string.hpp references. This PR is related with:

* eProsima/Fast-DDS#4269

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- N/A Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- N/A Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
