### PR TITLE
[20894] Clarify DomainParticipant deletion

### DIFF
--- a/docs/fastdds/dds_layer/domain/domainParticipant/createDomainParticipant.rst
+++ b/docs/fastdds/dds_layer/domain/domainParticipant/createDomainParticipant.rst
@@ -9,6 +9,9 @@ Creating a DomainParticipant
 Creation of a :ref:`dds_layer_domainParticipant` is done with the |DomainParticipantFactory::create_participant-api|
 member function on the
 :ref:`dds_layer_domainParticipantFactory` singleton, that acts as a factory for the DomainParticipant.
+Then, when the lifecycle of the participant finishes, every participant must be deleted with
+|DomainParticipantFactory::delete_participant-api|.
+Please refer to :ref:`dds_layer_domainParticipant_deletion` for further details on the deletion of a participant.
 
 Mandatory arguments are:
 
@@ -93,16 +96,18 @@ It is advisable to check that the returned value is a valid pointer.
 Deleting a DomainParticipant
 ----------------------------
 
-A DomainParticipant can be deleted with the |DomainParticipantFactory::delete_participant-api| member function on the
+A DomainParticipant shall be deleted with the |DomainParticipantFactory::delete_participant-api| member function on the
 :ref:`dds_layer_domainParticipantFactory` singleton.
 
-.. note::
+.. important::
 
    A DomainParticipant can only be deleted if all Entities belonging to the participant
    (Publisher, Subscriber or Topic) have already been deleted.
    Otherwise, the function will issue an error and the DomainParticipant will not be deleted.
-   This can be performed by using the |DomainParticipant::delete_contained_entities-api| member function of the
-   :ref:`dds_layer_domainParticipant`.
+   This can be performed either by using the |DomainParticipant::delete_contained_entities-api| member function of the
+   :ref:`dds_layer_domainParticipant` or manually deleting each entity with the corresponding *delete_* method from the
+   DomainParticipant e.g |DomainParticipant::delete_publisher-api|, |DomainParticipant::delete_subscriber-api|,
+   |DomainParticipant::delete_topic-api|, etc.
 
 .. literalinclude:: /../code/DDSCodeTester.cpp
    :language: c++


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
