### PR TITLE
[20849] New `max_message_size` property to limit output datagrams size

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -903,6 +903,28 @@ void dds_domain_examples()
             "unicast");
         //!--
     }
+
+    {
+        // MAX_MESSAGE_SIZE_PROPERTY_PARTICIPANT
+        eprosima::fastrtps::rtps::RTPSParticipantAttributes part_attributes;
+
+        // Set maximum number of bytes of the datagram to be sent
+        part_attributes.properties.properties().emplace_back(
+            "fastdds.max_message_size",
+            "1200");
+        //!--
+    }
+
+    {
+        // MAX_MESSAGE_SIZE_PROPERTY_WRITER
+        eprosima::fastrtps::rtps::WriterAttributes writer_attributes;
+
+        // Set maximum number of bytes of the datagram to be sent
+        writer_attributes.endpoint.properties.properties().emplace_back(
+            "fastdds.max_message_size",
+            "1200");
+        //!--
+    }
 }
 
 //DOMAINPARTICIPANTLISTENER-DISCOVERY-CALLBACKS
@@ -4986,10 +5008,10 @@ void dynamictypes_examples()
             sequence_member_descriptor->type(DynamicTypeBuilderFactory::get_instance()->create_type(
                     type_descriptor)->build());
         */
-        
+
         // Add the sequence member to the struct
         struct_builder->add_member(sequence_member_descriptor);
-        
+
         sequence_member_descriptor = traits<MemberDescriptor>::make_shared();
         sequence_member_descriptor->name("short_sequence");
         sequence_member_descriptor->type(DynamicTypeBuilderFactory::get_instance()->create_sequence_type(
@@ -5027,7 +5049,7 @@ void dynamictypes_examples()
         int16_t out_simple_value;
         sequence_data->set_int16_value(2, in_simple_value);
         sequence_data->get_int16_value(out_simple_value, 2);
-        
+
         data->return_loaned_value(sequence_data);
         //!--
     }
@@ -5080,7 +5102,7 @@ void dynamictypes_examples()
         int32_t out_simple_value;
         array_data->set_int32_value(2, in_simple_value);
         array_data->get_int32_value(out_simple_value, 2);
-        
+
         data->return_loaned_value(array_data);
         //!--
     }
@@ -5351,7 +5373,7 @@ void dynamictypes_examples()
         // Get the loan for the bitset member
         DynamicData::_ref_type bitset_data = data->loan_value(data->get_member_id_by_name("my_bitset"));
 
-        // Set and retrieve bitfield values 
+        // Set and retrieve bitfield values
         int16_t in_value {2};
         int16_t out_value;
         bitset_data->set_int16_value(bitset_data->get_member_id_by_name("d"), in_value);

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -906,10 +906,10 @@ void dds_domain_examples()
 
     {
         // MAX_MESSAGE_SIZE_PROPERTY_PARTICIPANT
-        eprosima::fastrtps::rtps::RTPSParticipantAttributes part_attributes;
+        DomainParticipantQos pqos;
 
         // Set maximum number of bytes of the datagram to be sent
-        part_attributes.properties.properties().emplace_back(
+        pqos.properties().properties().emplace_back(
             "fastdds.max_message_size",
             "1200");
         //!--
@@ -917,10 +917,10 @@ void dds_domain_examples()
 
     {
         // MAX_MESSAGE_SIZE_PROPERTY_WRITER
-        eprosima::fastrtps::rtps::WriterAttributes writer_attributes;
+        DataWriterQos wqos;
 
         // Set maximum number of bytes of the datagram to be sent
-        writer_attributes.endpoint.properties.properties().emplace_back(
+        wqos.properties().properties().emplace_back(
             "fastdds.max_message_size",
             "1200");
         //!--

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3240,7 +3240,7 @@
     <rtps>
         <propertiesPolicy>
             <properties>
-                <!-- Avoid local matching of this participant's endpoints -->
+                <!-- Set the maximum size in bytes for all RTPS datagrams sent by the participant -->
                 <property>
                     <name>fastdds.max_message_size</name>
                     <value>1200</value>
@@ -3258,7 +3258,7 @@
 <data_writer profile_name="max_msg_size_datawriter_xml_profile">
     <propertiesPolicy>
         <properties>
-            <!-- Enable pull mode -->
+            <!-- Set the maximum size in bytes for all RTPS datagrams sent by the participant -->
             <property>
                 <name>fastdds.max_message_size</name>
                 <value>1200</value>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3232,6 +3232,42 @@
 -->
 <!--><-->
 
+<!-->MAX_MESSAGE_SIZE_PROPERTY_PARTICIPANT<-->
+<!--
+<?xml version="1.0" encoding="UTF-8" ?>
+-->
+<participant profile_name="max_message_size_participant_xml_profile">
+    <rtps>
+        <propertiesPolicy>
+            <properties>
+                <!-- Avoid local matching of this participant's endpoints -->
+                <property>
+                    <name>fastdds.max_message_size</name>
+                    <value>1200</value>
+                </property>
+            </properties>
+        </propertiesPolicy>
+    </rtps>
+</participant>
+<!--><-->
+
+<!-->MAX_MESSAGE_SIZE_PROPERTY_WRITER<-->
+<!--
+<?xml version="1.0" encoding="UTF-8" ?>
+-->
+<data_writer profile_name="max_msg_size_datawriter_xml_profile">
+    <propertiesPolicy>
+        <properties>
+            <!-- Enable pull mode -->
+            <property>
+                <name>fastdds.max_message_size</name>
+                <value>1200</value>
+            </property>
+        </properties>
+    </propertiesPolicy>
+</data_writer>
+<!--><-->
+
 <!-->FASTDDS_STATISTICS_MODULE<-->
 <participant profile_name="statistics_domainparticipant_conf_xml_profile">
     <rtps>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3258,7 +3258,7 @@
 <data_writer profile_name="max_msg_size_datawriter_xml_profile">
     <propertiesPolicy>
         <properties>
-            <!-- Set the maximum size in bytes for all RTPS datagrams sent by the participant -->
+            <!-- Set the maximum size in bytes for all RTPS datagrams sent by the writer -->
             <property>
                 <name>fastdds.max_message_size</name>
                 <value>1200</value>

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -357,8 +357,17 @@ The behavior regarding this can be configured using the property ``fastdds.shm.e
 Maximum Message Size
 ^^^^^^^^^^^^^^^^^^^^
 
-It is possible to set the maximum number of bytes of an RTPS datagram sent by an RTPSParticipant.
-The value can be set in the RTPSParticipant properties or in the RTPSWriter properties.
+One common requirement is the differentiation between the maximum size of received and sent datagrams.
+This capability is especially important in scenarios where a system might need to handle large incoming
+data sizes but should restrict the size of the data it sends to prevent overwhelming network resources
+or complying with network traffic policies. The primary attribute for controlling datagram size is
+`maxMessageSize`, which sets the upper limit for both the size of datagrams that can be received and
+those that can be sent. For applications that need to restrict the size of outgoing datagrams without
+changing the size of incoming ones, it's possible to set the new property ``fastdds.max_message_size``.
+This property allows for the specific configuration of the maximum number of bytes for datagrams that
+are sent. By configuring this property to a value lower than the smallest `maxMessageSize` across all
+transports, applications can achieve a lower sending limit while maintaining the ability to receive
+larger datagrams.
 
 .. list-table::
    :header-rows: 1
@@ -368,8 +377,12 @@ The value can be set in the RTPSParticipant properties or in the RTPSWriter prop
      - PropertyPolicyQos value
      - Default value
    * - ``"fastdds.max_message_size"``
-     - ``int32_t``
+     - ``uint32_t``
      - ``"4294967295"``
+
+.. note::
+    An invalid value of ``fastdds.max_message_size`` would log an error,
+    and the default value will be used.
 
 .. tabs::
 
@@ -389,17 +402,6 @@ The value can be set in the RTPSParticipant properties or in the RTPSWriter prop
             :end-before: <!--><-->
             :lines: 2,4-16
 
-.. list-table::
-   :header-rows: 1
-   :align: left
-
-   * - PropertyPolicyQos name
-     - PropertyPolicyQos value
-     - Default value
-   * - ``"fastdds.max_message_size"``
-     - ``int32_t``
-     - ``"4294967295"``
-
 .. tabs::
 
     .. tab:: C++
@@ -417,6 +419,3 @@ The value can be set in the RTPSParticipant properties or in the RTPSWriter prop
             :start-after: <!-->MAX_MESSAGE_SIZE_PROPERTY_WRITER<-->
             :end-before: <!--><-->
             :lines: 2,4-14
-
-.. note::
-    An invalid value of ``fastdds.max_message_size`` results in an exception.

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -360,14 +360,15 @@ Maximum Message Size
 One common requirement is the differentiation between the maximum size of received and sent datagrams.
 This capability is especially important in scenarios where a system might need to handle large incoming
 data sizes but should restrict the size of the data it sends to prevent overwhelming network resources
-or complying with network traffic policies. The primary attribute for controlling datagram size is
-`maxMessageSize`, which sets the upper limit for both the size of datagrams that can be received and
-those that can be sent. For applications that need to restrict the size of outgoing datagrams without
-changing the size of incoming ones, it's possible to set the new property ``fastdds.max_message_size``.
+or complying with network traffic policies.
+The primary attribute for controlling datagram size is `maxMessageSize`, which sets the upper limit
+for both the size of datagrams that can be received and those that can be sent.
+Property ``fastdds.max_message_size`` allows restricting the size of outgoing datagrams without
+changing the size of incoming ones.
 This property allows for the specific configuration of the maximum number of bytes for datagrams that
-are sent. By configuring this property to a value lower than the smallest `maxMessageSize` across all
-transports, applications can achieve a lower sending limit while maintaining the ability to receive
-larger datagrams.
+are sent.
+By configuring this property to a value lower than the smallest `maxMessageSize` across all transports,
+applications can achieve a lower sending limit while maintaining the ability to receive larger datagrams.
 
 .. list-table::
    :header-rows: 1
@@ -383,6 +384,11 @@ larger datagrams.
 .. note::
     An invalid value of ``fastdds.max_message_size`` would log an error,
     and the default value will be used.
+
+.. _setting_max_message_size_participant:
+
+Setting ``fastdds.max_message_size`` At Participant Level
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 .. tabs::
 
@@ -401,6 +407,11 @@ larger datagrams.
             :start-after: <!-->MAX_MESSAGE_SIZE_PROPERTY_PARTICIPANT<-->
             :end-before: <!--><-->
             :lines: 2,4-16
+
+.. _setting_max_message_size_writer:
+
+Setting ``fastdds.max_message_size`` At Writer Level
+""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 .. tabs::
 

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -351,3 +351,72 @@ The behavior regarding this can be configured using the property ``fastdds.shm.e
            :language: xml
            :start-after: <!-->XML-SHM-ENFORCE-META-TRAFFIC
            :end-before: <!--><-->
+
+.. _property_max_message_size:
+
+Maximum Message Size
+^^^^^^^^^^^^^^^^^^^^
+
+It is possible to set the maximum number of bytes of an RTPS datagram sent by an RTPSParticipant.
+The value can be set in the RTPSParticipant properties or in the RTPSWriter properties.
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - PropertyPolicyQos name
+     - PropertyPolicyQos value
+     - Default value
+   * - ``"fastdds.max_message_size"``
+     - ``int32_t``
+     - ``"4294967295"``
+
+.. tabs::
+
+    .. tab:: C++
+
+        .. literalinclude:: /../code/DDSCodeTester.cpp
+            :language: c++
+            :start-after: // MAX_MESSAGE_SIZE_PROPERTY_PARTICIPANT
+            :end-before: //!--
+            :dedent: 6
+
+    .. tab:: XML
+
+        .. literalinclude:: /../code/XMLTester.xml
+            :language: xml
+            :start-after: <!-->MAX_MESSAGE_SIZE_PROPERTY_PARTICIPANT<-->
+            :end-before: <!--><-->
+            :lines: 2,4-16
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - PropertyPolicyQos name
+     - PropertyPolicyQos value
+     - Default value
+   * - ``"fastdds.max_message_size"``
+     - ``int32_t``
+     - ``"4294967295"``
+
+.. tabs::
+
+    .. tab:: C++
+
+        .. literalinclude:: /../code/DDSCodeTester.cpp
+            :language: c++
+            :start-after: // MAX_MESSAGE_SIZE_PROPERTY_WRITER
+            :end-before: //!--
+            :dedent: 6
+
+    .. tab:: XML
+
+        .. literalinclude:: /../code/XMLTester.xml
+            :language: xml
+            :start-after: <!-->MAX_MESSAGE_SIZE_PROPERTY_WRITER<-->
+            :end-before: <!--><-->
+            :lines: 2,4-14
+
+.. note::
+    An invalid value of ``fastdds.max_message_size`` results in an exception.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adds the documentation for max_message_size property in RTPS Writer and RTPS Participant.


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#4777

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
