### PR TITLE
[20508] TCP first message loss

### DIFF
--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -632,6 +632,7 @@
 .. |TCPTransportDescriptor::keep_alive_thread-api| replace:: :cpp:var:`keep_alive_thread<eprosima::fastdds::rtps::TCPTransportDescriptor::keep_alive_thread>`
 .. |TCPTransportDescriptor::accept_thread-api| replace:: :cpp:var:`accept_thread<eprosima::fastdds::rtps::TCPTransportDescriptor::accept_thread>`
 .. |TCPTransportDescriptor::tls_config-api| replace:: :cpp:var:`tls_config<eprosima::fastdds::rtps::TCPTransportDescriptor::tls_config>`
+.. |TCPTransportDescriptor::wait_for_logical_port_negotiation_ms-api| replace:: :cpp:var:`wait_for_logical_port_negotiation_ms<eprosima::fastdds::rtps::TCPTransportDescriptor::wait_for_logical_port_negotiation_ms>`
 
 .. |TCPTransportDescriptor::TLSConfig-api| replace:: :cpp:struct:`TLSConfig<eprosima::fastdds::rtps::TCPTransportDescriptor::TLSConfig>`
 .. |TCPTransportDescriptor::TLSConfig::add_verify_mode-api| replace:: :cpp:func:`add_verify_mode()<eprosima::fastdds::rtps::TCPTransportDescriptor::TLSConfig::add_verify_mode>`

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -632,7 +632,7 @@
 .. |TCPTransportDescriptor::keep_alive_thread-api| replace:: :cpp:var:`keep_alive_thread<eprosima::fastdds::rtps::TCPTransportDescriptor::keep_alive_thread>`
 .. |TCPTransportDescriptor::accept_thread-api| replace:: :cpp:var:`accept_thread<eprosima::fastdds::rtps::TCPTransportDescriptor::accept_thread>`
 .. |TCPTransportDescriptor::tls_config-api| replace:: :cpp:var:`tls_config<eprosima::fastdds::rtps::TCPTransportDescriptor::tls_config>`
-.. |TCPTransportDescriptor::wait_for_logical_port_negotiation_ms-api| replace:: :cpp:var:`wait_for_logical_port_negotiation_ms<eprosima::fastdds::rtps::TCPTransportDescriptor::wait_for_logical_port_negotiation_ms>`
+.. |TCPTransportDescriptor::tcp_negotiation_timeout-api| replace:: :cpp:var:`tcp_negotiation_timeout<eprosima::fastdds::rtps::TCPTransportDescriptor::tcp_negotiation_timeout>`
 
 .. |TCPTransportDescriptor::TLSConfig-api| replace:: :cpp:struct:`TLSConfig<eprosima::fastdds::rtps::TCPTransportDescriptor::TLSConfig>`
 .. |TCPTransportDescriptor::TLSConfig::add_verify_mode-api| replace:: :cpp:func:`add_verify_mode()<eprosima::fastdds::rtps::TCPTransportDescriptor::TLSConfig::add_verify_mode>`

--- a/docs/fastdds/transport/tcp/tcp.rst
+++ b/docs/fastdds/transport/tcp/tcp.rst
@@ -132,12 +132,13 @@ The following table describes the common data members for both TCPv4 and TCPv6.
     - |ThreadSettings|
     -
     - |ThreadSettings| for the threads processing incoming TCP connection requests.
-  * - |TCPTransportDescriptor::wait_for_logical_port_negotiation_ms-api|
+  * - |TCPTransportDescriptor::tcp_negotiation_timeout-api|
     - ``uint32_t``
-    - 50
+    - 0
     - Time to wait for logical port negotiation (in ms). If a logical port is under negotiation, it waits for the
-      negotiation to finish up to this timeout before trying to send a message to that port. Zero value means waiting
-      indefinitely.
+      negotiation to finish up to this timeout before trying to send a message to that port. Setting this option to
+      non-zero values increases the discovery time. Setting it to zero means no wait but could lead to loss of first
+      messages.
 
 .. note::
 

--- a/docs/fastdds/transport/tcp/tcp.rst
+++ b/docs/fastdds/transport/tcp/tcp.rst
@@ -132,6 +132,12 @@ The following table describes the common data members for both TCPv4 and TCPv6.
     - |ThreadSettings|
     -
     - |ThreadSettings| for the threads processing incoming TCP connection requests.
+  * - |TCPTransportDescriptor::wait_for_logical_port_negotiation_ms-api|
+    - ``uint32_t``
+    - 50
+    - Time to wait for logical port negotiation (in ms). If a logical port is under negotiation, it waits for the
+      negotiation to finish up to this timeout before trying to send a message to that port. Zero value means waiting
+      indefinitely.
 
 .. note::
 

--- a/docs/fastdds/xml_configuration/transports.rst
+++ b/docs/fastdds/xml_configuration/transports.rst
@@ -23,112 +23,112 @@ The following table lists all the available XML elements that can be defined wit
 element for the configuration of the transport layer.
 A more detailed explanation of each of these elements can be found in :ref:`comm-transports-configuration`.
 
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| Name                                      | Description                                        | Values               | Default  |
-+===========================================+====================================================+======================+==========+
-| ``<transport_id>``                        | Unique name to identify each transport             | ``string``           |          |
-|                                           | descriptor.                                        |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<type>``                                | Type of the transport descriptor.                  | UDPv4                | UDPv4    |
-|                                           |                                                    +----------------------+          |
-|                                           |                                                    | UDPv6                |          |
-|                                           |                                                    +----------------------+          |
-|                                           |                                                    | TCPv4                |          |
-|                                           |                                                    +----------------------+          |
-|                                           |                                                    | TCPv6                |          |
-|                                           |                                                    +----------------------+          |
-|                                           |                                                    | SHM                  |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<sendBufferSize>``                      | Size in bytes of the send socket buffer. |br|      | ``uint32_t``         | 0        |
-|                                           | If the value is zero then *Fast DDS* will use |br| |                      |          |
-|                                           | the system default socket size.                    |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<receiveBufferSize>``                   | Size in bytes of the reception socket |br|         | ``uint32_t``         | 0        |
-|                                           | buffer. If the value is zero then *Fast DDS* |br|  |                      |          |
-|                                           | will use the system default socket size.           |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<maxMessageSize>``                      | The maximum size in bytes of the transport's |br|  | ``uint32_t``         | 65500    |
-|                                           | message buffer.                                    |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<maxInitialPeersRange>``                | Number of channels opened with each initial |br|   | ``uint32_t``         | 4        |
-|                                           | remote peer.                                       |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<interfaceWhiteList>``                  | Allows defining an interfaces |whitelist|.         | |whitelist|          |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<TTL>``                                 | *Time To Live* (**UDP only**). See |br|            | ``uint8_t``          | 1        |
-|                                           | :ref:`transport_udp_udp`.                          |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<non_blocking_send>``                   | Whether to set the non-blocking send mode on |br|  | ``bool``             | ``false``|
-|                                           | the socket (**NOT available for SHM type**). See   |                      |          |
-|                                           | |br| :ref:`transport_udp_transportDescriptor` and  |                      |          |
-|                                           | |br| :ref:`transport_tcp_transportDescriptor`.     |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<output_port>``                         | Port used for output bound. |br|                   | ``uint16_t``         | 0        |
-|                                           | If this field isn't defined, the output port |br|  |                      |          |
-|                                           | will be random (**UDP only**).                     |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<wan_addr>``                            | Public WAN address when using **TCPv4** |br|       |  IPv4 formatted |br| |          |
-|                                           | **transports**. This field is optional if the |br| |  ``string``: |br|    |          |
-|                                           | transport doesn't need to define a WAN |br|        |  ``XXX.XXX.XXX.XXX`` |          |
-|                                           | address (**TCPv4 only**).                          |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<keep_alive_frequency_ms>``             | Frequency in milliseconds for sending              | ``uint32_t``         | 50000    |
-|                                           | :ref:`RTCP <rtcpdefinition>` |br|                  |                      |          |
-|                                           | keep-alive requests (**TCP only**).                |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<keep_alive_timeout_ms>``               | Time in milliseconds since the last |br|           | ``uint32_t``         | 10000    |
-|                                           | keep-alive request was sent to consider a |br|     |                      |          |
-|                                           | connection as broken (**TCP only**).               |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<max_logical_port>``                    | The maximum number of logical ports to try |br|    | ``uint16_t``         | 100      |
-|                                           | during :ref:`RTCP<rtcpdefinition>`                 |                      |          |
-|                                           | negotiations (**TCP only**).                       |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<logical_port_range>``                  | The maximum number of logical ports per |br|       | ``uint16_t``         | 20       |
-|                                           | request to try during                              |                      |          |
-|                                           | :ref:`RTCP<rtcpdefinition>` negotiations |br|      |                      |          |
-|                                           | (**TCP only**).                                    |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<logical_port_increment>``              | Increment between logical ports to try during |br| | ``uint16_t``         |  2       |
-|                                           | :ref:`RTCP<rtcpdefinition>` negotiation |br|       |                      |          |
-|                                           | (**TCP only**).                                    |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<listening_ports>``                     | Local port to work as TCP acceptor for input |br|  | ``List <uint16_t>``  |          |
-|                                           | connections. If not set, the transport will |br|   |                      |          |
-|                                           | work as TCP client only. If set to 0, an |br|      |                      |          |
-|                                           | available port will be automatically assigned |br| |                      |          |
-|                                           | (**TCP only**).                                    |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<tls>``                                 | Allows to define TLS related parameters and |br|   | :ref:`tcp-tls`       |          |
-|                                           | options (**TCP only**).                            |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<calculate_crc>``                       | Calculates the Cyclic Redundancy Code (CRC) |br|   | ``bool``             | ``true`` |
-|                                           | for error control (**TCP only**). |br|             |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<check_crc>``                           | Check the CRC for error control (**TCP** |br|      | ``bool``             | ``true`` |
-|                                           | **only**).                                         |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<enable_tcp_nodelay>``                  | Socket option for disabling the Nagle |br|         | ``bool``             | ``false``|
-|                                           | algorithm. (**TCP only**).                         |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<wait_for_logical_port_negotiation_ms>``| Time to wait for logical port negotiation (in ms)  | ``uint32_t``         | ``50``   |
-|                                           | |br| (**TCP only**).                               |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<segment_size>``                        | Size (in bytes) of the shared-memory segment. |br| | ``uint32_t``         | 262144   |
-|                                           | (Optional, **SHM only**).                          |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<port_queue_capacity>``                 | Capacity (in number of messages) available to |br| | ``uint32_t``         | 512      |
-|                                           | every Listener (Optional, **SHM only**).           |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<healthy_check_timeout_ms>``            | Maximum time-out (in milliseconds) used when |br|  | ``uint32_t``         | 1000     |
-|                                           | checking whether a Listener is alive |br|          |                      |          |
-|                                           | (Optional, **SHM only**).                          |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<rtps_dump_file>``                      | Complete path (including file) where RTPS |br|     | ``string``           | Empty    |
-|                                           | messages will be stored for debugging |br|         |                      |          |
-|                                           | purposes. An empty string indicates no trace |br|  |                      |          |
-|                                           | will be performed (Optional, **SHM only**).        |                      |          |
-+-------------------------------------------+----------------------------------------------------+----------------------+----------+
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| Name                          | Description                                        | Values               | Default  |
++===============================+====================================================+======================+==========+
+| ``<transport_id>``            | Unique name to identify each transport             | ``string``           |          |
+|                               | descriptor.                                        |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<type>``                    | Type of the transport descriptor.                  | UDPv4                | UDPv4    |
+|                               |                                                    +----------------------+          |
+|                               |                                                    | UDPv6                |          |
+|                               |                                                    +----------------------+          |
+|                               |                                                    | TCPv4                |          |
+|                               |                                                    +----------------------+          |
+|                               |                                                    | TCPv6                |          |
+|                               |                                                    +----------------------+          |
+|                               |                                                    | SHM                  |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<sendBufferSize>``          | Size in bytes of the send socket buffer. |br|      | ``uint32_t``         | 0        |
+|                               | If the value is zero then *Fast DDS* will use |br| |                      |          |
+|                               | the system default socket size.                    |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<receiveBufferSize>``       | Size in bytes of the reception socket |br|         | ``uint32_t``         | 0        |
+|                               | buffer. If the value is zero then *Fast DDS* |br|  |                      |          |
+|                               | will use the system default socket size.           |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<maxMessageSize>``          | The maximum size in bytes of the transport's |br|  | ``uint32_t``         | 65500    |
+|                               | message buffer.                                    |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<maxInitialPeersRange>``    | Number of channels opened with each initial |br|   | ``uint32_t``         | 4        |
+|                               | remote peer.                                       |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<interfaceWhiteList>``      | Allows defining an interfaces |whitelist|.         | |whitelist|          |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<TTL>``                     | *Time To Live* (**UDP only**). See |br|            | ``uint8_t``          | 1        |
+|                               | :ref:`transport_udp_udp`.                          |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<non_blocking_send>``       | Whether to set the non-blocking send mode on |br|  | ``bool``             | ``false``|
+|                               | the socket (**NOT available for SHM type**). See   |                      |          |
+|                               | |br| :ref:`transport_udp_transportDescriptor` and  |                      |          |
+|                               | |br| :ref:`transport_tcp_transportDescriptor`.     |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<output_port>``             | Port used for output bound. |br|                   | ``uint16_t``         | 0        |
+|                               | If this field isn't defined, the output port |br|  |                      |          |
+|                               | will be random (**UDP only**).                     |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<wan_addr>``                | Public WAN address when using **TCPv4** |br|       |  IPv4 formatted |br| |          |
+|                               | **transports**. This field is optional if the |br| |  ``string``: |br|    |          |
+|                               | transport doesn't need to define a WAN |br|        |  ``XXX.XXX.XXX.XXX`` |          |
+|                               | address (**TCPv4 only**).                          |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<keep_alive_frequency_ms>`` | Frequency in milliseconds for sending              | ``uint32_t``         | 50000    |
+|                               | :ref:`RTCP <rtcpdefinition>` |br|                  |                      |          |
+|                               | keep-alive requests (**TCP only**).                |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<keep_alive_timeout_ms>``   | Time in milliseconds since the last |br|           | ``uint32_t``         | 10000    |
+|                               | keep-alive request was sent to consider a |br|     |                      |          |
+|                               | connection as broken (**TCP only**).               |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<max_logical_port>``        | The maximum number of logical ports to try |br|    | ``uint16_t``         | 100      |
+|                               | during :ref:`RTCP<rtcpdefinition>`                 |                      |          |
+|                               | negotiations (**TCP only**).                       |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<logical_port_range>``      | The maximum number of logical ports per |br|       | ``uint16_t``         | 20       |
+|                               | request to try during                              |                      |          |
+|                               | :ref:`RTCP<rtcpdefinition>` negotiations |br|      |                      |          |
+|                               | (**TCP only**).                                    |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<logical_port_increment>``  | Increment between logical ports to try during |br| | ``uint16_t``         |  2       |
+|                               | :ref:`RTCP<rtcpdefinition>` negotiation |br|       |                      |          |
+|                               | (**TCP only**).                                    |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<listening_ports>``         | Local port to work as TCP acceptor for input |br|  | ``List <uint16_t>``  |          |
+|                               | connections. If not set, the transport will |br|   |                      |          |
+|                               | work as TCP client only. If set to 0, an |br|      |                      |          |
+|                               | available port will be automatically assigned |br| |                      |          |
+|                               | (**TCP only**).                                    |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<tls>``                     | Allows to define TLS related parameters and |br|   | :ref:`tcp-tls`       |          |
+|                               | options (**TCP only**).                            |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<calculate_crc>``           | Calculates the Cyclic Redundancy Code (CRC) |br|   | ``bool``             | ``true`` |
+|                               | for error control (**TCP only**). |br|             |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<check_crc>``               | Check the CRC for error control (**TCP** |br|      | ``bool``             | ``true`` |
+|                               | **only**).                                         |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<enable_tcp_nodelay>``      | Socket option for disabling the Nagle |br|         | ``bool``             | ``false``|
+|                               | algorithm. (**TCP only**).                         |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<tcp_negotiation_timeout>`` | Time to wait for logical port negotiation (in ms)  | ``uint32_t``         | ``0``    |
+|                               | |br| (**TCP only**).                               |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<segment_size>``            | Size (in bytes) of the shared-memory segment. |br| | ``uint32_t``         | 262144   |
+|                               | (Optional, **SHM only**).                          |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<port_queue_capacity>``     | Capacity (in number of messages) available to |br| | ``uint32_t``         | 512      |
+|                               | every Listener (Optional, **SHM only**).           |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<healthy_check_timeout_ms>``| Maximum time-out (in milliseconds) used when |br|  | ``uint32_t``         | 1000     |
+|                               | checking whether a Listener is alive |br|          |                      |          |
+|                               | (Optional, **SHM only**).                          |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<rtps_dump_file>``          | Complete path (including file) where RTPS |br|     | ``string``           | Empty    |
+|                               | messages will be stored for debugging |br|         |                      |          |
+|                               | purposes. An empty string indicates no trace |br|  |                      |          |
+|                               | will be performed (Optional, **SHM only**).        |                      |          |
++-------------------------------+----------------------------------------------------+----------------------+----------+
 
 The following XML code shows an example of transport protocol configuration using all configurable parameters.
 More examples of transports descriptors can be found in the :ref:`comm-transports-configuration` section.

--- a/docs/fastdds/xml_configuration/transports.rst
+++ b/docs/fastdds/xml_configuration/transports.rst
@@ -23,109 +23,112 @@ The following table lists all the available XML elements that can be defined wit
 element for the configuration of the transport layer.
 A more detailed explanation of each of these elements can be found in :ref:`comm-transports-configuration`.
 
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| Name                          | Description                                        | Values               | Default  |
-+===============================+====================================================+======================+==========+
-| ``<transport_id>``            | Unique name to identify each transport             | ``string``           |          |
-|                               | descriptor.                                        |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<type>``                    | Type of the transport descriptor.                  | UDPv4                | UDPv4    |
-|                               |                                                    +----------------------+          |
-|                               |                                                    | UDPv6                |          |
-|                               |                                                    +----------------------+          |
-|                               |                                                    | TCPv4                |          |
-|                               |                                                    +----------------------+          |
-|                               |                                                    | TCPv6                |          |
-|                               |                                                    +----------------------+          |
-|                               |                                                    | SHM                  |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<sendBufferSize>``          | Size in bytes of the send socket buffer. |br|      | ``uint32_t``         | 0        |
-|                               | If the value is zero then *Fast DDS* will use |br| |                      |          |
-|                               | the system default socket size.                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<receiveBufferSize>``       | Size in bytes of the reception socket |br|         | ``uint32_t``         | 0        |
-|                               | buffer. If the value is zero then *Fast DDS* |br|  |                      |          |
-|                               | will use the system default socket size.           |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<maxMessageSize>``          | The maximum size in bytes of the transport's |br|  | ``uint32_t``         | 65500    |
-|                               | message buffer.                                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<maxInitialPeersRange>``    | Number of channels opened with each initial |br|   | ``uint32_t``         | 4        |
-|                               | remote peer.                                       |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<interfaceWhiteList>``      | Allows defining an interfaces |whitelist|.         | |whitelist|          |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<TTL>``                     | *Time To Live* (**UDP only**). See |br|            | ``uint8_t``          | 1        |
-|                               | :ref:`transport_udp_udp`.                          |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<non_blocking_send>``       | Whether to set the non-blocking send mode on |br|  | ``bool``             | ``false``|
-|                               | the socket (**NOT available for SHM type**). See   |                      |          |
-|                               | |br| :ref:`transport_udp_transportDescriptor` and  |                      |          |
-|                               | |br| :ref:`transport_tcp_transportDescriptor`.     |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<output_port>``             | Port used for output bound. |br|                   | ``uint16_t``         | 0        |
-|                               | If this field isn't defined, the output port |br|  |                      |          |
-|                               | will be random (**UDP only**).                     |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<wan_addr>``                | Public WAN address when using **TCPv4** |br|       |  IPv4 formatted |br| |          |
-|                               | **transports**. This field is optional if the |br| |  ``string``: |br|    |          |
-|                               | transport doesn't need to define a WAN |br|        |  ``XXX.XXX.XXX.XXX`` |          |
-|                               | address (**TCPv4 only**).                          |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<keep_alive_frequency_ms>`` | Frequency in milliseconds for sending              | ``uint32_t``         | 50000    |
-|                               | :ref:`RTCP <rtcpdefinition>` |br|                  |                      |          |
-|                               | keep-alive requests (**TCP only**).                |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<keep_alive_timeout_ms>``   | Time in milliseconds since the last |br|           | ``uint32_t``         | 10000    |
-|                               | keep-alive request was sent to consider a |br|     |                      |          |
-|                               | connection as broken (**TCP only**).               |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<max_logical_port>``        | The maximum number of logical ports to try |br|    | ``uint16_t``         | 100      |
-|                               | during :ref:`RTCP<rtcpdefinition>`                 |                      |          |
-|                               | negotiations (**TCP only**).                       |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<logical_port_range>``      | The maximum number of logical ports per |br|       | ``uint16_t``         | 20       |
-|                               | request to try during                              |                      |          |
-|                               | :ref:`RTCP<rtcpdefinition>` negotiations |br|      |                      |          |
-|                               | (**TCP only**).                                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<logical_port_increment>``  | Increment between logical ports to try during |br| | ``uint16_t``         |  2       |
-|                               | :ref:`RTCP<rtcpdefinition>` negotiation |br|       |                      |          |
-|                               | (**TCP only**).                                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<listening_ports>``         | Local port to work as TCP acceptor for input |br|  | ``List <uint16_t>``  |          |
-|                               | connections. If not set, the transport will |br|   |                      |          |
-|                               | work as TCP client only. If set to 0, an |br|      |                      |          |
-|                               | available port will be automatically assigned |br| |                      |          |
-|                               | (**TCP only**).                                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<tls>``                     | Allows to define TLS related parameters and |br|   | :ref:`tcp-tls`       |          |
-|                               | options (**TCP only**).                            |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<calculate_crc>``           | Calculates the Cyclic Redundancy Code (CRC) |br|   | ``bool``             | ``true`` |
-|                               | for error control (**TCP only**). |br|             |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<check_crc>``               | Check the CRC for error control (**TCP** |br|      | ``bool``             | ``true`` |
-|                               | **only**).                                         |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<enable_tcp_nodelay>``      | Socket option for disabling the Nagle |br|         | ``bool``             | ``false``|
-|                               | algorithm. (**TCP only**).                         |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<segment_size>``            | Size (in bytes) of the shared-memory segment. |br| | ``uint32_t``         | 262144   |
-|                               | (Optional, **SHM only**).                          |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<port_queue_capacity>``     | Capacity (in number of messages) available to |br| | ``uint32_t``         | 512      |
-|                               | every Listener (Optional, **SHM only**).           |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<healthy_check_timeout_ms>``| Maximum time-out (in milliseconds) used when |br|  | ``uint32_t``         | 1000     |
-|                               | checking whether a Listener is alive |br|          |                      |          |
-|                               | (Optional, **SHM only**).                          |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<rtps_dump_file>``          | Complete path (including file) where RTPS |br|     | ``string``           | Empty    |
-|                               | messages will be stored for debugging |br|         |                      |          |
-|                               | purposes. An empty string indicates no trace |br|  |                      |          |
-|                               | will be performed (Optional, **SHM only**).        |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| Name                                      | Description                                        | Values               | Default  |
++===========================================+====================================================+======================+==========+
+| ``<transport_id>``                        | Unique name to identify each transport             | ``string``           |          |
+|                                           | descriptor.                                        |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<type>``                                | Type of the transport descriptor.                  | UDPv4                | UDPv4    |
+|                                           |                                                    +----------------------+          |
+|                                           |                                                    | UDPv6                |          |
+|                                           |                                                    +----------------------+          |
+|                                           |                                                    | TCPv4                |          |
+|                                           |                                                    +----------------------+          |
+|                                           |                                                    | TCPv6                |          |
+|                                           |                                                    +----------------------+          |
+|                                           |                                                    | SHM                  |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<sendBufferSize>``                      | Size in bytes of the send socket buffer. |br|      | ``uint32_t``         | 0        |
+|                                           | If the value is zero then *Fast DDS* will use |br| |                      |          |
+|                                           | the system default socket size.                    |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<receiveBufferSize>``                   | Size in bytes of the reception socket |br|         | ``uint32_t``         | 0        |
+|                                           | buffer. If the value is zero then *Fast DDS* |br|  |                      |          |
+|                                           | will use the system default socket size.           |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<maxMessageSize>``                      | The maximum size in bytes of the transport's |br|  | ``uint32_t``         | 65500    |
+|                                           | message buffer.                                    |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<maxInitialPeersRange>``                | Number of channels opened with each initial |br|   | ``uint32_t``         | 4        |
+|                                           | remote peer.                                       |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<interfaceWhiteList>``                  | Allows defining an interfaces |whitelist|.         | |whitelist|          |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<TTL>``                                 | *Time To Live* (**UDP only**). See |br|            | ``uint8_t``          | 1        |
+|                                           | :ref:`transport_udp_udp`.                          |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<non_blocking_send>``                   | Whether to set the non-blocking send mode on |br|  | ``bool``             | ``false``|
+|                                           | the socket (**NOT available for SHM type**). See   |                      |          |
+|                                           | |br| :ref:`transport_udp_transportDescriptor` and  |                      |          |
+|                                           | |br| :ref:`transport_tcp_transportDescriptor`.     |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<output_port>``                         | Port used for output bound. |br|                   | ``uint16_t``         | 0        |
+|                                           | If this field isn't defined, the output port |br|  |                      |          |
+|                                           | will be random (**UDP only**).                     |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<wan_addr>``                            | Public WAN address when using **TCPv4** |br|       |  IPv4 formatted |br| |          |
+|                                           | **transports**. This field is optional if the |br| |  ``string``: |br|    |          |
+|                                           | transport doesn't need to define a WAN |br|        |  ``XXX.XXX.XXX.XXX`` |          |
+|                                           | address (**TCPv4 only**).                          |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<keep_alive_frequency_ms>``             | Frequency in milliseconds for sending              | ``uint32_t``         | 50000    |
+|                                           | :ref:`RTCP <rtcpdefinition>` |br|                  |                      |          |
+|                                           | keep-alive requests (**TCP only**).                |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<keep_alive_timeout_ms>``               | Time in milliseconds since the last |br|           | ``uint32_t``         | 10000    |
+|                                           | keep-alive request was sent to consider a |br|     |                      |          |
+|                                           | connection as broken (**TCP only**).               |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<max_logical_port>``                    | The maximum number of logical ports to try |br|    | ``uint16_t``         | 100      |
+|                                           | during :ref:`RTCP<rtcpdefinition>`                 |                      |          |
+|                                           | negotiations (**TCP only**).                       |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<logical_port_range>``                  | The maximum number of logical ports per |br|       | ``uint16_t``         | 20       |
+|                                           | request to try during                              |                      |          |
+|                                           | :ref:`RTCP<rtcpdefinition>` negotiations |br|      |                      |          |
+|                                           | (**TCP only**).                                    |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<logical_port_increment>``              | Increment between logical ports to try during |br| | ``uint16_t``         |  2       |
+|                                           | :ref:`RTCP<rtcpdefinition>` negotiation |br|       |                      |          |
+|                                           | (**TCP only**).                                    |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<listening_ports>``                     | Local port to work as TCP acceptor for input |br|  | ``List <uint16_t>``  |          |
+|                                           | connections. If not set, the transport will |br|   |                      |          |
+|                                           | work as TCP client only. If set to 0, an |br|      |                      |          |
+|                                           | available port will be automatically assigned |br| |                      |          |
+|                                           | (**TCP only**).                                    |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<tls>``                                 | Allows to define TLS related parameters and |br|   | :ref:`tcp-tls`       |          |
+|                                           | options (**TCP only**).                            |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<calculate_crc>``                       | Calculates the Cyclic Redundancy Code (CRC) |br|   | ``bool``             | ``true`` |
+|                                           | for error control (**TCP only**). |br|             |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<check_crc>``                           | Check the CRC for error control (**TCP** |br|      | ``bool``             | ``true`` |
+|                                           | **only**).                                         |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<enable_tcp_nodelay>``                  | Socket option for disabling the Nagle |br|         | ``bool``             | ``false``|
+|                                           | algorithm. (**TCP only**).                         |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<wait_for_logical_port_negotiation_ms>``| Time to wait for logical port negotiation (in ms)  | ``uint32_t``         | ``50``   |
+|                                           | |br| (**TCP only**).                               |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<segment_size>``                        | Size (in bytes) of the shared-memory segment. |br| | ``uint32_t``         | 262144   |
+|                                           | (Optional, **SHM only**).                          |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<port_queue_capacity>``                 | Capacity (in number of messages) available to |br| | ``uint32_t``         | 512      |
+|                                           | every Listener (Optional, **SHM only**).           |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<healthy_check_timeout_ms>``            | Maximum time-out (in milliseconds) used when |br|  | ``uint32_t``         | 1000     |
+|                                           | checking whether a Listener is alive |br|          |                      |          |
+|                                           | (Optional, **SHM only**).                          |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
+| ``<rtps_dump_file>``                      | Complete path (including file) where RTPS |br|     | ``string``           | Empty    |
+|                                           | messages will be stored for debugging |br|         |                      |          |
+|                                           | purposes. An empty string indicates no trace |br|  |                      |          |
+|                                           | will be performed (Optional, **SHM only**).        |                      |          |
++-------------------------------------------+----------------------------------------------------+----------------------+----------+
 
 The following XML code shows an example of transport protocol configuration using all configurable parameters.
 More examples of transports descriptors can be found in the :ref:`comm-transports-configuration` section.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
With the related PR, the `tcp_negotiation_timeout` Transport Descriptor will be used to wait until logical port negotiation is finished prior sending data.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#4454


## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- N/A Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
