### PR TITLE
[20861] Add DATAREADER_QOS_USE_TOPIC_QOS and DATAWRITER_QOS_USE_TOPIC_QOS

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -2571,6 +2571,18 @@ void dds_dataWriter_examples()
             // Error
             return;
         }
+
+        // Create a DataWriter with default QoS and a custom TopicQos.
+        // The value DATAWRITER_QOS_USE_TOPIC_QOS is used to denote the default QoS
+        // and to override the TopicQos.
+        Topic* topic;
+        DataWriter* data_writer_with_default_qos_and_custom_topic_qos =
+                publisher->create_datawriter(topic, DATAWRITER_QOS_USE_TOPIC_QOS);
+        if (nullptr == data_writer_with_default_qos_and_custom_topic_qos)
+        {
+            // Error
+            return;
+        }
         //!--
     }
 
@@ -3360,6 +3372,18 @@ void dds_dataReader_examples()
         DataReader* data_reader_with_default_qos_and_custom_listener =
                 subscriber->create_datareader(topic, DATAREADER_QOS_DEFAULT, &custom_listener);
         if (nullptr == data_reader_with_default_qos_and_custom_listener)
+        {
+            // Error
+            return;
+        }
+
+        // Create a DataReader with default QoS and a custom TopicQos.
+        // The value DATAREADER_QOS_USE_TOPIC_QOS is used to denote the default QoS
+        // and to override the TopicQos.
+        Topic* topic;
+        DataReader* data_reader_with_default_qos_and_custom_topic_qos =
+                subscriber->create_datareader(topic, DATAREADER_QOS_USE_TOPIC_QOS);
+        if (nullptr == data_reader_with_default_qos_and_custom_topic_qos)
         {
             // Error
             return;

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -815,6 +815,8 @@
 .. |TOPIC_QOS_DEFAULT-api| replace:: :cpp:member:`TOPIC_QOS_DEFAULT <eprosima::fastdds::dds::TOPIC_QOS_DEFAULT>`
 .. |DATAWRITER_QOS_DEFAULT-api| replace:: :cpp:member:`DATAWRITER_QOS_DEFAULT <eprosima::fastdds::dds::DATAWRITER_QOS_DEFAULT>`
 .. |DATAREADER_QOS_DEFAULT-api| replace:: :cpp:member:`DATAREADER_QOS_DEFAULT <eprosima::fastdds::dds::DATAREADER_QOS_DEFAULT>`
+.. |DATAWRITER_QOS_USE_TOPIC_QOS-api| replace:: :cpp:member:`DATAWRITER_QOS_USE_TOPIC_QOS <eprosima::fastdds::dds::DATAWRITER_QOS_USE_TOPIC_QOS>`
+.. |DATAREADER_QOS_USE_TOPIC_QOS-api| replace:: :cpp:member:`DATAREADER_QOS_USE_TOPIC_QOS <eprosima::fastdds::dds::DATAREADER_QOS_USE_TOPIC_QOS>`
 
 .. |DomainId-api| replace:: :cpp:type:`DomainId <eprosima::fastdds::dds::DomainId_t>`
 .. |c_InstanceHandle_Unknown-api| replace:: :cpp:member:`c_InstanceHandle_Unknown <eprosima::fastrtps::rtps::c_InstanceHandle_Unknown>`

--- a/docs/fastdds/api_reference/dds_pim/publisher/datawriterqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/publisher/datawriterqos.rst
@@ -11,3 +11,6 @@ DataWriterQos
 
 .. doxygenvariable:: eprosima::fastdds::dds::DATAWRITER_QOS_DEFAULT
     :project: FastDDS
+
+.. doxygenvariable:: eprosima::fastdds::dds::DATAWRITER_QOS_USE_TOPIC_QOS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/subscriber/datareaderqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/datareaderqos.rst
@@ -11,3 +11,6 @@ DataReaderQos
 
 .. doxygenvariable:: eprosima::fastdds::dds::DATAREADER_QOS_DEFAULT
     :project: FastDDS
+
+.. doxygenvariable:: eprosima::fastdds::dds::DATAREADER_QOS_USE_TOPIC_QOS
+    :project: FastDDS

--- a/docs/fastdds/dds_layer/publisher/dataWriter/createDataWriter.rst
+++ b/docs/fastdds/dds_layer/publisher/dataWriter/createDataWriter.rst
@@ -17,6 +17,9 @@ Mandatory arguments are:
  * The :ref:`dds_layer_publisher_dataWriterQos` describing the behavior of the DataWriter.
    If the provided value is :class:`DATAWRITER_QOS_DEFAULT`,
    the value of the :ref:`dds_layer_defaultDataWriterQos` is used.
+   If the provided value is :class:`DATAWRITER_QOS_USE_TOPIC_QOS`,
+   the values of the default QoS and the provided TopicQoS are used, whereby any policy
+   that is set on the TopicQoS overrides the corresponding policy on the default QoS.
 
 Optional arguments are:
 

--- a/docs/fastdds/dds_layer/subscriber/dataReader/createDataReader.rst
+++ b/docs/fastdds/dds_layer/subscriber/dataReader/createDataReader.rst
@@ -17,6 +17,9 @@ Mandatory arguments are:
  * The :ref:`dds_layer_subscriber_dataReaderQos` describing the behavior of the DataReader.
    If the provided value is :class:`DATAREADER_QOS_DEFAULT`,
    the value of the :ref:`dds_layer_defaultDataReaderQos` is used.
+   If the provided value is :class:`DATAREADER_QOS_USE_TOPIC_QOS`,
+   the values of the default QoS and the provided TopicQoS are used, whereby any policy
+   that is set on the TopicQoS overrides the corresponding policy on the default QoS.
 
 Optional arguments are:
 

--- a/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/publisher/datawriterqos.rst
@@ -8,3 +8,5 @@ DataWriterQos
 .. autoclass:: fastdds.DataWriterQos
 
 .. autoclass:: fastdds.DATAWRITER_QOS_DEFAULT
+
+.. autoclass:: fastdds.DATAWRITER_QOS_USE_TOPIC_QOS

--- a/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderqos.rst
+++ b/docs/fastdds/python_api_reference/dds_pim/subscriber/datareaderqos.rst
@@ -8,3 +8,5 @@ DataReaderQos
 .. autoclass:: fastdds.DataReaderQos
 
 .. autoclass:: fastdds.DATAREADER_QOS_DEFAULT
+
+.. autoclass:: fastdds.DATAREADER_QOS_USE_TOPIC_QOS

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -76,6 +76,7 @@ datarate
 datareaders
 datasharing
 Datasharing
+DDSEntityStatus
 de
 deallocate
 deallocated


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adds DATAREADER_QOS_USE_TOPIC_QOS and DATAWRITER_QOS_USE_TOPIC_QOS documentation and snippets on how to use them.
Related PR:
* eProsima/Fast-DDS/pull/4719

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
