### PR TITLE
[20976] Remove reference to removed constant

### DIFF
--- a/docs/fastdds/api_reference/transport/transport_generic_interfaces/transport_interface.rst
+++ b/docs/fastdds/api_reference/transport/transport_generic_interfaces/transport_interface.rst
@@ -13,9 +13,6 @@ TransportInterface
 .. doxygenvariable:: eprosima::fastdds::rtps::s_maximumInitialPeersRange
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastdds::rtps::s_minimumSocketBuffer
-    :project: FastDDS
-
 .. doxygenvariable:: eprosima::fastdds::rtps::s_IPv4AddressAny
     :project: FastDDS
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Remove reference to `s_minimumSocketBuffer`, since it is being removed by eProsima/Fast-DDS#4760

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [__NO__] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
    - I edited directly in github, and forgot to reference the redmine task. I put it in the PR title, though.
- _N/A_ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
