### PR TITLE
[20566] Migrate classes from include/fastrtps to fastdds

### DIFF
--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -1,4 +1,6 @@
+#include <fstream>
 
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
@@ -6,7 +8,6 @@
 #include <fastdds/rtps/reader/ReaderListener.h>
 #include <fastdds/rtps/RTPSDomain.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
-#include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/utils/IPLocator.h>
 #include <fastrtps/log/Log.h>
 #include <fastrtps/log/FileConsumer.h>
@@ -15,7 +16,6 @@
 #include <fastrtps/types/DynamicTypeBuilderFactory.h>
 #include <fastrtps/types/DynamicTypeBuilderPtr.h>
 
-#include <fstream>
 
 using namespace eprosima::fastrtps;
 using namespace ::rtps;

--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -7,13 +7,13 @@
 #include <fastdds/rtps/RTPSDomain.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/utils/IPLocator.h>
 #include <fastrtps/log/Log.h>
 #include <fastrtps/log/FileConsumer.h>
 #include <fastrtps/TopicDataType.h>
 #include <fastrtps/types/DynamicDataFactory.h>
 #include <fastrtps/types/DynamicTypeBuilderFactory.h>
 #include <fastrtps/types/DynamicTypeBuilderPtr.h>
-#include <fastrtps/utils/IPLocator.h>
 
 #include <fstream>
 

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -40,6 +40,7 @@
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
+#include <fastdds/utils/IPLocator.h>
 #include <fastdds/statistics/dds/domain/DomainParticipant.hpp>
 #include <fastdds/statistics/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/statistics/topic_names.hpp>
@@ -47,7 +48,6 @@
 #include <fastrtps/types/DynamicTypeBuilderFactory.h>
 #include <fastrtps/types/DynamicTypeBuilderPtr.h>
 #include <fastrtps/types/DynamicTypePtr.h>
-#include <fastrtps/utils/IPLocator.h>
 
 
 using namespace eprosima::fastdds::dds;

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -40,10 +40,10 @@
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
-#include <fastdds/utils/IPLocator.h>
 #include <fastdds/statistics/dds/domain/DomainParticipant.hpp>
 #include <fastdds/statistics/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/statistics/topic_names.hpp>
+#include <fastdds/utils/IPLocator.h>
 #include <fastrtps/types/DynamicDataFactory.h>
 #include <fastrtps/types/DynamicTypeBuilderFactory.h>
 #include <fastrtps/types/DynamicTypeBuilderPtr.h>

--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.h
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.h
@@ -27,7 +27,7 @@
 #include <fastdds/dds/topic/TopicDataType.hpp>
 #include <fastdds/rtps/common/InstanceHandle.h>
 #include <fastdds/rtps/common/SerializedPayload.h>
-#include <fastrtps/utils/md5.h>
+#include <fastdds/utils/md5.h>
 
 #include "HelloWorld.h"
 

--- a/docs/fastdds/api_reference/spelling_wordlist.txt
+++ b/docs/fastdds/api_reference/spelling_wordlist.txt
@@ -3,6 +3,7 @@ ACKs
 addReaderLocator
 addReaderProxy
 addWriterProxy
+allowlist
 assignability
 autodispose
 autoenable
@@ -94,6 +95,8 @@ mutexes
 myFilterFactory
 nackResponseDelay
 nackSupressionDuration
+netmask
+Netmask
 NonConstEnabler
 NoOpDomainParticipantListener
 nullptr


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR migrates the following classes from include/fastrtps to fastdds:
 -  IPLocator.h
 -  md5.h

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#4518


## Contributor Checklist

- N/A Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- N/A Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
