### PR TITLE
[20825] Include v2.6.8 release notes

### DIFF
--- a/docs/notes/previous_versions/supported_versions.rst
+++ b/docs/notes/previous_versions/supported_versions.rst
@@ -25,6 +25,7 @@ Version 2.10
 Version 2.6
 -----------
 
+.. include:: v2.6.8.rst
 .. include:: v2.6.7.rst
 .. include:: v2.6.6.rst
 .. include:: v2.6.5.rst

--- a/docs/notes/previous_versions/v2.6.8.rst
+++ b/docs/notes/previous_versions/v2.6.8.rst
@@ -1,0 +1,62 @@
+`Version 2.6.8 <https://fast-dds.docs.eprosima.com/en/v2.6.8/index.html>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This release includes the following **features**:
+
+#. :ref:`Authentication Handshake Properties <property_policies_security>` documentation.
+#. TCP Client and Server Participant Decision Making.
+
+This release includes the following **improvements**:
+
+#. Make DataWriters always send the key hash on keyed topics.
+#. Include variety of terminate process signals handler in discovery server.
+#. Effectively assert ``AUTOMATIC/MANUAL_BY_PARTICIPANT`` liveliness.
+#. Pick smallest available participant ID for new participants.
+#. Check History QoS inconsistencies.
+#. Add check for XML API to PR template.
+#. ``LARGE_DATA`` Participants logic with same listening ports.
+
+TCP transport improvements:
+
+#. TCP unique client announced local port.
+#. Remove unnecessary TCP warning and Fix some tests.
+#. TCP ``non-blocking`` send.
+#. Enabling multiple interfaces through whitelist in TCP servers.
+#. Set real TCP ``non-blocking-send`` limitation.
+
+Github CI management:
+
+#. Refactor Github CI sanitizer related jobs.
+#. Avoid running GitHub CI if PR has conflicts.
+#. Add manual Ubuntu Github CI.
+#. Improve CI version management.
+#. Build ``ShapesDemo`` on Ubuntu Github CI.
+#. Only run PRs CI when review is requested.
+#. Add macOS and Ubuntu Github CI.
+#. Build Fast DDS Python bindings in Fast DDS Docs Github CI job.
+#. Pin CMake version and ``vm.mmap_rnd_bits`` in sanitizer workflows.
+
+This release includes the following **fixes**:
+
+#. Fix and refactor Windows Github CI.
+#. Fix max clash with Windows CI.
+#. Fix the shared memory cleaning script.
+#. Fix doxygen docs warnings. Prepare for compiling with ``Doxygen 1.10.0``.
+#. Prevent index overflow and correctly assert the end iterator in DataSharing.
+#. Add a keyed fragmented change to the reader data instance only when its completed.
+#. Add missing virtual destructor for ``StatisticsAncillary``.
+#. Fix wrong log info messages on TCP.
+#. Migrate apt package installation action to ``eProsima-CI``.
+#. Fix CI documentation workflow label triggering.
+#. Upgrade dependency version to last patch version in ``.repos`` file.
+#. Fix ``CVE-2024-28231``
+#. Fix data race on PDP.
+#. Discard already processed samples on PDPListener.
+#. Fix flaky Log tests.
+#. Add missing ``TypeLookup`` listeners.
+#. Fix hidden overloaded virtual methods.
+#. Fix TCP reconnection after open logical port failure.
+#. Fix ``CVE-2024-30258 / CVE-2024-30259``
+#. Make :cpp:func:`DataReader::get_first_untaken_info()<eprosima::fastdds::dds::DataReader::get_first_untaken_info>` coherent with ``read()/take()``.
+#. Removed warning in ``ParameterList``.
+#. TCP avoid first message loss.

--- a/docs/notes/versions.rst
+++ b/docs/notes/versions.rst
@@ -314,9 +314,9 @@ The following table shows the corresponding versions of the Fast DDS library dep
             * - Product
               - Related version
             * - `Fast CDR <https://github.com/eProsima/Fast-CDR/>`__
-              - `v1.0.24 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.0.24>`__
+              - `v1.0.28 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.0.28>`__
             * - `Foonathan Memory Vendor <https://github.com/eProsima/foonathan_memory_vendor/>`__
-              - `v1.2.1 <https://github.com/eProsima/foonathan_memory_vendor/releases/tag/v1.2.1>`__
+              - `v1.2.2 <https://github.com/eProsima/foonathan_memory_vendor/releases/tag/v1.2.2>`__
             * - `Asio <https://github.com/chriskohlhoff/asio>`__
               - `v1.18.1 <https://github.com/chriskohlhoff/asio/tree/asio-1-18-1>`__
             * - `TinyXML2 <https://github.com/leethomason/tinyxml2>`__
@@ -390,10 +390,10 @@ Fast DDS as the core middleware.
             * - Product
               - Related version
             * - `Fast DDS Gen <https://github.com/eProsima/Fast-DDS-Gen/>`__
-              - `v2.1.2 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v2.1.2>`__
+              - `v2.1.3 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v2.1.2>`__
             * - `Fast DDS Gen - IDL parser <https://github.com/eProsima/IDL-Parser/>`__
               - `v1.2.0 <https://github.com/eProsima/IDL-Parser/releases/tag/v1.2.0>`__
             * - `Fast DDS python <https://github.com/eProsima/Fast-DDS-python/>`__
               - `v1.0.2 <https://github.com/eProsima/Fast-DDS-python/releases/tag/v1.0.2>`__
             * - `Shapes Demo <https://github.com/eProsima/ShapesDemo/>`__
-              - `v2.6.7 <https://github.com/eProsima/ShapesDemo/releases/tag/v2.6.7>`__
+              - `v2.6.8 <https://github.com/eProsima/ShapesDemo/releases/tag/v2.6.8>`__


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
