### PR TITLE
[20313] Allow single listening port on TCP

### DIFF
--- a/docs/fastdds/transport/tcp/tcp.rst
+++ b/docs/fastdds/transport/tcp/tcp.rst
@@ -71,7 +71,7 @@ The following table describes the common data members for both TCPv4 and TCPv6.
   * - |TCPTransportDescriptor::listening_ports-api|
     - ``vector<uint16_t>``
     - Empty vector
-    - List of ports to listen as *server*. If a port is set to 0, an available port will be automatically assigned. 
+    - List of ports to listen as *server*. If a port is set to 0, an available port will be automatically assigned.
   * - |TCPTransportDescriptor::keep_alive_frequency_ms-api|
     - ``uint32_t``
     - 5000

--- a/docs/fastdds/transport/tcp/tcp.rst
+++ b/docs/fastdds/transport/tcp/tcp.rst
@@ -71,7 +71,7 @@ The following table describes the common data members for both TCPv4 and TCPv6.
   * - |TCPTransportDescriptor::listening_ports-api|
     - ``vector<uint16_t>``
     - Empty vector
-    - List of ports to listen as *server*. If a port is set to 0, an available port will be automatically assigned.
+    - List of ports to listen as *server*. If a port is set to 0, an available port will be automatically assigned. 
   * - |TCPTransportDescriptor::keep_alive_frequency_ms-api|
     - ``uint32_t``
     - 5000
@@ -132,6 +132,11 @@ The following table describes the common data members for both TCPv4 and TCPv6.
     - |ThreadSettings|
     -
     - |ThreadSettings| for the threads processing incoming TCP connection requests.
+
+.. warning::
+
+  Although the member |TCPTransportDescriptor::listening_ports-api| accepts multiple ports, only the first listening port
+  will be effectively used. The rest of the ports will be ignored.
 
 .. note::
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This related PR limits the amount of listening ports to one. If more listening ports are passed, those are ignored.
This PR documents this limitation.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#4348


## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- N/A Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
