### PR TITLE
[20862] Add Reception threads configuration example

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4147,6 +4147,20 @@ void dds_qos_examples()
         thread_settings.priority = 10;
         thread_settings.affinity = 4;
         thread_settings.stack_size = 2000;
+
+        //!--
+
+        //DDS_RECEPTION_THREADS_SETTINGS
+        PortBasedTransportDescriptor::ReceptionThreadsConfigMap reception_threads_config;
+        reception_threads_config[20000].scheduling_policy = 1;
+        reception_threads_config[20000].priority = 30;
+        reception_threads_config[20000].affinity = 2;
+        reception_threads_config[20000].stack_size = 1024;
+        reception_threads_config[20001].scheduling_policy = 2;
+        reception_threads_config[20001].priority = 10;
+        reception_threads_config[20001].affinity = 6;
+        reception_threads_config[20001].stack_size = 4096;
+
         //!--
     }
 

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -242,6 +242,29 @@
 <-->
 <!--><-->
 
+<!-->CONF-COMMON-RECEPTION-THREADS-SETTINGS<-->
+<transport_descriptors>
+    <transport_descriptor>
+        <transport_id>Test</transport_id>
+        <type>UDPv4</type>
+        <reception_threads>
+            <reception_thread port="20000">
+                <scheduling_policy>1</scheduling_policy>
+                <priority>30</priority>
+                <affinity>2</affinity>
+                <stack_size>1024</stack_size>
+            </reception_thread>
+            <reception_thread port="20001">
+                <scheduling_policy>2</scheduling_policy>
+                <priority>10</priority>
+                <affinity>6</affinity>
+                <stack_size>4096</stack_size>
+            </reception_thread>
+        </reception_threads>
+    </transport_descriptor>
+</transport_descriptors>
+<!--><-->
+
 <!-->CONF-COMMON-TRANSPORT-SETTING<-->
 <transport_descriptors>
     <transport_descriptor>

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -929,7 +929,7 @@ Changing these values may require special permissions.
 * |ThreadSettings::stack_size-api|: Configures the thread's stack size in bytes.
   This value is platform specific and it is used as-is to configure the specific platform thread.
 
-The :ref:`threadsettingsqos` for reception threads in port-based transport desciptors can also be configured
+The :ref:`threadsettingsqos` for reception threads in port-based transport descriptors can also be configured
 by associating each thread-specific configuration with its corresponding port number.
 
 Example

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -929,8 +929,13 @@ Changing these values may require special permissions.
 * |ThreadSettings::stack_size-api|: Configures the thread's stack size in bytes.
   This value is platform specific and it is used as-is to configure the specific platform thread.
 
+The :ref:`threadsettingsqos` for reception threads in port-based transport desciptors can also be configured
+by associating each thread-specific configuration with its corresponding port number.
+
 Example
 """""""
+
+The following example illustrate a thread settings configuration:
 
 .. tabs::
 
@@ -949,6 +954,25 @@ Example
         :start-after: <!-->CONF-COMMON-THREAD-SETTINGS<-->
         :lines: 10,12-15,17
         :dedent: 16
+
+The subsequent example depicts a reception threads settings configuration:
+
+.. tabs::
+
+  .. tab:: C++
+
+    .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+      :language: c++
+      :dedent: 8
+      :start-after: //DDS_RECEPTION_THREADS_SETTINGS
+      :end-before: //!
+
+  .. tab:: XML
+
+    .. literalinclude:: /../code/XMLTester.xml
+        :language: xml
+        :start-after: <!-->CONF-COMMON-RECEPTION-THREADS-SETTINGS<-->
+        :end-before: <!--><-->
 
 .. _transportconfigqos:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adds reception threads configuration example to the docs.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
