### PR TITLE
[20551] Improve python bindings documentation

### DIFF
--- a/docs/fastddsgen/python_bindings/python_bindings.rst
+++ b/docs/fastddsgen/python_bindings/python_bindings.rst
@@ -13,6 +13,10 @@ Calling *eProsima Fast DDS-Gen* with the option `-python` will generate these fi
 first generating C++ files (for connecting C++ and Python) and Python files (Python module for your type) and
 then compiling the C++ sources.
 
+.. note::
+
+    The Python bindings does not support the use of namespaces.
+
 Before calling CMake, the :ref:`fastddsgen_python_build` process needs several :ref:`fastddsgen_python_deps` to be met.
 
 .. _fastddsgen_python_deps:
@@ -44,6 +48,11 @@ Call CMake:
 
 This will create the Python files (`.py`) with the modules (one per each IDL file) that have to be imported within the
 Python script.
+
+.. note::
+
+    The python bindings does not support using different modules in the same idl file.
+    Split them in different files for expected behavior.
 
 .. External links
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adds a couple of notes improving python binding documentation regarding modules and namespaces
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes eProsima/Fast-DDS-python#105

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
