### PR TITLE
[21580] Improve `mutation_tries` documentation

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4653,7 +4653,9 @@ void dds_qos_examples()
         DomainParticipantQos participant_qos;
         // Set the guid prefix
         std::istringstream("72.61.73.70.66.61.72.6d.74.65.73.74") >> participant_qos.wire_protocol().prefix;
-        //Configure Builtin Attributes
+        // Manually set the participantId
+        participant_qos.wire_protocol().participant_id = 11;
+        // Configure Builtin Attributes
         participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
                 eprosima::fastdds::rtps::DiscoveryProtocol::SERVER;
         // Add locator to unicast list
@@ -4686,6 +4688,8 @@ void dds_qos_examples()
         participant_qos.wire_protocol().default_external_unicast_locators[1][0].push_back(external_locator);
         // Drop non matching locators
         participant_qos.wire_protocol().ignore_non_matching_locators = true;
+        // Increase mutation tries
+        participant_qos.wire_protocol().builtin.mutation_tries = 300u;
         // Use modified QoS in the creation of the DomainParticipant entity
         participant_ = factory_->create_participant(domain, participant_qos);
         //!--

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3793,6 +3793,7 @@
 <participant profile_name="UDP SERVER WP" is_default_profile="true">
     <rtps>
         <prefix>72.61.73.70.66.61.72.6d.74.65.73.74</prefix>
+        <participantID>11</participantID>
         <builtin>
             <discovery_config>
                 <discoveryProtocol>SERVER</discoveryProtocol>
@@ -3811,6 +3812,7 @@
                     <port>34567</port>
                 </udpv4>
             </metatraffic_external_unicast_locators>
+            <mutation_tries>300</mutation_tries>
         </builtin>
         <defaultUnicastLocatorList>
             <locator>

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1248,8 +1248,8 @@ List of QoS Policy data members:
      available ports for them if the amount of DomainParticipants created reaches the value of
      :cpp:var:`BuiltinAttributes::mutation_tries<eprosima::fastdds::rtps::BuiltinAttributes::mutation_tries>`
      (100 by default).
-     When it happens, the DomainParticipants will not be able to create the listening ports and will be created
-     without locators configured.
+     When that happens, the DomainParticipants will not be able to create the listening ports (this is notified
+     with a log warning) and will be created without unicast locators configured.
 
 .. _wireprotocolconfigqos_example:
 

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1243,6 +1243,16 @@ List of QoS Policy data members:
      |BuiltinAttributes::discovery_config-api| within |WireProtocolConfigQos::builtin-api| (see
      :ref:`DS_modify_server_list`).
 
+.. note::
+     In single process deployments where multiple endpoints are created within the same DomainParticipant, each of
+     them will have the same **participantId** but different *unicast locator* ports.
+     That can lead on participant creation failure if the amount of endpoints to be created reaches the value of
+     :cpp:var:`BuiltinAttributes::mutation_tries<eprosima::fastrtps::rtps::BuiltinAttributes::mutation_tries>`, due to
+     exceeding the maximum amount of mutations of the same **participantId** into different port number for the
+     *unicast locator* creation.
+
+.. _wireprotocolconfigqos_example:
+
 Example
 """""""
 
@@ -1262,4 +1272,7 @@ Example
           :language: xml
           :start-after: <!-->XML_WIRE_PROTOCOL_CONFIG_QOS<-->
           :end-before: <!--><-->
+
+.. note::
+    For extended XML information, refer to :ref:`domainparticipantconfig` and :ref:`builtin` XML sections.
 

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1244,13 +1244,12 @@ List of QoS Policy data members:
      :ref:`DS_modify_server_list`).
 
 .. note::
-     In single process deployments where multiple Datareaders and Datawriters are created within the same
-     DomainParticipant, each of them will have the same **participantId** but different *unicast locator* ports.
-     That can lead on participant creation failure if the amount of Datareaders and Datawriters to be created reaches
-     the value of
-     :cpp:var:`BuiltinAttributes::mutation_tries<eprosima::fastdds::rtps::BuiltinAttributes::mutation_tries>`, due to
-     exceeding the maximum amount of mutations of the same **participantId** into different port number for the
-     *unicast locator* creation.
+     Deployments where multiple DomainParticipants are created within the same host can lead into denying
+     available ports for them if the amount of DomainParticipants created reaches the value of
+     :cpp:var:`BuiltinAttributes::mutation_tries<eprosima::fastdds::rtps::BuiltinAttributes::mutation_tries>`
+     (100 by default).
+     When it happens, the DomainParticipants will not be able to create the listening ports and will be created
+     without locators configured.
 
 .. _wireprotocolconfigqos_example:
 

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1248,7 +1248,7 @@ List of QoS Policy data members:
      DomainParticipant, each of them will have the same **participantId** but different *unicast locator* ports.
      That can lead on participant creation failure if the amount of Datareaders and Datawriters to be created reaches
      the value of
-     :cpp:var:`BuiltinAttributes::mutation_tries<eprosima::fastrtps::rtps::BuiltinAttributes::mutation_tries>`, due to
+     :cpp:var:`BuiltinAttributes::mutation_tries<eprosima::fastdds::rtps::BuiltinAttributes::mutation_tries>`, due to
      exceeding the maximum amount of mutations of the same **participantId** into different port number for the
      *unicast locator* creation.
 

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1244,9 +1244,10 @@ List of QoS Policy data members:
      :ref:`DS_modify_server_list`).
 
 .. note::
-     In single process deployments where multiple endpoints are created within the same DomainParticipant, each of
-     them will have the same **participantId** but different *unicast locator* ports.
-     That can lead on participant creation failure if the amount of endpoints to be created reaches the value of
+     In single process deployments where multiple Datareaders and Datawriters are created within the same
+     DomainParticipant, each of them will have the same **participantId** but different *unicast locator* ports.
+     That can lead on participant creation failure if the amount of Datareaders and Datawriters to be created reaches
+     the value of
      :cpp:var:`BuiltinAttributes::mutation_tries<eprosima::fastrtps::rtps::BuiltinAttributes::mutation_tries>`, due to
      exceeding the maximum amount of mutations of the same **participantId** into different port number for the
      *unicast locator* creation.

--- a/docs/fastdds/transport/listening_locators.rst
+++ b/docs/fastdds/transport/listening_locators.rst
@@ -177,6 +177,10 @@ further configuring the :ref:`comm-transports-configuration`.
    (neither *unicast* nor *multicast*), *Fast DDS* enables one *unicast* Locator
    that will be used for peer-to-peer communication of :ref:`dds_layer_topic_topic` data.
 
+ * If the application does not define any **participantId**, *Fast DDS* will use the value given by the
+   :ref:`dds_layer_domainParticipantFactory`, which will try always to provide the lowest available value per
+   DomainParticipantFactory (per process).
+
 For example, it is possible to prevent *multicast* traffic adding a single *metatraffic unicast* Locator
 as described in :ref:`transport_disableMulticast`.
 
@@ -211,6 +215,18 @@ Well-known ports are calculated using the following predefined rules:
 The values used in these rules are explained on the following table.
 The default values can be modified using the |WireProtocolConfigQos::port-api| member of the
 :ref:`wireprotocolconfigqos` on the :ref:`dds_layer_domainParticipantQos`.
+
+.. note::
+
+    In single process deployments where multiple endpoints are created within the same DomainParticipant, each of
+    them will have the same **participantId** but different *unicast locator* ports.
+    That can lead on participant creation failure if the amount of endpoints to be created reaches the value of
+    :cpp:var:`mutation_tries<eprosima::fastrtps::rtps::BuiltinAttributes::mutation_tries>`, due to exceeding the
+    maximum amount of mutations of the same **participantId** into different port number for the *unicast locator*
+    creation.
+
+    Refer to :ref:`this example <wireprotocolconfigqos_example>` for configuring both the **participantId** and the
+    *mutation_tries* values.
 
 .. list-table:: Values used in the rules to calculate well-known ports
    :header-rows: 1

--- a/docs/fastdds/transport/listening_locators.rst
+++ b/docs/fastdds/transport/listening_locators.rst
@@ -221,7 +221,7 @@ The default values can be modified using the |WireProtocolConfigQos::port-api| m
     In single process deployments where multiple Datareaders and Datawriters are created within the same
     DomainParticipant, each of them will have the same **participantId** but different *unicast locator* ports.
     That can lead on participant creation failure if the amount of Datareaders and Datawriters to be created reaches the
-    value of :cpp:var:`mutation_tries<eprosima::fastrtps::rtps::BuiltinAttributes::mutation_tries>`, due to exceeding
+    value of :cpp:var:`mutation_tries<eprosima::fastdds::rtps::BuiltinAttributes::mutation_tries>`, due to exceeding
     the maximum amount of mutations of the same **participantId** into different port number for the *unicast locator*
     creation.
 

--- a/docs/fastdds/transport/listening_locators.rst
+++ b/docs/fastdds/transport/listening_locators.rst
@@ -218,11 +218,11 @@ The default values can be modified using the |WireProtocolConfigQos::port-api| m
 
 .. note::
 
-    In single process deployments where multiple endpoints are created within the same DomainParticipant, each of
-    them will have the same **participantId** but different *unicast locator* ports.
-    That can lead on participant creation failure if the amount of endpoints to be created reaches the value of
-    :cpp:var:`mutation_tries<eprosima::fastrtps::rtps::BuiltinAttributes::mutation_tries>`, due to exceeding the
-    maximum amount of mutations of the same **participantId** into different port number for the *unicast locator*
+    In single process deployments where multiple Datareaders and Datawriters are created within the same
+    DomainParticipant, each of them will have the same **participantId** but different *unicast locator* ports.
+    That can lead on participant creation failure if the amount of Datareaders and Datawriters to be created reaches the
+    value of :cpp:var:`mutation_tries<eprosima::fastrtps::rtps::BuiltinAttributes::mutation_tries>`, due to exceeding
+    the maximum amount of mutations of the same **participantId** into different port number for the *unicast locator*
     creation.
 
     Refer to :ref:`this example <wireprotocolconfigqos_example>` for configuring both the **participantId** and the

--- a/docs/fastdds/transport/listening_locators.rst
+++ b/docs/fastdds/transport/listening_locators.rst
@@ -222,8 +222,8 @@ The default values can be modified using the |WireProtocolConfigQos::port-api| m
      available ports for them if the amount of DomainParticipants created reaches the value of
      :cpp:var:`BuiltinAttributes::mutation_tries<eprosima::fastdds::rtps::BuiltinAttributes::mutation_tries>`
      (100 by default).
-     When it happens, the DomainParticipants will not be able to create the listening ports and will be created
-     without locators configured.
+     When that happens, the DomainParticipants will not be able to create the listening ports (this is notified
+     with a log warning) and will be created without unicast locators configured.
 
     Refer to :ref:`this example <wireprotocolconfigqos_example>` for configuring both the *mutation_tries* values.
 

--- a/docs/fastdds/transport/listening_locators.rst
+++ b/docs/fastdds/transport/listening_locators.rst
@@ -218,15 +218,14 @@ The default values can be modified using the |WireProtocolConfigQos::port-api| m
 
 .. note::
 
-    In single process deployments where multiple Datareaders and Datawriters are created within the same
-    DomainParticipant, each of them will have the same **participantId** but different *unicast locator* ports.
-    That can lead on participant creation failure if the amount of Datareaders and Datawriters to be created reaches the
-    value of :cpp:var:`mutation_tries<eprosima::fastdds::rtps::BuiltinAttributes::mutation_tries>`, due to exceeding
-    the maximum amount of mutations of the same **participantId** into different port number for the *unicast locator*
-    creation.
+     Deployments where multiple DomainParticipants are created within the same host can lead into denying
+     available ports for them if the amount of DomainParticipants created reaches the value of
+     :cpp:var:`BuiltinAttributes::mutation_tries<eprosima::fastdds::rtps::BuiltinAttributes::mutation_tries>`
+     (100 by default).
+     When it happens, the DomainParticipants will not be able to create the listening ports and will be created
+     without locators configured.
 
-    Refer to :ref:`this example <wireprotocolconfigqos_example>` for configuring both the **participantId** and the
-    *mutation_tries* values.
+    Refer to :ref:`this example <wireprotocolconfigqos_example>` for configuring both the *mutation_tries* values.
 
 .. list-table:: Values used in the rules to calculate well-known ports
    :header-rows: 1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR improves the usage and definition of `mutation_tries` and gives extra information about the `participantId` usage too.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.10.x 2.6.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Uncommenting this line when PR gets reviewed-->
Fixes eProsima/Fast-DDS#4754

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
