### PR TITLE
[20733] Document how to annotate members as key in XML types

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -4358,6 +4358,9 @@
 </struct>
 <!--><-->
 <struct name="MembersExample">
+<!-->XML-MEMBER_WITH_KEY<-->
+<member name="my_long" type="int32" key="true"/>
+<!--><-->
 <!-->XML-BOUNDEDSTRINGS<-->
 <member name="my_large_string" type="string" stringMaxLength="41925"/>
 <member name="my_large_wstring" type="wstring" stringMaxLength="20925"/>

--- a/docs/fastdds/xml_configuration/dynamic_types.rst
+++ b/docs/fastdds/xml_configuration/dynamic_types.rst
@@ -60,6 +60,12 @@ Member types
 Member types are defined as any type that can belong to a `Struct`_ or a `Union`_, or be aliased by a
 `Typedef`_.
 These can be defined by the ``<member>`` XML tag.
+A member can be annotated as ``key`` (equivalent of the IDL's ``@key``) by setting the ``key`` attribute to ``"true"``.
+
+.. literalinclude:: /../code/XMLTester.xml
+  :language: xml
+  :start-after: <!-->XML-MEMBER_WITH_KEY<-->
+  :end-before: <!--><-->
 
 Primitive types
 ***************


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR documents how to annotate members as key in XML types (`@key` equivalent)

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#4694


## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
