### PR TITLE
[20709] Remove RTPSMessageGroup from aliases-api includes

### DIFF
--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -1032,7 +1032,6 @@
 
 .. |MonitorServiceDataReaderQos-api| replace:: :cpp:class:`MonitorServiceDataReaderQos <eprosima::fastdds::statistics::dds::MonitorServiceDataReaderQos>`
 
-.. |RTPSMessageGroup| replace:: :cpp:class:`RTPSMessageGroup <eprosima::fastrtps::rtps::RTPSMessageGroup>`
 .. |MessageReceiver| replace:: :cpp:class:`MessageReceiver <eprosima::fastrtps::rtps::MessageReceiver>`
 
 .. |WriteParams-api| replace:: :cpp:class:`WriteParams <eprosima::fastrtps::rtps::WriteParams>`

--- a/docs/fastdds/statistics/dds_layer/topic_names.rst
+++ b/docs/fastdds/statistics/dds_layer/topic_names.rst
@@ -66,8 +66,8 @@ the corresponding user's callback.
 The ``_fastdds_statistics_network_latency`` statistics topic collects data related with the network latency (expressed
 in *ns*) between any two communicating locators.
 This measurement provides information about the transport layer latency.
-The measured latency corresponds to the time spent between the message being written in the |RTPSMessageGroup| until the
-message being received in the |MessageReceiver|.
+The measured latency corresponds to the time spent between the message being written until the message being received
+in the |MessageReceiver|.
 
 .. important::
     In the case of :ref:`transport_tcp_tcp`, the reported latency also includes the time spent on the datagram's CRC


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Remove RTPSMessageGroup from aliases-api includes.
Related PR in Fast DDS:
* https://github.com/eProsima/Fast-DDS/pull/4657
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- N/A Code snippets related to the added documentation have been provided.
- N/A Documentation tests pass locally.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
