### PR TITLE
[20029] Update 2.12.2 release notes

### DIFF
--- a/docs/notes/previous_versions/previous_versions.rst
+++ b/docs/notes/previous_versions/previous_versions.rst
@@ -4,6 +4,7 @@ Previous end-of-life versions
 Version 2.12 (EOL)
 ------------------
 
+.. include:: v2.12.2.rst
 .. include:: v2.12.1.rst
 .. include:: v2.12.0.rst
 

--- a/docs/notes/previous_versions/v2.12.2.rst
+++ b/docs/notes/previous_versions/v2.12.2.rst
@@ -1,0 +1,61 @@
+`Version 2.12.2 (EOL) <https://fast-dds.docs.eprosima.com/en/v2.12.2/index.html>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This release includes the following **features**:
+
+1. Methods to configure :ref:`transport scenarios <rtps_layer_builtin_transports>`
+2. Support ``Autofill port`` (:ref:`automatically set the port <transport_tcp_transportDescriptor>`) for TCP Transport
+3. Support :ref:`TCP for Discovery Server <use-case-tcp-discovery-server>` CLI and environment variable
+4. Define a :ref:`super client by environment variable <env_vars_ros_super_client>`
+5. Change serialize function default behaviour to omit the data representation
+6. ``LARGE_DATA`` Participants logic with same listening ports
+7. TCP Client&Server Participant Decision-Making logic
+8. Expose :ref:`Authentication Handshake Properties <property_policies_security>`
+9. Enabling multiple interfaces through whitelist in TCP servers
+10. Add macOS and Ubuntu Github CI
+
+This release includes the following **improvements**:
+
+1. Improve environment variable substitution algorithm
+2. Upgrade dependency version to last patch version in .repos file
+3. Rerun failed tests with ctest option instead of colcon's
+4. Remove unnecessary TCP warning
+5. Update PR template to include check for PR description, title and backports
+6. Improvements in GitHub CI
+
+This release includes the following **fixes**:
+
+1. Fix TCP reconnection after open logical port failure
+2. TCP unique client announced local port
+3. TCP non-blocking send
+4. Fix wrong log info messages on TCP
+5. Improve ``IgnoreNonExistentSegment`` test
+6. Use ``SO_EXCLUSIVEADDRUSE`` for Win32 unicast listening sockets
+7. Fix DNS filter in CMakeLists file for tests
+8. Fix bad-free when receiving malformed DATA_FRAG submessage
+9. Fix memory problem related to ciphering payload
+10. Fix CVE-2023-50257
+11. Fix build with TLS, but not security
+12. Fix comparison in ``remove_from_pdp_reader_history``
+13. Fix data race in ``PDPListener`` and ``SecurityManager``
+14. Discard already processed samples on ``PDPListener``
+15. Fix .repos versions
+16. Fix the shared memory cleaning script
+17. Fix data race on writer destruction while sending heartbeat
+18. Return ``const`` reference to the shared pointer instead of a copy in ``get_log_resources``
+19. Ignore ``0x8007`` if coming from other vendor
+20. Fix Doxygen docs warnings and prepare for compiling with Doxygen 1.10.0
+21. Include variety of terminate process signals handler in discovery server
+22. Add missing ``TypeLookup`` listeners
+23. Add a keyed fragmented change to the reader data instance only when its completed
+24. Fix data race on PDP
+25. Check History QoS inconsistencies
+26. Make DataWriters always send the key hash on keyed topics
+27. Prevent index overflow and correctly assert the end iterator in DataSharing
+28. Fix uninitialized member in ``RTPSParticipantAttributes``
+29. Remove unnecessary ``std::move`` in ``FileWatch.hpp`` causing warning
+30. Add missing thread include
+31. Add missing virtual destructor for ``StatisticsAncillary``
+32. Protect asio exception
+33. ``TCPSendResources`` cleanup
+34. Downgrade CMake version to 3.20


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR update 2.12.2 release notes
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- N/A Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
