### PR TITLE
[20543] Create Participant with default profile (use environment XML configuration)

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -393,6 +393,31 @@ void dds_domain_examples()
     }
 
     {
+        //DDS_CREATE_DOMAINPARTICIPANT_DEFAULT_PROFILE
+        // Create a DomainParticipant using the environment profile and no Listener
+        DomainParticipant* participant =
+                DomainParticipantFactory::get_instance()->create_participant_with_default_profile();
+        if (nullptr == participant)
+        {
+            // Error
+            return;
+        }
+
+        // Create a DomainParticipant using the environment profile and a custom Listener.
+        // CustomDomainParticipantListener inherits from DomainParticipantListener.
+        CustomDomainParticipantListener custom_listener;
+        DomainParticipant* participant_with_custom_listener =
+                DomainParticipantFactory::get_instance()->create_participant_with_default_profile(
+                        &custom_listener, StatusMask::none());
+        if (nullptr == participant_with_custom_listener)
+        {
+            // Error
+            return;
+        }
+        //!--
+    }
+
+    {
         //DDS_CHANGE_DOMAINPARTICIPANTQOS
         // Create a DomainParticipant with default DomainParticipantQos
         DomainParticipant* participant =
@@ -6458,6 +6483,11 @@ void pubsub_api_example_create_entities()
     //PUBSUB_API_CREATE_PARTICIPANT
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    //!--
+
+    //PUBSUB_API_CREATE_DEFAULT_PARTICIPANT
+    DomainParticipant* default_participant =
+            DomainParticipantFactory::get_instance()->create_participant_with_default_profile();
     //!--
 
     //PUBSUB_API_CREATE_PUBLISHER

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -150,6 +150,7 @@
 .. |DomainParticipant::disable-monitor-service-api| replace:: :cpp:func:`disable_monitor_service()<eprosima::fastdds::dds::DomainParticipant::disable_monitor_service>`
 
 .. |DomainParticipantFactory-api| replace:: :cpp:class:`DomainParticipantFactory<eprosima::fastdds::dds::DomainParticipantFactory>`
+.. |DomainParticipantFactory::create_participant_with_default_profile-api| replace:: :cpp:func:`create_participant_with_default_profile()<eprosima::fastdds::dds::DomainParticipantFactory::create_participant_with_default_profile>`
 .. |DomainParticipantFactory::create_participant_with_profile-api| replace:: :cpp:func:`create_participant_with_profile()<eprosima::fastdds::dds::DomainParticipantFactory::create_participant_with_profile>`
 .. |DomainParticipantFactory::create_participant-api| replace:: :cpp:func:`create_participant()<eprosima::fastdds::dds::DomainParticipantFactory::create_participant>`
 .. |DomainParticipantFactory::delete_participant-api| replace:: :cpp:func:`delete_participant()<eprosima::fastdds::dds::DomainParticipantFactory::delete_participant>`

--- a/docs/fastdds/dds_layer/domain/domainParticipant/createDomainParticipant.rst
+++ b/docs/fastdds/dds_layer/domain/domainParticipant/createDomainParticipant.rst
@@ -88,6 +88,42 @@ It is advisable to check that the returned value is a valid pointer.
    :end-before: //!
    :dedent: 8
 
+.. _dds_layer_domainParticipant_creation_default_profile:
+
+Default profile DomainParticipant creation
+------------------------------------------
+
+If there is a profile already exported in the environment (please refer to :ref:`xml_profiles` for related
+information), creating a DomainParticipant with the
+|DomainParticipantFactory::create_participant_with_default_profile-api| member function on the
+:ref:`dds_layer_domainParticipantFactory` singleton would use that settings to configure the participant.
+If the profile has not been exported, the DomainParticipant will be created with the default values per
+:ref:`dds_layer_domainParticipantQos`, and ``0`` as |DomainId-api|.
+
+Optional arguments are:
+
+ * A Listener derived from :ref:`dds_layer_domainParticipantListener`, implementing the callbacks
+   that will be triggered in response to events and state changes on the DomainParticipant.
+   By default empty callbacks are used.
+
+ * A |StatusMask-api| that activates or deactivates triggering of individual callbacks on the
+   :ref:`dds_layer_domainParticipantListener`.
+   By default all events are enabled.
+
+|DomainParticipantFactory::create_participant_with_default_profile-api| will return a null pointer if there was an
+error during the operation.
+It is advisable to check that the returned value is a valid pointer.
+
+.. note::
+
+   XML profiles must have been loaded previously. See :ref:`xml_profiles`.
+
+.. literalinclude:: /../code/DDSCodeTester.cpp
+   :language: c++
+   :start-after: //DDS_CREATE_DOMAINPARTICIPANT_DEFAULT_PROFILE
+   :end-before: //!
+   :dedent: 8
+
 .. _dds_layer_domainParticipant_deletion:
 
 Deleting a DomainParticipant

--- a/docs/fastdds/xml_configuration/making_xml_profiles.rst
+++ b/docs/fastdds/xml_configuration/making_xml_profiles.rst
@@ -64,6 +64,11 @@ if founded.
     :end-before: //!--
     :dedent: 8
 
+For simplicity, the |DomainParticipantFactory::create_participant_with_default_profile-api| method takes the default
+profile set in the environment to create a participant.
+It requires the XML profile to have been already loaded.
+Please, refer to :ref:`xml_profiles` for further information regarding loading profiles.
+
 .. warning::
 
     It is worth mentioning that if the same XML profile file is loaded multiple times, the second loading of


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR includes documentation regarding new `DomainParticipantFactory` method that creates participants without arguments, taking relevant configuration from environment-loaded XML profiles (or default values).
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#4534

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
