### PR TITLE
[20501] Clarify how sockets_size affects SHM segment size

### DIFF
--- a/docs/fastdds/use_cases/tcp/tcp_large_data_with_options.rst
+++ b/docs/fastdds/use_cases/tcp/tcp_large_data_with_options.rst
@@ -21,6 +21,7 @@ All builtin transports can be configured by adjusting the following parameters:
   Its maximum value is (2^32)-1 B for TCP and SHM and 65500 KB for UDP.
 + ``sockets_size``: Size of the send and receive socket buffers.
   This value must be higher or equal than the ``max_msg_size`` to obtain a valid configuration.
+  It also defines the size of the shared memory segment, calculated as twice the value set.
   Its maximum value is (2^32)-1 B.
 + ``non_blocking``: If set to true, the transport will use non-blocking sockets.
   This can be useful to avoid blocking the application if the socket buffers are full.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR specifies how the sockets_size parameter in the builtin transports options affects the shared memory segment size. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
