### PR TITLE
[20567] Remove LivelinessData from API reference

### DIFF
--- a/docs/fastdds/api_reference/rtps/writer/LivelinessData.rst
+++ b/docs/fastdds/api_reference/rtps/writer/LivelinessData.rst
@@ -1,8 +1,0 @@
-.. rst-class:: api-ref
-
-LivelinessData
-------------------------------------------------
-
-.. doxygenstruct:: eprosima::fastrtps::rtps::LivelinessData
-    :project: FastDDS
-    :members:

--- a/docs/fastdds/api_reference/rtps/writer/writer.rst
+++ b/docs/fastdds/api_reference/rtps/writer/writer.rst
@@ -5,6 +5,5 @@ RTPSWriter
 
 .. toctree::
 
-    /fastdds/api_reference/rtps/writer/LivelinessData.rst
     /fastdds/api_reference/rtps/writer/RTPSWriter.rst
     /fastdds/api_reference/rtps/writer/WriterListener.rst


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR removes `LivelinessData` from the API reference since it is made private in:

* eProsima/Fast-DDS#4545

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_: Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
