### PR TITLE
[20551] Modify statistic data writer profile name in the xml file 

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3147,7 +3147,7 @@
         </participant>
 
         <!-- Generic profile for all the statistics DataWriter -->
-        <data_writer profile_name="GENERIC_STATISTICS_WRITER_PROFILE">
+        <data_writer profile_name="GENERIC_STATISTICS_PROFILE">
             <!-- Configure History QoS as KEEP_LAST 20 -->
             <!-- History depth depends on the user application constraints (publication rate for instance) -->
             <topic>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
--> 
This PR modifies the statistic data writer profile name of the xml file to troubleshoot statistics module, changing it to the right one. The error was pointed out in the issue https://github.com/eProsima/Fast-DDS/issues/4389.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
 @Mergifyio backport 2.13.x 2.12.x 2.10.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes eProsima/Fast-DDS#4389

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- N/A Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- N/A Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
