### PR TITLE
[20501] Improve large data docs

### DIFF
--- a/docs/fastdds/use_cases/tcp/tcp_use_case.rst
+++ b/docs/fastdds/use_cases/tcp/tcp_use_case.rst
@@ -2,8 +2,8 @@
 
 .. _use-case-tcp:
 
-Fast DDS over TCP
-=================
+LARGE_DATA mode and Fast DDS over TCP
+======================================
 
 As explained in :ref:`transport_tcp_tcp`, Fast DDS offers the possibility to communicate nodes within distributed
 applications with DDS over a TCP transport layer.
@@ -16,10 +16,16 @@ links.
 The configuration of the TCP transport typically involves an *a priori* knowledge of the deployment in order
 to set :ref:`Simple Initial Peers` for :ref:`discovery`, which may not always be possible and creates difficulties when
 reallocating nodes of the distributed applications, as the entire discovery configuration needs to be changed.
-To overcome this problem, these use cases present an approach for leveraging the Fast DDS' TCP transport capabilities
-while at the same time not requiring configuration modifications when the deployment changes over time.
-One option is to configure the participant discovery phase (see :ref:`disc_phases`) to occur over UDP multicast, while
-the application data delivery occurs over TCP. Also, it is possible to enable TCP communication while using
+To overcome this problem, Fast DDS presents the ``LARGE_DATA`` builtin transports configuration as an approach for
+leveraging the Fast DDS' TCP transport capabilities while at the same time not requiring configuration modifications
+when the deployment changes over time.
+
+``LARGE_DATA`` has been specifically designed to improve communication performance of large data samples over lossy
+networks. When configured, UDP transport will exclusively be used during the :ref:`PDP discovery<disc_phases>` phase,
+taking advantage of the more reliable TCP/SHM for the remainder of the communication process. Fast DDS offers
+an extremely straightforward implementation for this mode through an environment variable, XML profiles or via code.
+
+Also, it is possible to enable TCP communication while using
 :ref:`discovery-server-use-case` to manage :ref:`discovery`.
 
 .. toctree::

--- a/docs/fastdds/use_cases/tcp/tcp_use_case.rst
+++ b/docs/fastdds/use_cases/tcp/tcp_use_case.rst
@@ -2,7 +2,7 @@
 
 .. _use-case-tcp:
 
-LARGE_DATA mode and Fast DDS over TCP
+Large Data mode and Fast DDS over TCP
 ======================================
 
 As explained in :ref:`transport_tcp_tcp`, Fast DDS offers the possibility to communicate nodes within distributed

--- a/docs/fastdds/use_cases/tcp/tcp_with_multicast_discovery.rst
+++ b/docs/fastdds/use_cases/tcp/tcp_with_multicast_discovery.rst
@@ -3,7 +3,7 @@
 
 .. _use-case-tcp-multicast:
 
-TCP / SHM Communication with Multicast Discovery (LARGE_DATA)
+LARGE_DATA: TCP / SHM Communication with Multicast Discovery
 =============================================================
 
 The following snippets show how to configure *Fast DDS* |DomainParticipants| to run the

--- a/docs/fastdds/use_cases/use_cases.rst
+++ b/docs/fastdds/use_cases/use_cases.rst
@@ -16,8 +16,6 @@ with distributed systems:
   optimizes communication performance for large data samples over lossy networks by employing a combination of UDP and
   TCP/SHM transports.
 
-  TODO Carlos: Insert video demo
-
 + :ref:`use-case-fast-rtps-over-wifi`.
   Presents a case where :ref:`discovery` through multicast communication is a challenge.
   This example shows how to:

--- a/docs/fastdds/use_cases/use_cases.rst
+++ b/docs/fastdds/use_cases/use_cases.rst
@@ -10,6 +10,14 @@ Typical Use-Cases
 This section provides configuration examples for the following typical use cases when dealing
 with distributed systems:
 
++ :ref:`use-case-tcp`.
+  Describes how to configure *Fast DDS* to use the ``LARGE_DATA`` builtin transports mode. This mode enables
+  efficient utilization of TCP transport without the need for constant reconfiguration during deployment changes. It
+  optimizes communication performance for large data samples over lossy networks by employing a combination of UDP and
+  TCP/SHM transports.
+
+  TODO Carlos: Insert video demo
+
 + :ref:`use-case-fast-rtps-over-wifi`.
   Presents a case where :ref:`discovery` through multicast communication is a challenge.
   This example shows how to:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR improves explanation about LARGE_DATA and reorganizes the Typical Cases of Use. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
