### PR TITLE
[21077] Update Fast DDS docs QoS examples

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4520,19 +4520,6 @@ void dds_qos_examples()
     }
 
     {
-        //DDS_CHANGE_TYPE_CONSISTENCY_QOS
-        // This example only applies to DataReader entities
-        DataReaderQos reader_qos;
-        // You can change the DataRepresentationQosPolicy. For further details see DataRepresentationQosPolicySection section.
-        reader_qos.type_consistency().representation.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
-        // You can change the TypeConsistencyEnforcementQosPolicy. For further details see TypeConsistencyEnforcementQosPolicy section.
-        reader_qos.type_consistency().type_consistency.m_kind = TypeConsistencyKind::ALLOW_TYPE_COERCION;
-        // Use modified QoS in the creation of the DataReader entity
-        reader_ = subscriber_->create_datareader(topic_, reader_qos);
-        //!--
-    }
-
-    {
         //DDS_CHANGE_WIRE_PROTOCOL_CONFIG_QOS
         // This example only applies to DomainParticipant entities
         DomainParticipantQos participant_qos;

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -3970,6 +3970,9 @@ public:
 void dds_qos_examples()
 {
     // Taken out of the examples to avoid bloating them
+    // Note that the following lines are included to make these examples compilable and more readable.
+    // In a real application, calling creation functions multiple times on the same pointer should
+    // be avoided, as this can lead to memory leaks. It is more robust to use unique_ptrs if necessary.
     DomainParticipantFactory* factory_ = DomainParticipantFactory::get_instance();
     DomainParticipant* participant_ = factory_->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     Subscriber* subscriber_ =
@@ -3998,7 +4001,7 @@ void dds_qos_examples()
         //DDS_CHANGE_DURABILITY_QOS_POLICY
         // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
-        // The DurabilityQosPolicy is default constructed with kind = VOLATILE_DURABILITY_QOS
+        // The DurabilityQosPolicy is constructed with kind = VOLATILE_DURABILITY_QOS by default
         // Change the kind to TRANSIENT_LOCAL_DURABILITY_QOS
         writer_qos.durability().kind = TRANSIENT_LOCAL_DURABILITY_QOS;
         // Use modified QoS in the creation of the corresponding entity
@@ -4011,7 +4014,7 @@ void dds_qos_examples()
         // This example uses a Participant, but it can also be applied to
         // DomainParticipantFactory, Publisher and Subscriber entities
         DomainParticipantQos participant_qos;
-        // The EntityFactoryQosPolicy is default constructed with autoenable_created_entities = true
+        // The EntityFactoryQosPolicy is constructed with autoenable_created_entities = true by default
         // Change it to false
         participant_qos.entity_factory().autoenable_created_entities = false;
         // Use modified QoS in the creation of the corresponding entity
@@ -4023,7 +4026,7 @@ void dds_qos_examples()
         //DDS_CHANGE_GROUP_DATA_QOS_POLICY
         // This example uses a Publisher, but it can also be applied to Subscriber entities
         PublisherQos publisher_qos;
-        // The GroupDataQosPolicy is default constructed with an empty collection
+        // The GroupDataQosPolicy is constructed with an empty collection by default
         // Collection is a private member so you need to use getters and setters to access
 
         // Add data to the collection in initialization
@@ -4051,7 +4054,7 @@ void dds_qos_examples()
         //DDS_CHANGE_HISTORY_QOS_POLICY
         // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
-        // The HistoryQosPolicy is default constructed with kind = KEEP_LAST and depth = 1.
+        // The HistoryQosPolicy is constructed with kind = KEEP_LAST and depth = 1 by default
         // It is possible to adjust the depth and keep the kind as KEEP_LAST
         writer_qos.history().depth = 20;
         // Or you can also change the kind to KEEP_ALL (depth will not be used).
@@ -4065,7 +4068,7 @@ void dds_qos_examples()
         //DDS_CHANGE_LIFESPAN_QOS_POLICY
         // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
-        // The LifespanQosPolicy is default constructed with duration set to infinite.
+        // The LifespanQosPolicy is constructed with duration set to infinite by default
         // Change the duration to 5 s
         writer_qos.lifespan().duration = {5, 0};
         // Use modified QoS in the creation of the corresponding entity
@@ -4077,13 +4080,13 @@ void dds_qos_examples()
         //DDS_CHANGE_LIVELINESS_QOS_POLICY
         // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
-        // The LivelinessQosPolicy is default constructed with kind = AUTOMATIC
+        // The LivelinessQosPolicy is constructed with kind = AUTOMATIC by default
         // Change the kind to MANUAL_BY_PARTICIPANT
         writer_qos.liveliness().kind = MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
-        // The LivelinessQosPolicy is default constructed with lease_duration set to infinite
+        // The LivelinessQosPolicy is constructed with lease_duration set to infinite by default
         // Change the lease_duration to 1 second
         writer_qos.liveliness().lease_duration = {1, 0};
-        // The LivelinessQosPolicy is default constructed with announcement_period set to infinite
+        // The LivelinessQosPolicy is constructed with announcement_period set to infinite by default
         // Change the announcement_period to 1 ms
         writer_qos.liveliness().announcement_period = {0, 1000000};
         // Use modified QoS in the creation of the corresponding entity
@@ -4095,7 +4098,7 @@ void dds_qos_examples()
         //DDS_CHANGE_OWNERSHIP_QOS_POLICY
         // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
-        // The OwnershipQosPolicy is default constructed with kind = SHARED.
+        // The OwnershipQosPolicy is constructed with kind = SHARED by default
         // Change the kind to EXCLUSIVE
         writer_qos.ownership().kind = EXCLUSIVE_OWNERSHIP_QOS;
         // Use modified QoS in the creation of the corresponding entity
@@ -4107,7 +4110,7 @@ void dds_qos_examples()
         //DDS_CHANGE_OWNERSHIP_STRENGTH_QOS_POLICY
         // This example only applies to DataWriter entities
         DataWriterQos writer_qos;
-        // The OwnershipStrengthQosPolicy is default constructed with value 0
+        // The OwnershipStrengthQosPolicy is constructed with value 0 by default
         // Change the strength to 10
         writer_qos.ownership_strength().value = 10;
         // Use modified QoS in the creation of the corresponding DataWriter
@@ -4119,11 +4122,11 @@ void dds_qos_examples()
         //DDS_CHANGE_PARTITION_QOS_POLICY
         // This example uses a Publisher, but it can also be applied to Subscriber entities
         PublisherQos publisher_qos;
-        // The PartitionsQosPolicy is default constructed with max_size = 0
+        // The PartitionsQosPolicy is constructed with max_size = 0 by default
         // Max_size is a private member so you need to use getters and setters to access
         // Change the max_size to 20
         publisher_qos.partition().set_max_size(20); // Setter function
-        // The PartitionsQosPolicy is default constructed with an empty list of partitions
+        // The PartitionsQosPolicy is constructed with an empty list of partitions by default
         // Partitions is a private member so you need to use getters and setters to access
 
         // Add new partitions in initialization
@@ -4147,10 +4150,10 @@ void dds_qos_examples()
         //DDS_CHANGE_RELIABILITY_QOS_POLICY
         // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
-        // The ReliabilityQosPolicy is default constructed with kind = BEST_EFFORT
+        // The ReliabilityQosPolicy is constructed with kind = BEST_EFFORT by default
         // Change the kind to RELIABLE
         writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-        // The ReliabilityQosPolicy is default constructed with max_blocking_time = 100ms
+        // The ReliabilityQosPolicy is constructed with max_blocking_time = 100ms by default
         // Change the max_blocking_time to 1s
         writer_qos.reliability().max_blocking_time = {1, 0};
         // Use modified QoS in the creation of the corresponding entity
@@ -4162,16 +4165,16 @@ void dds_qos_examples()
         //DDS_CHANGE_RESOURCE_LIMITS_QOS_POLICY
         // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
-        // The ResourceLimitsQosPolicy is default constructed with max_samples = 5000
+        // The ResourceLimitsQosPolicy is constructed with max_samples = 5000 by default
         // Change max_samples to 200
         writer_qos.resource_limits().max_samples = 200;
-        // The ResourceLimitsQosPolicy is default constructed with max_instances = 10
+        // The ResourceLimitsQosPolicy is constructed with max_instances = 10 by default
         // Change max_instances to 20
         writer_qos.resource_limits().max_instances = 20;
-        // The ResourceLimitsQosPolicy is default constructed with max_samples_per_instance = 400
+        // The ResourceLimitsQosPolicy is constructed with max_samples_per_instance = 400 by default
         // Change max_samples_per_instance to 100 as it must be lower than max_samples
         writer_qos.resource_limits().max_samples_per_instance = 100;
-        // The ResourceLimitsQosPolicy is default constructed with allocated_samples = 100
+        // The ResourceLimitsQosPolicy is constructed with allocated_samples = 100 by default
         // Change allocated_samples to 50
         writer_qos.resource_limits().allocated_samples = 50;
         // Use modified QoS in the creation of the corresponding entity
@@ -4183,7 +4186,7 @@ void dds_qos_examples()
         //DDS_CHANGE_TOPIC_DATA_QOS_POLICY
         // This example only applies to Topic entities
         TopicQos topic_qos;
-        // The TopicDataQosPolicy is default constructed with an empty vector.
+        // The TopicDataQosPolicy is constructed with an empty vector by default
         std::vector<eprosima::fastdds::rtps::octet> vec;
         // Add two new octets to topic data vector
         eprosima::fastdds::rtps::octet val = 3;
@@ -4255,11 +4258,11 @@ void dds_qos_examples()
         // For further details see RTPSReliableWriterQos & RTPSReliableReaderQos sections.
         DataWriterQos writer_qos;
         DataReaderQos reader_qos;
-        // The DisablePositiveACKsQosPolicy is default constructed with enabled = false
+        // The DisablePositiveACKsQosPolicy is constructed with enabled = false by default
         // Change enabled to true
         writer_qos.reliable_writer_qos().disable_positive_acks.enabled = true;
         reader_qos.reliable_reader_qos().disable_positive_acks.enabled = true;
-        // The DisablePositiveACKsQosPolicy is default constructed with infinite duration
+        // The DisablePositiveACKsQosPolicy is constructed with infinite duration by default
         // Change the duration to 1 second
         writer_qos.reliable_writer_qos().disable_positive_acks.duration = {1, 0};
         reader_qos.reliable_reader_qos().disable_positive_acks.duration = {1, 0};
@@ -4277,21 +4280,21 @@ void dds_qos_examples()
         //DDS_CHANGE_RTPS_RELIABLE_WRITER_QOS
         // This example only applies to DataWriter entities
         DataWriterQos writer_qos;
-        // The RTPSReliableWriterQos is default constructed with initialHeartbeatDelay = 12 ms
+        // The RTPSReliableWriterQos is constructed with initialHeartbeatDelay = 12 ms by default
         // Change the initialHeartbeatDelay to 20 nanoseconds
         writer_qos.reliable_writer_qos().times.initialHeartbeatDelay = {0, 20};
-        // The RTPSReliableWriterQos is default constructed with heartbeatPeriod = 3 s
+        // The RTPSReliableWriterQos is constructed with heartbeatPeriod = 3 s by default
         // Change the heartbeatPeriod to 5 seconds
         writer_qos.reliable_writer_qos().times.heartbeatPeriod = {5, 0};
-        // The RTPSReliableWriterQos is default constructed with nackResponseDelay = 5 ms
+        // The RTPSReliableWriterQos is constructed with nackResponseDelay = 5 ms by default
         // Change the nackResponseDelay to 10 nanoseconds
         writer_qos.reliable_writer_qos().times.nackResponseDelay = {0, 10};
-        // The RTPSReliableWriterQos is default constructed with nackSupressionDuration = 0 s
+        // The RTPSReliableWriterQos is constructed with nackSupressionDuration = 0 s by default
         // Change the nackSupressionDuration to 20 nanoseconds
         writer_qos.reliable_writer_qos().times.nackSupressionDuration = {0, 20};
         // You can also change the DisablePositiveACKsQosPolicy. For further details see DisablePositiveACKsQosPolicy section.
         writer_qos.reliable_writer_qos().disable_positive_acks.enabled = true;
-        // The RTPSReliableWriterQos is default constructed with disable_heartbeat_piggyback = false
+        // The RTPSReliableWriterQos is constructed with disable_heartbeat_piggyback = false by default
         // Disable the heartbeat piggyback mechanism.
         writer_qos.reliable_writer_qos().disable_heartbeat_piggyback = true;
         // Use modified QoS in the creation of the DataWriter entity
@@ -4303,10 +4306,10 @@ void dds_qos_examples()
         //DDS_CHANGE_RTPS_RELIABLE_READER_QOS
         // This example only applies to DataReader entities
         DataReaderQos reader_qos;
-        // The RTPSReliableReaderQos is default constructed with initial_acknack_delay = 70 ms
+        // The RTPSReliableReaderQos is constructed with initial_acknack_delay = 70 ms by default
         // Change the initialAcknackDelay to 70 nanoseconds
         reader_qos.reliable_reader_qos().times.initial_acknack_delay = {0, 70};
-        // The RTPSReliableReaderQos is default constructed with heartbeat_response_delay = 5 ms
+        // The RTPSReliableReaderQos is constructed with heartbeat_response_delay = 5 ms by default
         // Change the heartbeatResponseDelay to 5 nanoseconds
         reader_qos.reliable_reader_qos().times.heartbeat_response_delay = {0, 5};
         // You can also change the DisablePositiveACKsQosPolicy. For further details see DisablePositiveACKsQosPolicy section.
@@ -4364,7 +4367,7 @@ void dds_qos_examples()
         //DDS_CHANGE_PUBLISH_MODE_QOS
         // This example only applies to DataWriter entities
         DataWriterQos writer_qos;
-        // The PublishModeQosPolicy is default constructed with kind = SYNCHRONOUS
+        // The PublishModeQosPolicy is constructed with kind = SYNCHRONOUS by default
         // Change the kind to ASYNCHRONOUS
         writer_qos.publish_mode().kind = ASYNCHRONOUS_PUBLISH_MODE;
         // Use modified QoS in the creation of the DataWriter entity
@@ -4431,7 +4434,7 @@ void dds_qos_examples()
         writer_qos.endpoint().user_defined_id = 3;
         // Set 4 as entity id
         writer_qos.endpoint().entity_id = 4;
-        // The RTPSWriterQos is default constructed with history_memory_policy = PREALLOCATED
+        // The RTPSWriterQos is constructed with history_memory_policy = PREALLOCATED by default
         // Change the history_memory_policy to DYNAMIC_RESERVE
         writer_qos.endpoint().history_memory_policy = eprosima::fastdds::rtps::DYNAMIC_RESERVE_MEMORY_MODE;
         // Use modified QoS in the creation of the corresponding entity
@@ -4580,7 +4583,7 @@ void dds_qos_examples()
         //DDS_CHANGE_TYPE_CONSISTENCY_ENFORCEMENT_QOS
         // This example only applies to DataReader entities
         DataReaderQos reader_qos;
-        // The TypeConsistencyEnforcementQosPolicy is default constructed with kind = ALLOW_TYPE_COERCION
+        // The TypeConsistencyEnforcementQosPolicy is constructed with kind = ALLOW_TYPE_COERCION by default
         // Change the kind to DISALLOW_TYPE_COERCION
         reader_qos.type_consistency().m_kind = TypeConsistencyKind::DISALLOW_TYPE_COERCION;
         //Configures the system to ignore the sequence sizes in assignations
@@ -6695,19 +6698,19 @@ void dds_usecase_examples()
         //CONF-MEMORY-QOS-PUBSUB
         ResourceLimitsQosPolicy resource_limits;
 
-        // The ResourceLimitsQosPolicy is default constructed with max_samples = 5000
+        // The ResourceLimitsQosPolicy is constructed with max_samples = 5000 by default
         // Change max_samples to the minimum
         resource_limits.max_samples = 1;
 
-        // The ResourceLimitsQosPolicy is default constructed with max_instances = 10
+        // The ResourceLimitsQosPolicy is constructed with max_instances = 10 by default
         // Change max_instances to the minimum
         resource_limits.max_instances = 1;
 
-        // The ResourceLimitsQosPolicy is default constructed with max_samples_per_instance = 400
+        // The ResourceLimitsQosPolicy is constructed with max_samples_per_instance = 400 by default
         // Change max_samples_per_instance to the minimum
         resource_limits.max_samples_per_instance = 1;
 
-        // The ResourceLimitsQosPolicy is default constructed with allocated_samples = 100
+        // The ResourceLimitsQosPolicy is constructed with allocated_samples = 100 by default
         // No allocated samples
         resource_limits.allocated_samples = 0;
         //!--

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -3971,370 +3971,480 @@ void dds_qos_examples()
 {
     {
         //DDS_CHANGE_DEADLINE_QOS_POLICY
-        DeadlineQosPolicy deadline;
-        //The DeadlineQosPolicy is default constructed with an infinite period.
-        //Change the period to 1 second
-        deadline.period.seconds = 1;
-        deadline.period.nanosec = 0;
+        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        DataWriterQos writer_qos;
+        // The DeadlineQosPolicy is default constructed with an infinite period.
+        // Change the period to 1 second
+        writer_qos.deadline().period.seconds = 1;
+        writer_qos.deadline().period.nanosec = 0;
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_DURABILITY_QOS_POLICY
-        DurabilityQosPolicy durability;
-        //The DurabilityQosPolicy is default constructed with kind = VOLATILE_DURABILITY_QOS
-        //Change the kind to TRANSIENT_LOCAL_DURABILITY_QOS
-        durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        DataWriterQos writer_qos;
+        // The DurabilityQosPolicy is default constructed with kind = VOLATILE_DURABILITY_QOS
+        // Change the kind to TRANSIENT_LOCAL_DURABILITY_QOS
+        writer_qos.durability().kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_ENTITY_FACTORY_QOS_POLICY
-        EntityFactoryQosPolicy entity_factory;
-        //The EntityFactoryQosPolicy is default constructed with autoenable_created_entities = true
-        //Change it to false
-        entity_factory.autoenable_created_entities = false;
+        // This example uses a Participant, but it can also be applied to:
+        // DomainParticipantFactory, DomainParticipant, Publisher and Subscriber entities
+        DomainParticipantQos participant_qos;
+        // The EntityFactoryQosPolicy is default constructed with autoenable_created_entities = true
+        // Change it to false
+        participant_qos.entity_factory().autoenable_created_entities = false;
+        // Use modified QoS in the creation of the corresponding entity
+        participant_ = factory_->create_participant(domain, participant_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_GROUP_DATA_QOS_POLICY
-        GroupDataQosPolicy group_data;
-        //The GroupDataQosPolicy is default constructed with an empty collection
-        //Collection is a private member so you need to use getters and setters to access
-        //Add data to the collection
-        std::vector<eprosima::fastdds::rtps::octet> vec;
-        vec = group_data.data_vec(); // Getter function
+        // This example uses a Publisher, but it can also be applied to: Publisher and Subscriber entities
+        PublisherQos publisher_qos;
+        // The GroupDataQosPolicy is default constructed with an empty collection
+        // Collection is a private member so you need to use getters and setters to access
 
-        //Add two new octets to group data vector
+        // Add data to the collection in initialization
+        std::vector<eprosima::fastdds::rtps::octet> vec;
+        // Add two new octets to group data vector
         eprosima::fastdds::rtps::octet val = 3;
         vec.push_back(val);
         val = 10;
         vec.push_back(val);
-        group_data.data_vec(vec); //Setter function
+        publisher_qos.group_data().data_vec(vec); // Setter function
+        // Use modified QoS in the creation of the corresponding entity
+        publisher_ = participant_->create_publisher(publisher_qos);
+
+        // Add data to the collection at runtime
+        vec = publisher_qos.group_data().data_vec(); // Getter to keep old values
+        val = 31;
+        vec.push_back(val);
+        publisher_qos.group_data().data_vec(vec); // Setter function
+        // Update the QoS in the corresponding entity
+        publisher_->set_qos(publisher_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_HISTORY_QOS_POLICY
-        HistoryQosPolicy history;
-        //The HistoryQosPolicy is default constructed with kind = KEEP_LAST and depth = 1.
-        //Change the depth to 20
-        history.depth = 20;
-        //You can also change the kind to KEEP_ALL but after that the depth will not have effect.
-        history.kind = KEEP_ALL_HISTORY_QOS;
+        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        DataWriterQos writer_qos;
+        // The HistoryQosPolicy is default constructed with kind = KEEP_LAST and depth = 1.
+        // It is possible to adjust the depth and keep the kind as KEEP_LAST
+        writer_qos.history().depth = 20;
+        // Or you can also change the kind to KEEP_ALL (depth will not be used).
+        writer_qos.history().kind = KEEP_ALL_HISTORY_QOS;
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_LIFESPAN_QOS_POLICY
-        LifespanQosPolicy lifespan;
-        //The LifespanQosPolicy is default constructed with duration set to infinite.
-        //Change the duration to 5 s
-        lifespan.duration = {5, 0};
+        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        DataWriterQos writer_qos;
+        // The LifespanQosPolicy is default constructed with duration set to infinite.
+        // Change the duration to 5 s
+        writer_qos.lifespan().duration = {5, 0};
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_LIVELINESS_QOS_POLICY
-        LivelinessQosPolicy liveliness;
-        //The LivelinessQosPolicy is default constructed with kind = AUTOMATIC
-        //Change the kind to MANUAL_BY_PARTICIPANT
-        liveliness.kind = MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
-        //The LivelinessQosPolicy is default constructed with lease_duration set to infinite
-        //Change the lease_duration to 1 second
-        liveliness.lease_duration = {1, 0};
-        //The LivelinessQosPolicy is default constructed with announcement_period set to infinite
-        //Change the announcement_period to 1 ms
-        liveliness.announcement_period = {0, 1000000};
+        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        DataWriterQos writer_qos;
+        // The LivelinessQosPolicy is default constructed with kind = AUTOMATIC
+        // Change the kind to MANUAL_BY_PARTICIPANT
+        writer_qos.liveliness().kind = MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+        // The LivelinessQosPolicy is default constructed with lease_duration set to infinite
+        // Change the lease_duration to 1 second
+        writer_qos.liveliness().lease_duration = {1, 0};
+        // The LivelinessQosPolicy is default constructed with announcement_period set to infinite
+        // Change the announcement_period to 1 ms
+        writer_qos.liveliness().announcement_period = {0, 1000000};
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_OWNERSHIP_QOS_POLICY
-        OwnershipQosPolicy ownership;
-        //The OwnershipQosPolicy is default constructed with kind = SHARED.
-        //Change the kind to EXCLUSIVE
-        ownership.kind = EXCLUSIVE_OWNERSHIP_QOS;
+        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        DataWriterQos writer_qos;
+        // The OwnershipQosPolicy is default constructed with kind = SHARED.
+        // Change the kind to EXCLUSIVE
+        writer_qos.ownership().kind = EXCLUSIVE_OWNERSHIP_QOS;
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_OWNERSHIP_STRENGTH_QOS_POLICY
-        OwnershipStrengthQosPolicy ownership_strength;
-        //The OwnershipStrengthQosPolicy is default constructed with value 0
-        //Change the strength to 10
-        ownership_strength.value = 10;
+        // This example only applies to DataWriter entities
+        DataWriterQos writer_qos;
+        // The OwnershipStrengthQosPolicy is default constructed with value 0
+        // Change the strength to 10
+        writer_qos.ownership_strength().value = 10;
+        // Use modified QoS in the creation of the corresponding DataWriter
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_PARTITION_QOS_POLICY
-        PartitionQosPolicy partitions;
-        //The PartitionsQosPolicy is default constructed with max_size = 0.
-        //Max_size is a private member so you need to use getters and setters to access
-        //Change the max_size to 20
-        partitions.set_max_size(20); //Setter function
-        //The PartitionsQosPolicy is default constructed with an empty list of partitions
-        //Partitions is a private member so you need to use getters and setters to access
-        //Add new partitions
-        std::vector<std::string> part = partitions.names(); //Getter function
+        // This example uses a Publisher, but it can also be applied to: Publisher and Subscriber entities
+        PublisherQos publisher_qos;
+        // The PartitionsQosPolicy is default constructed with max_size = 0
+        // Max_size is a private member so you need to use getters and setters to access
+        // Change the max_size to 20
+        publisher_qos.partition().set_max_size(20); // Setter function
+        // The PartitionsQosPolicy is default constructed with an empty list of partitions
+        // Partitions is a private member so you need to use getters and setters to access
+
+        // Add new partitions in initialization
+        std::vector<std::string> part;
         part.push_back("part1");
         part.push_back("part2");
-        partitions.names(part); //Setter function
+        publisher_qos.partition().names(part); // Setter function
+        // Use modified QoS in the creation of the corresponding entity
+        publisher_ = participant_->create_publisher(publisher_qos);
+
+        // Add data to the collection at runtime
+        part = publisher_qos.partition().names(); // Getter to keep old values
+        part.push_back("part3");
+        publisher_qos.partition().names(part); // Setter function
+        // Update the QoS in the corresponding entity
+        publisher_->set_qos(publisher_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_RELIABILITY_QOS_POLICY
-        ReliabilityQosPolicy reliability;
-        //The ReliabilityQosPolicy is default constructed with kind = BEST_EFFORT
-        //Change the kind to RELIABLE
-        reliability.kind = RELIABLE_RELIABILITY_QOS;
-        //The ReliabilityQosPolicy is default constructed with max_blocking_time = 100ms
-        //Change the max_blocking_time to 1s
-        reliability.max_blocking_time = {1, 0};
+        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        DataWriterQos writer_qos;
+        // The ReliabilityQosPolicy is default constructed with kind = BEST_EFFORT
+        // Change the kind to RELIABLE
+        writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+        // The ReliabilityQosPolicy is default constructed with max_blocking_time = 100ms
+        // Change the max_blocking_time to 1s
+        writer_qos.reliability().max_blocking_time = {1, 0};
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_RESOURCE_LIMITS_QOS_POLICY
-        ResourceLimitsQosPolicy resource_limits;
-        //The ResourceLimitsQosPolicy is default constructed with max_samples = 5000
-        //Change max_samples to 200
-        resource_limits.max_samples = 200;
-        //The ResourceLimitsQosPolicy is default constructed with max_instances = 10
-        //Change max_instances to 20
-        resource_limits.max_instances = 20;
-        //The ResourceLimitsQosPolicy is default constructed with max_samples_per_instance = 400
-        //Change max_samples_per_instance to 100 as it must be lower than max_samples
-        resource_limits.max_samples_per_instance = 100;
-        //The ResourceLimitsQosPolicy is default constructed with allocated_samples = 100
-        //Change allocated_samples to 50
-        resource_limits.allocated_samples = 50;
+        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        DataWriterQos writer_qos;
+        // The ResourceLimitsQosPolicy is default constructed with max_samples = 5000
+        // Change max_samples to 200
+        writer_qos.resource_limits().max_samples = 200;
+        // The ResourceLimitsQosPolicy is default constructed with max_instances = 10
+        // Change max_instances to 20
+        writer_qos.resource_limits().max_instances = 20;
+        // The ResourceLimitsQosPolicy is default constructed with max_samples_per_instance = 400
+        // Change max_samples_per_instance to 100 as it must be lower than max_samples
+        writer_qos.resource_limits().max_samples_per_instance = 100;
+        // The ResourceLimitsQosPolicy is default constructed with allocated_samples = 100
+        // Change allocated_samples to 50
+        writer_qos.resource_limits().allocated_samples = 50;
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_TOPIC_DATA_QOS_POLICY
-        //The TopicDataQosPolicy is default constructed with an empty vector.
-        TopicDataQosPolicy topic_data;
+        // This example only applies to Topic entities
+        TopicQos topic_qos;
+        // The TopicDataQosPolicy is default constructed with an empty vector.
         std::vector<eprosima::fastdds::rtps::octet> vec;
-        vec = topic_data.data_vec(); // Getter Function
-
-        //Add two new octets to topic data vector
+        // Add two new octets to topic data vector
         eprosima::fastdds::rtps::octet val = 3;
         vec.push_back(val);
         val = 10;
         vec.push_back(val);
-        topic_data.data_vec(vec); //Setter Function
+        topic_qos.topic_data().data_vec(vec); // Setter Function
+        // Use modified QoS in the creation of the corresponding Topic
+        topic_ = participant_->create_topic(topic_name, type_name, topic_qos);
         //!--
     }
-
 
     {
         //DDS_CHANGE_USER_DATA_QOS_POLICY
-        //The TopicDataQosPolicy is default constructed with an empty vector.
-        UserDataQosPolicy user_data;
+        // This example uses a DataWriter, but it can also be applied to: DomainParticipant, DataWriter, and DataReader entities
+        DataWriterQos writer_qos;
         std::vector<eprosima::fastdds::rtps::octet> vec;
-        vec = user_data.data_vec(); // Getter Function
-
-        //Add two new octets to user data vector
+        // Add two new octets to user data vector
         eprosima::fastdds::rtps::octet val = 3;
         vec.push_back(val);
         val = 10;
         vec.push_back(val);
-        user_data.data_vec(vec); //Setter Function
-        //!--
-    }
-
-    {
-        //DDS_CHANGE_DISABLE_POSITIVE_ACKS_QOS_POLICY
-        DisablePositiveACKsQosPolicy disable_acks;
-        //The DisablePositiveACKsQosPolicy is default constructed with enabled = false
-        //Change enabled to true
-        disable_acks.enabled = true;
-        //The DisablePositiveACKsQosPolicy is default constructed with infinite duration
-        //Change the duration to 1 second
-        disable_acks.duration = {1, 0};
-
+        writer_qos.user_data().data_vec(vec); // Setter Function
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_DATASHARING_QOS_POLICY
-        DataSharingQosPolicy datasharing;
+        // This example uses a DataWriter, but it can also be applied to: DataWriter and DataReader entities
+        DataWriterQos writer_qos;
 
-        // Configure the DataSharing as AUTO with two user-defined IDs
+        // DataSharing is set to AUTO by default, which means that DataSharing will be used if the topic
+        // is compatible. If no Shared Memory directory is specified, the default one will be used.
+
+        // Configure DataSharing to ON to enable DataSharing and specify the shared memory directory (mandatory)
+        writer_qos.data_sharing().on("/path/to/shared_memory/directory");
+        // Alternatively, configure DataSharing to OFF to disable it
+        writer_qos.data_sharing().off();
+
+        // Configure the DataSharing as AUTO with two user-defined IDs (can also be used with ON)
         std::vector<uint16_t> ids;
         ids.push_back(0x1234);
         ids.push_back(0xABCD);
-        datasharing.automatic(ids);
+        writer_qos.data_sharing().automatic(ids);
 
-        // Alternatively, configure with no IDs and add them afterwards
-        datasharing.automatic();
-        datasharing.add_domain_id(uint16_t(0x1234));
-        datasharing.add_domain_id(uint16_t(0xABCD));
+        // Alternatively, add them individually
+        writer_qos.data_sharing().add_domain_id(uint16_t(0x1234));
+        writer_qos.data_sharing().add_domain_id(uint16_t(0xABCD));
+        // Or you can leave the IDs empty and the system will automatically create a
+        // unique ID for the current machine
 
-        // Or you can leave the IDs empty and the system will create one for you
-        // unique for the current machine
-        datasharing.automatic();
+        // Set the maximum number of domains to 5. Setting 0 means 'unlimited'
+        writer_qos.data_sharing().set_max_domains(5);
 
         // [OPTIONAL] ThreadSettings for listening thread
-        datasharing.data_sharing_listener_thread(eprosima::fastdds::rtps::ThreadSettings{-1, 0, 0, -1});
+        writer_qos.data_sharing().data_sharing_listener_thread(eprosima::fastdds::rtps::ThreadSettings{-1, 0, 0, -1});
 
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
-        //DDS_CHANGE_PARTICIPANT_RESOURCE_LIMITS_QOS_POLICY
-        ParticipantResourceLimitsQos participant_limits;
-        //Set the maximum size of participant resource limits collection to 3 and it allocation configuration to fixed size
-        participant_limits.participants = eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(
-            3u);
-        //Set the maximum size of reader's resource limits collection to 2 and its allocation configuration to fixed size
-        participant_limits.readers = eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
-        //Set the maximum size of writer's resource limits collection to 1 and its allocation configuration to fixed size
-        participant_limits.writers = eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
-        //Set the maximum size of the partition data to 256
-        participant_limits.data_limits.max_partitions = 256u;
-        //Set the maximum size of the user data to 256
-        participant_limits.data_limits.max_user_data = 256u;
-        //Set the maximum size of the properties data to 512
-        participant_limits.data_limits.max_properties = 512u;
-        //Set the preallocated filter expression size to 512
-        participant_limits.content_filter.expression_initial_size = 512u;
-        //Set the maximum number of expression parameters to 4 and its allocation configuration to fixed size
-        participant_limits.content_filter.expression_parameters =
-                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(4u);
-        //!--
-    }
+        //DDS_CHANGE_DISABLE_POSITIVE_ACKS_QOS_POLICY
+        // This Qos has different API for DataWriter and DataReader entities, because it is accesed
+        // through the ReliableWriterQos and ReliableReaderQos respectively.
+        // For further details see RTPSReliableWriterQos & RTPSReliableReaderQos sections.
+        DataWriterQos writer_qos;
+        DataReaderQos reader_qos;
+        // The DisablePositiveACKsQosPolicy is default constructed with enabled = false
+        // Change enabled to true
+        writer_qos.reliable_writer_qos().disable_positive_acks.enabled = true;
+        reader_qos.reliable_reader_qos().disable_positive_acks.enabled = true;
+        // The DisablePositiveACKsQosPolicy is default constructed with infinite duration
+        // Change the duration to 1 second
+        writer_qos.reliable_writer_qos().disable_positive_acks.duration = {1, 0};
+        reader_qos.reliable_reader_qos().disable_positive_acks.duration = {1, 0};
 
-    {
-        //DDS_CHANGE_PROPERTY_POLICY_QOS
-        PropertyPolicyQos property_policy;
-        //Add new property for the Auth:PKI-DH plugin
-        property_policy.properties().emplace_back("dds.sec.auth.plugin", "builtin.PKI-DH");
-        //Add new property for the Access:Permissions plugin
-        property_policy.properties().emplace_back(eprosima::fastdds::rtps::Property("dds.sec.access.plugin",
-                "builtin.Access-Permissions"));
+        // Exclusively, DataWriters can additionally disable the heartbeat piggyback
+        writer_qos.reliable_writer_qos().disable_heartbeat_piggyback = true;
 
-        //Add new user custom property to send to external Participants
-        property_policy.properties().emplace_back("Custom Property Name", "Custom value", true);
-        //!--
-    }
-
-    {
-        //DDS_CHANGE_PUBLISH_MODE_QOS
-        PublishModeQosPolicy publish_mode;
-        //The PublishModeQosPolicy is default constructed with kind = SYNCHRONOUS
-        //Change the kind to ASYNCHRONOUS
-        publish_mode.kind = ASYNCHRONOUS_PUBLISH_MODE;
-        // Optionally, select the flow controller name
-        publish_mode.flow_controller_name = "example_flow_controller_name";
-        //!--
-    }
-
-    {
-        //DDS_CHANGE_READER_RESOURCE_LIMITS_QOS
-        ReaderResourceLimitsQos reader_limits;
-        //Set the maximum size for writer matched resource limits collection to 1 and its allocation configuration to fixed size
-        reader_limits.matched_publisher_allocation =
-                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
-        //!--
-    }
-
-    {
-        //DDS_CHANGE_WRITER_RESOURCE_LIMITS_QOS
-        WriterResourceLimitsQos writer_limits;
-        //Set the maximum size for reader matched resource limits collection to 3 and its allocation configuration to fixed size
-        writer_limits.matched_subscriber_allocation =
-                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
-        // Set the maximum number of writer side content filters to 1 and its allocation configuration to fixed size
-        writer_limits.reader_filters_allocation =
-                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
-        //!--
-    }
-
-    {
-        //DDS_CHANGE_RTPS_ENDPOINT_QOS
-        RTPSEndpointQos endpoint;
-        //Add new unicast locator with port 7800
-        eprosima::fastdds::rtps::Locator_t new_unicast_locator;
-        new_unicast_locator.port = 7800;
-        endpoint.unicast_locator_list.push_back(new_unicast_locator);
-        //Add new multicast locator with IP 239.255.0.4 and port 7900
-        eprosima::fastdds::rtps::Locator_t new_multicast_locator;
-        eprosima::fastdds::rtps::IPLocator::setIPv4(new_multicast_locator, "239.255.0.4");
-        new_multicast_locator.port = 7900;
-        endpoint.multicast_locator_list.push_back(new_multicast_locator);
-        // Add an external locator with IP 100.100.100.10, port 12345, mask 24, externality 1, and cost 0
-        eprosima::fastdds::rtps::LocatorWithMask external_locator;
-        external_locator.kind = LOCATOR_KIND_UDPv4;
-        external_locator.port = 12345;
-        external_locator.mask(24);
-        endpoint.external_unicast_locators[1][0].push_back(external_locator);
-        // Drop non matching locators
-        endpoint.ignore_non_matching_locators = true;
-        //Set 3 as user defined id
-        endpoint.user_defined_id = 3;
-        //Set 4 as entity id
-        endpoint.entity_id = 4;
-        //The RTPSEndpointQos is default constructed with history_memory_policy = PREALLOCATED
-        //Change the history_memory_policy to DYNAMIC_RESERVE
-        endpoint.history_memory_policy = eprosima::fastdds::rtps::DYNAMIC_RESERVE_MEMORY_MODE;
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
+        reader_ = subscriber_->create_datareader(topic_, reader_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_RTPS_RELIABLE_WRITER_QOS
-        RTPSReliableWriterQos reliable_writer_qos;
-        //The RTPSReliableWriterQos is default constructed with initialHeartbeatDelay = 12 ms
-        //Change the initialHeartbeatDelay to 20 nanoseconds
-        reliable_writer_qos.times.initialHeartbeatDelay = {0, 20};
-        //The RTPSReliableWriterQos is default constructed with heartbeatPeriod = 3 s
-        //Change the heartbeatPeriod to 5 seconds
-        reliable_writer_qos.times.heartbeatPeriod = {5, 0};
-        //The RTPSReliableWriterQos is default constructed with nackResponseDelay = 5 ms
-        //Change the nackResponseDelay to 10 nanoseconds
-        reliable_writer_qos.times.nackResponseDelay = {0, 10};
-        //The RTPSReliableWriterQos is default constructed with nackSupressionDuration = 0 s
-        //Change the nackSupressionDuration to 20 nanoseconds
-        reliable_writer_qos.times.nackSupressionDuration = {0, 20};
-        //You can also change the DisablePositiveACKsQosPolicy. For further details see DisablePositiveACKsQosPolicy section.
-        reliable_writer_qos.disable_positive_acks.enabled = true;
-        //The RTPSReliableWriterQos is default constructed with disable_heartbeat_piggyback = false
-        //Disable the heartbeat piggyback mechanism.
-        reliable_writer_qos.disable_heartbeat_piggyback = true;
+        // This example only applies to DataWriter entities
+        DataWriterQos writer_qos;
+        // The RTPSReliableWriterQos is default constructed with initialHeartbeatDelay = 12 ms
+        // Change the initialHeartbeatDelay to 20 nanoseconds
+        writer_qos.reliable_writer_qos().times.initialHeartbeatDelay = {0, 20};
+        // The RTPSReliableWriterQos is default constructed with heartbeatPeriod = 3 s
+        // Change the heartbeatPeriod to 5 seconds
+        writer_qos.reliable_writer_qos().times.heartbeatPeriod = {5, 0};
+        // The RTPSReliableWriterQos is default constructed with nackResponseDelay = 5 ms
+        // Change the nackResponseDelay to 10 nanoseconds
+        writer_qos.reliable_writer_qos().times.nackResponseDelay = {0, 10};
+        // The RTPSReliableWriterQos is default constructed with nackSupressionDuration = 0 s
+        // Change the nackSupressionDuration to 20 nanoseconds
+        writer_qos.reliable_writer_qos().times.nackSupressionDuration = {0, 20};
+        // You can also change the DisablePositiveACKsQosPolicy. For further details see DisablePositiveACKsQosPolicy section.
+        writer_qos.reliable_writer_qos().disable_positive_acks.enabled = true;
+        // The RTPSReliableWriterQos is default constructed with disable_heartbeat_piggyback = false
+        // Disable the heartbeat piggyback mechanism.
+        writer_qos.reliable_writer_qos().disable_heartbeat_piggyback = true;
+        // Use modified QoS in the creation of the DataWriter entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_RTPS_RELIABLE_READER_QOS
-        RTPSReliableReaderQos reliable_reader_qos;
-        //The RTPSReliableReaderQos is default constructed with initial_acknack_delay = 70 ms
-        //Change the initial_acknack_delay to 70 nanoseconds
-        reliable_reader_qos.times.initial_acknack_delay = {0, 70};
-        //The RTPSReliableWriterQos is default constructed with heartbeat_response_delay = 5 ms
-        //Change the heartbeat_response_delay to 5 nanoseconds
-        reliable_reader_qos.times.heartbeat_response_delay = {0, 5};
-        //You can also change the DisablePositiveACKsQosPolicy. For further details see DisablePositiveACKsQosPolicy section.
-        reliable_reader_qos.disable_positive_ACKs.enabled = true;
+        // This example only applies to DataReader entities
+        DataReaderQos reader_qos;
+        // The RTPSReliableReaderQos is default constructed with initial_acknack_delay = 70 ms
+        // Change the initialAcknackDelay to 70 nanoseconds
+        reader_qos.reliable_reader_qos().times.initial_acknack_delay = {0, 70};
+        // The RTPSReliableReaderQos is default constructed with heartbeat_response_delay = 5 ms
+        // Change the heartbeatResponseDelay to 5 nanoseconds
+        reader_qos.reliable_reader_qos().times.heartbeat_response_delay = {0, 5};
+        // You can also change the DisablePositiveACKsQosPolicy. For further details see DisablePositiveACKsQosPolicy section.
+        reader_qos.reliable_reader_qos().disable_positive_acks.enabled = true;
+        // Use modified QoS in the creation of the DataReader entity
+        reader_ = subscriber_->create_datareader(topic_, reader_qos);
+        //!--
+    }
+
+    {
+        //DDS_CHANGE_PARTICIPANT_RESOURCE_LIMITS_QOS_POLICY
+        // This example only applies to DomainParticipant entities
+        DomainParticipantQos participant_qos;
+        // Set the maximum size of participant resource limits collection to 3 and it allocation configuration to fixed size
+        participant_qos.allocation().participants = eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(
+            3u);
+        // Set the maximum size of reader's resource limits collection to 2 and its allocation configuration to fixed size
+        participant_qos.allocation().readers = eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
+        // Set the maximum size of writer's resource limits collection to 1 and its allocation configuration to fixed size
+        participant_qos.allocation().writers = eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+        // Set the maximum size of the partition data to 256
+        participant_qos.allocation().data_limits.max_partitions = 256u;
+        // Set the maximum size of the user data to 256
+        participant_qos.allocation().data_limits.max_user_data = 256u;
+        // Set the maximum size of the properties data to 512
+        participant_qos.allocation().data_limits.max_properties = 512u;
+        // Set the preallocated filter expression size to 512
+        participant_qos.allocation().content_filter.expression_initial_size = 512u;
+        // Set the maximum number of expression parameters to 4 and its allocation configuration to fixed size
+        participant_qos.allocation().content_filter.expression_parameters =
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(4u);
+        // Use modified QoS in the creation of the corresponding DomainParticipant
+        participant_ = factory_->create_participant(domain, participant_qos);
+        //!--
+    }
+
+    {
+        //DDS_CHANGE_PROPERTY_POLICY_QOS
+        // This example uses a DataWriter, but it can also be applied to: DomainParticipant, DataWriter and DataReader entities
+        DataWriterQos writer_qos;
+        // Add new property for the Auth:PKI-DH plugin
+        writer_qos.properties().properties().emplace_back("dds.sec.auth.plugin", "builtin.PKI-DH");
+        // Add new property for the Access:Permissions plugin
+        writer_qos.properties().properties().emplace_back(eprosima::fastdds::rtps::Property("dds.sec.access.plugin",
+                "builtin.Access-Permissions"));
+
+        // Add new user custom property to send to external Participants
+        writer_qos.properties().properties().emplace_back("Custom Property Name", "Custom value", true);
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
+        //!--
+    }
+
+    {
+        //DDS_CHANGE_PUBLISH_MODE_QOS
+        // This example only applies to DataWriter entities
+        DataWriterQos writer_qos;
+        // The PublishModeQosPolicy is default constructed with kind = SYNCHRONOUS
+        // Change the kind to ASYNCHRONOUS
+        writer_qos.publish_mode().kind = ASYNCHRONOUS_PUBLISH_MODE;
+        // Use modified QoS in the creation of the DataWriter entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
+        //!--
+    }
+
+    {
+        //DDS_CHANGE_READER_RESOURCE_LIMITS_QOS
+        // This example only applies to DataReader entities
+        DataReaderQos reader_qos;
+        // Set the maximum size for writer matched resource limits collection to 1 and its allocation configuration to fixed size
+        reader_qos.reader_resource_limits().matched_publisher_allocation =
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+        // Set the maximum size for sample info resource limits to 22 and its allocation configuration to fixed size
+        reader_qos.reader_resource_limits().sample_infos_allocation =
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(22u);
+        // Set the maximum size for writer matched resource limits collection to 3 and its allocation configuration to fixed size
+        reader_qos.reader_resource_limits().outstanding_reads_allocation =
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+        reader_qos.reader_resource_limits().max_samples_per_read = 42;
+        // Use modified QoS in the creation of the DataReader entity
+        reader_ = subscriber->create_datareader(topic_, reader_qos);
+        //!--
+    }
+
+    {
+        //DDS_CHANGE_WRITER_RESOURCE_LIMITS_QOS
+        // This example only applies to DataWriter entities
+        DataWriterQos writer_qos;
+        // Set the maximum size for reader matched resource limits collection to 3 and its allocation configuration to fixed size
+        writer_qos.writer_resource_limits().matched_subscriber_allocation =
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+        // Set the maximum number of writer side content filters to 1 and its allocation configuration to fixed size
+        writer_qos.writer_resource_limits().reader_filters_allocation =
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+        // Use modified QoS in the creation of the DataWriter entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
+        //!--
+    }
+
+    {
+        //DDS_CHANGE_RTPS_ENDPOINT_QOS
+        // This example uses a DataWriter, but it can also be applied to: DataWriter and DataReader entities
+        DataWriterQos writer_qos;
+        // Add new unicast locator with port 7800
+        eprosima::fastdds::rtps::Locator_t new_unicast_locator;
+        new_unicast_locator.port = 7800;
+        writer_qos.endpoint().unicast_locator_list.push_back(new_unicast_locator);
+        // Add new multicast locator with IP 239.255.0.4 and port 7900
+        eprosima::fastdds::rtps::Locator_t new_multicast_locator;
+        eprosima::fastdds::rtps::IPLocator::setIPv4(new_multicast_locator, "239.255.0.4");
+        new_multicast_locator.port = 7900;
+        writer_qos.endpoint().multicast_locator_list.push_back(new_multicast_locator);
+        // Add an external locator with IP 100.100.100.10, port 12345, mask 24, externality 1, and cost 0
+        eprosima::fastdds::rtps::LocatorWithMask external_locator;
+        external_locator.kind = LOCATOR_KIND_UDPv4;
+        external_locator.port = 12345;
+        external_locator.mask(24);
+        writer_qos.endpoint().external_unicast_locators[1][0].push_back(external_locator);
+        // Drop non matching locators
+        writer_qos.endpoint().ignore_non_matching_locators = true;
+        // Set 3 as user defined id
+        writer_qos.endpoint().user_defined_id = 3;
+        // Set 4 as entity id
+        writer_qos.endpoint().entity_id = 4;
+        // The RTPSWriterQos is default constructed with history_memory_policy = PREALLOCATED
+        // Change the history_memory_policy to DYNAMIC_RESERVE
+        writer_qos.endpoint().history_memory_policy = eprosima::fastdds::rtps::DYNAMIC_RESERVE_MEMORY_MODE;
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         using namespace eprosima::fastdds::rtps;
         //DDS_CHANGE_THREAD_SETTINGS
-        ThreadSettings thread_settings;
-        thread_settings.scheduling_policy = 2;
-        thread_settings.priority = 10;
-        thread_settings.affinity = 4;
-        thread_settings.stack_size = 2000;
+        // This example uses a specific thread of the DomainParticipantQos, but it can also be applied to most of
+        // the threads used by FastDDS in DomainParticipantFactoryQos, DomainParticipantQos or DataSharingQosPolicy.
+        // Each thread has its own getter and setter function. See Fast DDS documentation for further details.
+        DomainParticipantQos participant_qos;
+        participant_qos.timed_events_thread().scheduling_policy = 2;
+        participant_qos.timed_events_thread().priority = 10;
+        participant_qos.timed_events_thread().affinity = 4;
+        participant_qos.timed_events_thread().stack_size = 2000;
 
+        // Use modified QoS in the creation of the corresponding entity
+        participant_ = factory_->create_participant(domain, participant_qos);
         //!--
 
         //DDS_RECEPTION_THREADS_SETTINGS
+        PortBasedTransportDescriptor descriptor;
         PortBasedTransportDescriptor::ReceptionThreadsConfigMap reception_threads_config;
         reception_threads_config[20000].scheduling_policy = 1;
         reception_threads_config[20000].priority = 30;
@@ -4345,95 +4455,124 @@ void dds_qos_examples()
         reception_threads_config[20001].affinity = 6;
         reception_threads_config[20001].stack_size = 4096;
 
+        // Use setter to set the reception threads configuration
+        descriptor.reception_threads(reception_threads_config);
         //!--
     }
 
     {
         //DDS_CHANGE_TRANSPORT_CONFIG_QOS
-        TransportConfigQos transport;
+        // This example only applies to DomainParticipant entities
+        DomainParticipantQos participant_qos;
         // Add new transport to the list of user transports
         std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor> descriptor =
                 std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
         descriptor->sendBufferSize = 9126;
         descriptor->receiveBufferSize = 9126;
-        transport.user_transports.push_back(descriptor);
+        participant_qos.transport().user_transports.push_back(descriptor);
         // Set use_builtin_transports to false
-        transport.use_builtin_transports = false;
+        participant_qos.transport().use_builtin_transports = false;
         // [OPTIONAL] Set ThreadSettings for the builtin transports reception threads
-        transport.builtin_transports_reception_threads_ = eprosima::fastdds::rtps::ThreadSettings{2, 2, 2, 2};
+        participant_qos.transport().builtin_transports_reception_threads_ = eprosima::fastdds::rtps::ThreadSettings{2, 2, 2, 2};
         // Set max_msg_size_no_frag to a value > 65500 KB
-        transport.max_msg_size_no_frag = 70000;
+        participant_qos.transport().max_msg_size_no_frag = 70000;
         // Configure netmask filter
-        transport.netmask_filter = eprosima::fastdds::rtps::NetmaskFilterKind::ON;
+        participant_qos.transport().netmask_filter = eprosima::fastdds::rtps::NetmaskFilterKind::ON;
+        // Use modified QoS in the creation of the DomainParticipant entity
+        participant_ = factory_->create_participant(domain, participant_qos);
+        //!--
+    }
+
+    {
+        //DDS_CHANGE_TYPE_CONSISTENCY_QOS
+        // This example only applies to DataReader entities
+        DataReaderQos reader_qos;
+        // You can change the DataRepresentationQosPolicy. For further details see DataRepresentationQosPolicySection section.
+        reader_qos.type_consistency().representation.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+        // You can change the TypeConsistencyEnforcementQosPolicy. For further details see TypeConsistencyEnforcementQosPolicy section.
+        reader_qos.type_consistency().type_consistency.m_kind = TypeConsistencyKind::ALLOW_TYPE_COERCION;
+        // Use modified QoS in the creation of the DataReader entity
+        reader_ = subscriber_->create_datareader(topic_, reader_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_WIRE_PROTOCOL_CONFIG_QOS
-        WireProtocolConfigQos wire_protocol;
-        //Set the guid prefix
-        std::istringstream("72.61.73.70.66.61.72.6d.74.65.73.74") >> wire_protocol.prefix;
+        // This example only applies to DomainParticipant entities
+        DomainParticipantQos participant_qos;
+        // Set the guid prefix
+        std::istringstream("72.61.73.70.66.61.72.6d.74.65.73.74") >> participant_qos.wire_protocol().prefix;
         //Configure Builtin Attributes
-        wire_protocol.builtin.discovery_config.discoveryProtocol =
+        participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
                 eprosima::fastdds::rtps::DiscoveryProtocol::SERVER;
-        //Add locator to unicast list
+        // Add locator to unicast list
         eprosima::fastdds::rtps::Locator_t server_locator;
         eprosima::fastdds::rtps::IPLocator::setIPv4(server_locator, "192.168.10.57");
         server_locator.port = 56542;
-        wire_protocol.builtin.metatrafficUnicastLocatorList.push_back(server_locator);
+        participant_qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(server_locator);
         // Add a metatraffic external locator with IP 100.100.100.10, port 34567, mask 24, externality 1, and cost 0
         eprosima::fastdds::rtps::LocatorWithMask meta_external_locator;
         meta_external_locator.kind = LOCATOR_KIND_UDPv4;
         meta_external_locator.port = 34567;
         meta_external_locator.mask(24);
-        wire_protocol.builtin.metatraffic_external_unicast_locators[1][0].push_back(meta_external_locator);
-        //Add locator to default unicast locator list
+        participant_qos.wire_protocol().builtin.metatraffic_external_unicast_locators[1][0].push_back(meta_external_locator);
+        // Add locator to default unicast locator list
         eprosima::fastdds::rtps::Locator_t unicast_locator;
         eprosima::fastdds::rtps::IPLocator::setIPv4(unicast_locator, 192, 168, 1, 41);
         unicast_locator.port = 7400;
-        wire_protocol.default_unicast_locator_list.push_back(unicast_locator);
-        //Add locator to default multicast locator list
+        participant_qos.wire_protocol().default_unicast_locator_list.push_back(unicast_locator);
+        // Add locator to default multicast locator list
         eprosima::fastdds::rtps::Locator_t multicast_locator;
         eprosima::fastdds::rtps::IPLocator::setIPv4(multicast_locator, 192, 168, 1, 41);
         multicast_locator.port = 7400;
-        wire_protocol.default_multicast_locator_list.push_back(multicast_locator);
+        participant_qos.wire_protocol().default_multicast_locator_list.push_back(multicast_locator);
         // Add a default external locator with IP 100.100.100.10, port 23456, mask 24, externality 1, and cost 0
         eprosima::fastdds::rtps::LocatorWithMask external_locator;
         external_locator.kind = LOCATOR_KIND_UDPv4;
         external_locator.port = 23456;
         external_locator.mask(24);
-        wire_protocol.default_external_unicast_locators[1][0].push_back(external_locator);
+        participant_qos.wire_protocol().default_external_unicast_locators[1][0].push_back(external_locator);
         // Drop non matching locators
-        wire_protocol.ignore_non_matching_locators = true;
+        participant_qos.wire_protocol().ignore_non_matching_locators = true;
+        // Use modified QoS in the creation of the DomainParticipant entity
+        participant_ = factory_->create_participant(domain, participant_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_DATA_REPRESENTATION_QOS
-        DataRepresentationQosPolicy data_representation;
-        //Add XCDR v1 data representation to the list of valid representations
-        data_representation.m_value.push_back(DataRepresentationId_t::XCDR_DATA_REPRESENTATION);
-        //Add XML data representation to the list of valid representations
-        data_representation.m_value.push_back(DataRepresentationId_t::XML_DATA_REPRESENTATION);
+        // This example uses a DataWriter, but it can also be applied to: DataWriter and Topic entities.
+        // DataRepresentationQosPolicy of DataReaders is contained in the TypeConsistencyQos
+        // (for further details see TypeConsistencyQos section).
+        DataWriterQos writer_qos;
+        // Add XCDR v1 data representation to the list of valid representations
+        writer_qos.representation().m_value.push_back(DataRepresentationId_t::XCDR_DATA_REPRESENTATION);
+        // Add XML data representation to the list of valid representations
+        writer_qos.representation().m_value.push_back(DataRepresentationId_t::XML_DATA_REPRESENTATION);
+        // Use modified QoS in the creation of the corresponding entity
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
         //!--
     }
 
     {
         //DDS_CHANGE_TYPE_CONSISTENCY_ENFORCEMENT_QOS
-        TypeConsistencyEnforcementQosPolicy type_enforcement;
-        //The TypeConsistencyEnforcementQosPolicy is default constructed with kind = ALLOW_TYPE_COERCION
-        //Change the kind to DISALLOW_TYPE_COERCION
-        type_enforcement.m_kind = TypeConsistencyKind::DISALLOW_TYPE_COERCION;
+        // This example only applies to DataReader entities
+        DataReaderQos reader_qos;
+        // The TypeConsistencyEnforcementQosPolicy is default constructed with kind = ALLOW_TYPE_COERCION
+        // Change the kind to DISALLOW_TYPE_COERCION
+        reader_qos.type_consistency().m_kind = TypeConsistencyKind::DISALLOW_TYPE_COERCION;
         //Configures the system to ignore the sequence sizes in assignations
-        type_enforcement.m_ignore_sequence_bounds = true;
+        reader_qos.type_consistency().m_ignore_sequence_bounds = true;
         //Configures the system to ignore the string sizes in assignations
-        type_enforcement.m_ignore_string_bounds = true;
+        reader_qos.type_consistency().m_ignore_string_bounds = true;
         //Configures the system to ignore the member names. Members with same ID could have different names
-        type_enforcement.m_ignore_member_names = true;
+        reader_qos.type_consistency().m_ignore_member_names = true;
         //Configures the system to allow type widening
-        type_enforcement.m_prevent_type_widening = false;
+        reader_qos.type_consistency().m_prevent_type_widening = false;
         //Configures the system to not use the complete Type Information in entities match process
-        type_enforcement.m_force_type_validation = false;
+        reader_qos.type_consistency().m_force_type_validation = false;
+        // Use modified QoS in the creation of the corresponding entity
+        reader_ = subscriber_->create_datareader(topic_, reader_qos);
         //!--
     }
 
@@ -4454,7 +4593,6 @@ void dds_qos_examples()
         RequestedIncompatibleQosStatus status;
         data_reader->get_requested_incompatible_qos_status(status);
         uint32_t incompatible_reliability_count = status.policies[RELIABILITY_QOS_POLICY_ID].count;
-
         //!--
     }
 
@@ -4476,6 +4614,8 @@ void dds_qos_examples()
 
         DomainParticipantQos participant_qos;
         participant_qos.wire_protocol().prefix = guid_prefix;
+        // Use modified QoS in the creation of the DomainParticipant entity
+        participant_ = factory_->create_participant(domain, participant_qos);
         //!--
     }
 
@@ -4483,6 +4623,8 @@ void dds_qos_examples()
         //CONF_GUIDPREFIX_OPTION_2
         DomainParticipantQos participant_qos;
         std::istringstream("77.73.71.85.69.76.95.66.65.82.82.79") >> participant_qos.wire_protocol().prefix;
+        // Use modified QoS in the creation of the DomainParticipant entity
+        participant_ = factory_->create_participant(domain, participant_qos);
         //!--
     }
 }

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -3971,8 +3971,7 @@ void dds_qos_examples()
 {
     // Taken out of the examples to avoid bloating them
     DomainParticipantFactory* factory_ = DomainParticipantFactory::get_instance();
-    DomainParticipant* participant_ =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    DomainParticipant* participant_ = factory_->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     Subscriber* subscriber_ =
             participant_->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
     Publisher* publisher_ =
@@ -3984,9 +3983,9 @@ void dds_qos_examples()
     uint16_t domain = 7;
     {
         //DDS_CHANGE_DEADLINE_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
-        // The DeadlineQosPolicy is default constructed with an infinite period.
+        // The DeadlineQosPolicy is constructed with an infinite period by default
         // Change the period to 1 second
         writer_qos.deadline().period.seconds = 1;
         writer_qos.deadline().period.nanosec = 0;
@@ -3997,7 +3996,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_DURABILITY_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
         // The DurabilityQosPolicy is default constructed with kind = VOLATILE_DURABILITY_QOS
         // Change the kind to TRANSIENT_LOCAL_DURABILITY_QOS
@@ -4009,8 +4008,8 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_ENTITY_FACTORY_QOS_POLICY
-        // This example uses a Participant, but it can also be applied to:
-        // DomainParticipantFactory, DomainParticipant, Publisher and Subscriber entities
+        // This example uses a Participant, but it can also be applied to
+        // DomainParticipantFactory, Publisher and Subscriber entities
         DomainParticipantQos participant_qos;
         // The EntityFactoryQosPolicy is default constructed with autoenable_created_entities = true
         // Change it to false
@@ -4022,7 +4021,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_GROUP_DATA_QOS_POLICY
-        // This example uses a Publisher, but it can also be applied to: Publisher and Subscriber entities
+        // This example uses a Publisher, but it can also be applied to Subscriber entities
         PublisherQos publisher_qos;
         // The GroupDataQosPolicy is default constructed with an empty collection
         // Collection is a private member so you need to use getters and setters to access
@@ -4050,7 +4049,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_HISTORY_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
         // The HistoryQosPolicy is default constructed with kind = KEEP_LAST and depth = 1.
         // It is possible to adjust the depth and keep the kind as KEEP_LAST
@@ -4064,7 +4063,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_LIFESPAN_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
         // The LifespanQosPolicy is default constructed with duration set to infinite.
         // Change the duration to 5 s
@@ -4076,7 +4075,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_LIVELINESS_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
         // The LivelinessQosPolicy is default constructed with kind = AUTOMATIC
         // Change the kind to MANUAL_BY_PARTICIPANT
@@ -4094,7 +4093,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_OWNERSHIP_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
         // The OwnershipQosPolicy is default constructed with kind = SHARED.
         // Change the kind to EXCLUSIVE
@@ -4118,7 +4117,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_PARTITION_QOS_POLICY
-        // This example uses a Publisher, but it can also be applied to: Publisher and Subscriber entities
+        // This example uses a Publisher, but it can also be applied to Subscriber entities
         PublisherQos publisher_qos;
         // The PartitionsQosPolicy is default constructed with max_size = 0
         // Max_size is a private member so you need to use getters and setters to access
@@ -4146,7 +4145,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_RELIABILITY_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
         // The ReliabilityQosPolicy is default constructed with kind = BEST_EFFORT
         // Change the kind to RELIABLE
@@ -4161,7 +4160,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_RESOURCE_LIMITS_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DataWriter, DataReader and Topic entities
+        // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
         // The ResourceLimitsQosPolicy is default constructed with max_samples = 5000
         // Change max_samples to 200
@@ -4199,7 +4198,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_USER_DATA_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DomainParticipant, DataWriter, and DataReader entities
+        // This example uses a DataWriter, but it can also be applied to DomainParticipant and DataReader entities
         DataWriterQos writer_qos;
         std::vector<eprosima::fastdds::rtps::octet> vec;
         // Add two new octets to user data vector
@@ -4215,7 +4214,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_DATASHARING_QOS_POLICY
-        // This example uses a DataWriter, but it can also be applied to: DataWriter and DataReader entities
+        // This example uses a DataWriter, but it can also be applied to DataReader entities
         DataWriterQos writer_qos;
 
         // DataSharing is set to AUTO by default, which means that DataSharing will be used if the topic
@@ -4346,7 +4345,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_PROPERTY_POLICY_QOS
-        // This example uses a DataWriter, but it can also be applied to: DomainParticipant, DataWriter and DataReader entities
+        // This example uses a DataWriter, but it can also be applied to DomainParticipant and DataReader entities
         DataWriterQos writer_qos;
         // Add new property for the Auth:PKI-DH plugin
         writer_qos.properties().properties().emplace_back("dds.sec.auth.plugin", "builtin.PKI-DH");
@@ -4409,7 +4408,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_RTPS_ENDPOINT_QOS
-        // This example uses a DataWriter, but it can also be applied to: DataWriter and DataReader entities
+        // This example uses a DataWriter, but it can also be applied to DataReader entities
         DataWriterQos writer_qos;
         // Add new unicast locator with port 7800
         eprosima::fastdds::rtps::Locator_t new_unicast_locator;
@@ -4564,7 +4563,7 @@ void dds_qos_examples()
 
     {
         //DDS_CHANGE_DATA_REPRESENTATION_QOS
-        // This example uses a DataWriter, but it can also be applied to: DataWriter and Topic entities.
+        // This example uses a DataWriter, but it can also be applied to Topic entities.
         // DataRepresentationQosPolicy of DataReaders is contained in the TypeConsistencyQos
         // (for further details see TypeConsistencyQos section).
         DataWriterQos writer_qos;

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -500,7 +500,7 @@
 
 .. |RTPSReliableReaderQos-api| replace:: :cpp:class:`RTPSReliableReaderQos<eprosima::fastdds::dds::RTPSReliableReaderQos>`
 .. |RTPSReliableReaderQos::times-api| replace:: :cpp:member:`times<eprosima::fastdds::dds::RTPSReliableReaderQos::times>`
-.. |RTPSReliableReaderQos::disable_positive_ACKs-api| replace:: :cpp:member:`disable_positive_ACKs<eprosima::fastdds::dds::RTPSReliableReaderQos::disable_positive_ACKs>`
+.. |RTPSReliableReaderQos::disable_positive_acks-api| replace:: :cpp:member:`disable_positive_acks<eprosima::fastdds::dds::RTPSReliableReaderQos::disable_positive_acks>`
 
 .. |DisablePositiveACKsQosPolicy-api| replace:: :cpp:class:`DisablePositiveACKsQosPolicy<eprosima::fastdds::dds::DisablePositiveACKsQosPolicy>`
 .. |DisablePositiveACKsQosPolicy::enabled-api| replace:: :cpp:member:`enabled<eprosima::fastdds::dds::DisablePositiveACKsQosPolicy::enabled>`

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -75,7 +75,7 @@ List of QoS Policy data members:
   The |ThreadSettings| for the data-sharing thread dedicated to listening for incoming traffic.
 
 .. note::
-     This QoS Policy concerns to |DataWriter| and |DataReader| entities.
+     This QoS Policy applies to |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -176,7 +176,7 @@ List of QoS Policy data members:
   This value does not apply to DataReaders.
 
 .. note::
-     This QoS Policy concerns to |DataWriter| and |DataReader| entities.
+     This QoS Policy applies to |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      The |DisablePositiveACKsQosPolicy::enabled-api| Data Member cannot be modified on enabled entities.
      Thus, this feature must be set up during initialization.
@@ -252,7 +252,7 @@ List of QoS Policy data members:
   See :ref:`disablepositiveacksqospolicy` for further details.
 
 .. note::
-     This QoS Policy concerns to |DataReader| entities.
+     This QoS Policy applies to |DataReader| entities.
      :raw-html:`<br />`
      Only the |DisablePositiveACKsQosPolicy::duration-api| Data Member of the :ref:`disablepositiveacksqospolicy` and the |RTPSReliableReaderQos::times-api|
      Data Member can be modified on enabled entities.
@@ -332,7 +332,7 @@ List of QoS Policy data members:
   See :ref:`disableheartbeatpiggyback` for further details.
 
 .. note::
-     This QoS Policy concerns to |DataWriter| entities.
+     This QoS Policy applies to |DataWriter| entities.
      :raw-html:`<br />`
      Only the |DisablePositiveACKsQosPolicy::duration-api| Data Member of the :ref:`disablepositiveacksqospolicy` and the |RTPSReliableWriterQos::times-api|
      Data Member can be modified on enabled entities.
@@ -441,7 +441,7 @@ Please refer to :ref:`flow-controllers` section for more information.
 
 
 .. note::
-     This QoS Policy concerns to |DomainParticipant| entities.
+     This QoS Policy applies to |DomainParticipant| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -492,7 +492,7 @@ List of QoS Policy data members:
   States the limits for content-filter discovery information.
 
 .. note::
-     This QoS Policy concerns to |DomainParticipant| entities.
+     This QoS Policy applies to |DomainParticipant| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -687,7 +687,7 @@ This QoS also allows to add custom user properties that could be sent to the ext
 This could be done by setting as :code:`true` the :code:`propagate` value of the Property.
 
 .. note::
-     This QoS Policy concerns to |DomainParticipant|, |DataWriter| and |DataReader| entities.
+     This QoS Policy applies to |DomainParticipant|, |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -740,7 +740,7 @@ List of QoS Policy data members:
      - |FASTDDS_FLOW_CONTROLLER_DEFAULT-api|
 
 .. note::
-     This QoS Policy concerns to |DataWriter| entities.
+     This QoS Policy applies to |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -797,7 +797,7 @@ List of QoS Policy data members:
 
 
 .. note::
-     This QoS Policy concerns to |DataReader| entities.
+     This QoS Policy applies to |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -841,7 +841,7 @@ List of QoS Policy data members:
 +-----------------------------------------------------------------------------+----------------------------------------+
 
 .. note::
-     This QoS Policy concerns to |DataWriter| entities.
+     This QoS Policy applies to |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -929,7 +929,7 @@ List of QoS Policy data members:
   Indicates the way the memory is managed in terms of dealing with the CacheChanges.
 
 .. note::
-     This QoS Policy concerns to |DataWriter| and |DataReader| entities.
+     This QoS Policy applies to |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -1119,7 +1119,7 @@ List of QoS Policy data members:
   :ref:`Network filter<netmask_filtering>` configuration.
 
 .. note::
-     This QoS Policy concerns to |DomainParticipant| entities.
+     This QoS Policy applies to |DomainParticipant| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -1236,7 +1236,7 @@ List of QoS Policy data members:
   any of the locators announced by this DDS participant.
 
 .. note::
-     This QoS Policy concerns to |DomainParticipant| entities.
+     This QoS Policy applies to |DomainParticipant| entities.
 
 .. important::
      The only mutable field on enabled entities is |m_DiscoveryServers|, which is contained in

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -210,21 +210,200 @@ Table with the possible combinations:
 Example
 """""""
 
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_DISABLE_POSITIVE_ACKS_QOS_POLICY
-   :end-before: //!
+.. tabs::
 
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->PUBSUB_API_CONF_PUBSUB_DISABLE_POSITIVE_ACKS
-    :end-before: <!--><-->
+   .. tab:: C++
 
+      .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_DISABLE_POSITIVE_ACKS_QOS_POLICY
+          :end-before: //!
+
+   .. tab:: XML
+
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->PUBSUB_API_CONF_PUBSUB_DISABLE_POSITIVE_ACKS
+          :end-before: <!--><-->
+
+.. _rtpsreliablereaderqos:
+
+RTPSReliableReaderQos
+^^^^^^^^^^^^^^^^^^^^^
+
+This RTPS QoS Policy allows the configuration of several RTPS reliable reader's aspects.
+See |RTPSReliableReaderQos-api|.
+
+List of QoS Policy data members:
+
++--------------------------------------------------------------------------------+-------------------------------------+
+| Data Member Name                                                               | Type                                |
++================================================================================+=====================================+
+| |RTPSReliableReaderQos::times-api|                                             | :ref:`readertimes`                  |
++--------------------------------------------------------------------------------+-------------------------------------+
+| |RTPSReliableReaderQos::disable_positive_acks-api|                             | :ref:`disablepositiveacksqospolicy` |
++--------------------------------------------------------------------------------+-------------------------------------+
+
+* |RTPSReliableReaderQos::times-api|:
+  Defines the duration of the RTPSReader events. See :ref:`readertimes` for further details.
+* |RTPSReliableReaderQos::disable_positive_acks-api|:
+  Configures the settings to disable the positive acks.
+  See :ref:`disablepositiveacksqospolicy` for further details.
+
+.. note::
+     This QoS Policy concerns to |DataReader| entities.
+     :raw-html:`<br />`
+     Only the |DisablePositiveACKsQosPolicy::duration-api| Data Member of the :ref:`disablepositiveacksqospolicy` and the |RTPSReliableReaderQos::times-api|
+     Data Member can be modified on enabled entities.
+
+.. _readertimes:
+
+ReaderTimes
+"""""""""""
+
+This structure defines the times associated with the Reliable Readers' events.
+See |ReaderTimes-api|.
+
+List of structure members:
+
++-----------------------------------------------------------------------------------+------------------+---------------+
+| Member Name                                                                       | Type             | Default Value |
++===================================================================================+==================+===============+
+| |ReaderTimes::initial_acknack_delay-api|                                          | |Duration_t-api| | 70 ms         |
++-----------------------------------------------------------------------------------+------------------+---------------+
+| |ReaderTimes::heartbeat_response_delay-api|                                       | |Duration_t-api| | 5 ms          |
++-----------------------------------------------------------------------------------+------------------+---------------+
+
+* |ReaderTimes::initial_acknack_delay-api|:
+  Defines the duration of the initial acknack delay.
+* |ReaderTimes::heartbeat_response_delay-api|:
+  Establishes the duration of the delay applied when a heartbeat message is received.
+
+Example
+"""""""
+
+.. tabs::
+
+   .. tab:: C++
+
+     .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+        :language: c++
+        :dedent: 8
+        :start-after: //DDS_CHANGE_RTPS_RELIABLE_READER_QOS
+        :end-before: //!
+
+   .. tab:: XML
+
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->XML_RTPS_RELIABLE_READER_QOS<-->
+          :end-before: <!--><-->
+
+
+.. _rtpsreliablewriterqos:
+
+RTPSReliableWriterQos
+^^^^^^^^^^^^^^^^^^^^^
+
+This RTPS QoS Policy allows the configuration of several RTPS reliable writer's aspects.
+See |RTPSReliableWriterQos-api|.
+
+List of QoS Policy data members:
+
++--------------------------------------------------------------------------------+-------------------------------------+
+| Data Member Name                                                               | Type                                |
++================================================================================+=====================================+
+| |RTPSReliableWriterQos::times-api|                                             | :ref:`writertimes`                  |
++--------------------------------------------------------------------------------+-------------------------------------+
+| |RTPSReliableWriterQos::disable_positive_acks-api|                             | :ref:`disablepositiveacksqospolicy` |
++--------------------------------------------------------------------------------+-------------------------------------+
+| |RTPSReliableWriterQos::disable_heartbeat_piggyback-api|                       | :ref:`disableheartbeatpiggyback`    |
++--------------------------------------------------------------------------------+-------------------------------------+
+
+* |RTPSReliableWriterQos::times-api|:
+  Defines the duration of the RTPSWriter events.
+  See :ref:`writertimes` for further details.
+* |RTPSReliableWriterQos::disable_positive_acks-api|:
+  Configures the settings to disable the positive acks.
+  See :ref:`disablepositiveacksqospolicy` for further details.
+* |RTPSReliableWriterQos::disable_heartbeat_piggyback-api|:
+  Configures the settings to disable the heartbeat piggyback mechanism.
+  See :ref:`disableheartbeatpiggyback` for further details.
+
+.. note::
+     This QoS Policy concerns to |DataWriter| entities.
+     :raw-html:`<br />`
+     Only the |DisablePositiveACKsQosPolicy::duration-api| Data Member of the :ref:`disablepositiveacksqospolicy` and the |RTPSReliableWriterQos::times-api|
+     Data Member can be modified on enabled entities.
+
+.. _writertimes:
+
+WriterTimes
+"""""""""""
+
+This structure defines the times associated with the Reliable Writers' events.
+
+List of structure members:
+
++-----------------------------------------------------------------------------------+------------------+---------------+
+| Member Name                                                                       | Type             | Default Value |
++===================================================================================+==================+===============+
+| |WriterTimes::initialHeartbeatDelay-api|                                          | |Duration_t-api| | 12ms          |
++-----------------------------------------------------------------------------------+------------------+---------------+
+| |WriterTimes::heartbeatPeriod-api|                                                | |Duration_t-api| | 3s            |
++-----------------------------------------------------------------------------------+------------------+---------------+
+| |WriterTimes::nackResponseDelay-api|                                              | |Duration_t-api| | 5ms           |
++-----------------------------------------------------------------------------------+------------------+---------------+
+| |WriterTimes::nackSupressionDuration-api|                                         | |Duration_t-api| | 0s            |
++-----------------------------------------------------------------------------------+------------------+---------------+
+
+* |WriterTimes::initialHeartbeatDelay-api|:
+  Defines duration of the initial heartbeat delay.
+* |WriterTimes::heartbeatPeriod-api|:
+  Specifies the interval between periodic heartbeats.
+* |WriterTimes::nackResponseDelay-api|:
+  Establishes the duration of the delay applied to the response of an ACKNACK message.
+* |WriterTimes::nackSupressionDuration-api|:
+  The RTPSWriter ignores the nack messages received after sending the data until the
+  duration time elapses.
+
+.. _disableheartbeatpiggyback:
+
+DisableHeartbeatPiggyback
+"""""""""""""""""""""""""
+
+Besides sending heartbeats periodically using the |WriterTimes::heartbeatPeriod-api| (see :ref:`writertimes`), reliable
+DataWriters also use a mechanism to append a heartbeat submessage in the same message where data is being delivered to
+the DataReaders.
+This mechanism acts in specific situations where the reliable communication state must be up to date to maintain
+optimal communication:
+
+- When the DataWriter sends as many bytes to the *socket* as the length of the *socket* buffer, a heartbeat
+  submessage is appended after the last data.
+- When the DataWriter's history is full, the DataWriter starts to append heartbeat submessages after each data.
+
+This mechanism can be disabled using this policy.
+
+Example
+"""""""
+
+.. tabs::
+
+   .. tab:: C++
+
+     .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_RTPS_RELIABLE_WRITER_QOS
+          :end-before: //!
+
+   .. tab:: XML
+
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->XML_RTPS_RELIABLE_WRITER_QOS<-->
+          :end-before: <!--><-->
 
 .. _flowcontrollersqos:
 
@@ -273,7 +452,6 @@ ParticipantResourceLimitsQos
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This QoS configures allocation limits and the use of physical memory for internal resources.
-See |ParticipantResourceLimitsQos-api|.
 
 List of QoS Policy data members:
 
@@ -477,20 +655,23 @@ List of structure members:
 Example
 """""""
 
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_PARTICIPANT_RESOURCE_LIMITS_QOS_POLICY
-   :end-before: //!
+.. tabs::
 
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->CONF-ALLOCATION-QOS-EXAMPLE
-    :end-before: <data_writer
+   .. tab:: C++
+
+      .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_PARTICIPANT_RESOURCE_LIMITS_QOS_POLICY
+          :end-before: //!
+
+   .. tab:: XML
+
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->CONF-ALLOCATION-QOS-EXAMPLE
+          :end-before: <data_writer
+          :lines: 2-4, 5-
 
 .. _propertypolicyqos:
 
@@ -504,23 +685,30 @@ For the complete list of settings that can be configured with this QoS Policy, p
 This QoS also allows to add custom user properties that could be sent to the external entities.
 This could be done by setting as :code:`true` the :code:`propagate` value of the Property.
 
+.. note::
+     This QoS Policy concerns to |DomainParticipant|, |DataWriter| and |DataReader| entities.
+     :raw-html:`<br />`
+     It cannot be changed on enabled entities.
+
 Example
 """""""
 
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_PROPERTY_POLICY_QOS
-   :end-before: //!
+.. tabs::
 
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->XML_PROPERTY_POLICY
-    :end-before: <!--><-->
+   .. tab:: C++
+
+      .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_PROPERTY_POLICY_QOS
+          :end-before: //!
+
+   .. tab:: XML
+
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->XML_PROPERTY_POLICY
+          :end-before: <!--><-->
 
 .. _publishmodeqospolicy:
 
@@ -551,7 +739,7 @@ List of QoS Policy data members:
      - |FASTDDS_FLOW_CONTROLLER_DEFAULT-api|
 
 .. note::
-     This QoS Policy concerns to DataWriter entities.
+     This QoS Policy concerns to |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -572,20 +760,22 @@ descriptor name.
 Example
 """""""
 
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_PUBLISH_MODE_QOS
-   :end-before: //!
+.. tabs::
 
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->CONF-QOS-PUBLISHMODE<-->
-    :end-before: <!--><-->
+   .. tab:: C++
+
+      .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_PUBLISH_MODE_QOS
+          :end-before: //!
+
+   .. tab:: XML
+
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->CONF-QOS-PUBLISHMODE<-->
+          :end-before: <!--><-->
 
 .. _readerresourcelimitsqos:
 
@@ -606,27 +796,73 @@ List of QoS Policy data members:
 
 
 .. note::
-     This QoS Policy concerns to DataReader entities.
+     This QoS Policy concerns to |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
 Example
 """""""
 
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_READER_RESOURCE_LIMITS_QOS
-   :end-before: //!
+.. tabs::
 
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->XML_READER_RESOURCE_LIMITS_QOS<-->
-    :end-before: <!--><-->
+   .. tab:: C++
+
+      .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_READER_RESOURCE_LIMITS_QOS
+          :end-before: //!
+
+   .. tab:: XML
+
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->XML_READER_RESOURCE_LIMITS_QOS<-->
+          :end-before: <!--><-->
+
+.. _writerresourcelimitsqos:
+
+WriterResourceLimitsQos
+^^^^^^^^^^^^^^^^^^^^^^^
+
+This QoS Policy states the limits for the matched |DataReaders|' resource limited collections based on the maximum
+number of DataReaders that are going to match with the |DataWriter|.
+See |WriterResourceLimitsQos-api|.
+
+List of QoS Policy data members:
+
++-----------------------------------------------------------------------------+----------------------------------------+
+| Data Member Name                                                            | Type                                   |
++=============================================================================+========================================+
+| |WriterResourceLimitsQos::matched_subscriber_allocation-api|                | :ref:`resourcelimitedcontainerconfig`  |
++-----------------------------------------------------------------------------+----------------------------------------+
+| |WriterResourceLimitsQos::reader_filters_allocation-api|                    | :ref:`resourcelimitedcontainerconfig`  |
++-----------------------------------------------------------------------------+----------------------------------------+
+
+.. note::
+     This QoS Policy concerns to |DataWriter| entities.
+     :raw-html:`<br />`
+     It cannot be changed on enabled entities.
+
+Example
+"""""""
+
+.. tabs::
+
+   .. tab:: C++
+
+     .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_WRITER_RESOURCE_LIMITS_QOS
+          :end-before: //!
+
+   .. tab:: XML
+
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->XML_WRITER_RESOURCE_LIMITS_QOS<-->
+          :end-before: <!--><-->
 
 .. _rtpsendpointqos:
 
@@ -720,194 +956,22 @@ There are four possible values (see |MemoryManagementPolicy-api|):
 Example
 """""""
 
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_RTPS_ENDPOINT_QOS
-   :end-before: //!
+.. tabs::
 
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->XML_RTPS_ENDPOINT_QOS<-->
-    :end-before: <!--><-->
+   .. tab:: C++
 
-.. _rtpsreliablereaderqos:
+     .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_RTPS_ENDPOINT_QOS
+          :end-before: //!
 
-RTPSReliableReaderQos
-^^^^^^^^^^^^^^^^^^^^^
+   .. tab:: XML
 
-This RTPS QoS Policy allows the configuration of several RTPS reliable reader's aspects.
-See |RTPSReliableReaderQos-api|.
-
-List of QoS Policy data members:
-
-+--------------------------------------------------------------------------------+-------------------------------------+
-| Data Member Name                                                               | Type                                |
-+================================================================================+=====================================+
-| |RTPSReliableReaderQos::times-api|                                             | :ref:`readertimes`                  |
-+--------------------------------------------------------------------------------+-------------------------------------+
-| |RTPSReliableReaderQos::disable_positive_ACKs-api|                             | :ref:`disablepositiveacksqospolicy` |
-+--------------------------------------------------------------------------------+-------------------------------------+
-
-* |RTPSReliableReaderQos::times-api|:
-  Defines the duration of the RTPSReader events. See :ref:`readertimes` for further details.
-* |RTPSReliableReaderQos::disable_positive_ACKs-api|:
-  Configures the settings to disable the positive acks.
-  See :ref:`disablepositiveacksqospolicy` for further details.
-
-.. note::
-     This QoS Policy concerns to |DataReader| entities.
-     :raw-html:`<br />`
-     Only the |DisablePositiveACKsQosPolicy::duration-api| Data Member of the :ref:`disablepositiveacksqospolicy` and the |RTPSReliableReaderQos::times-api|
-     Data Member can be modified on enabled entities.
-
-.. _readertimes:
-
-ReaderTimes
-"""""""""""
-
-This structure defines the times associated with the Reliable Readers' events.
-See |ReaderTimes-api|.
-
-List of structure members:
-
-+-----------------------------------------------------------------------------------+------------------+---------------+
-| Member Name                                                                       | Type             | Default Value |
-+===================================================================================+==================+===============+
-| |ReaderTimes::initial_acknack_delay-api|                                          | |Duration_t-api| | 70 ms         |
-+-----------------------------------------------------------------------------------+------------------+---------------+
-| |ReaderTimes::heartbeat_response_delay-api|                                       | |Duration_t-api| | 5 ms          |
-+-----------------------------------------------------------------------------------+------------------+---------------+
-
-* |ReaderTimes::initial_acknack_delay-api|:
-  Defines the duration of the initial acknack delay.
-* |ReaderTimes::heartbeat_response_delay-api|:
-  Establishes the duration of the delay applied when a heartbeat message is received.
-
-Example
-"""""""
-
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_RTPS_RELIABLE_READER_QOS
-   :end-before: //!
-
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->XML_RTPS_RELIABLE_READER_QOS<-->
-    :end-before: <!--><-->
-
-
-.. _rtpsreliablewriterqos:
-
-RTPSReliableWriterQos
-^^^^^^^^^^^^^^^^^^^^^
-
-This RTPS QoS Policy allows the configuration of several RTPS reliable writer's aspects.
-See |RTPSReliableWriterQos-api|.
-
-List of QoS Policy data members:
-
-+--------------------------------------------------------------------------------+-------------------------------------+
-| Data Member Name                                                               | Type                                |
-+================================================================================+=====================================+
-| |RTPSReliableWriterQos::times-api|                                             | :ref:`writertimes`                  |
-+--------------------------------------------------------------------------------+-------------------------------------+
-| |RTPSReliableWriterQos::disable_positive_acks-api|                             | :ref:`disablepositiveacksqospolicy` |
-+--------------------------------------------------------------------------------+-------------------------------------+
-| |RTPSReliableWriterQos::disable_heartbeat_piggyback-api|                       | :ref:`disableheartbeatpiggyback`    |
-+--------------------------------------------------------------------------------+-------------------------------------+
-
-* |RTPSReliableWriterQos::times-api|:
-  Defines the duration of the RTPSWriter events.
-  See :ref:`writertimes` for further details.
-* |RTPSReliableWriterQos::disable_positive_acks-api|:
-  Configures the settings to disable the positive acks.
-  See :ref:`disablepositiveacksqospolicy` for further details.
-* |RTPSReliableWriterQos::disable_heartbeat_piggyback-api|:
-  Configures the settings to disable the heartbeat piggyback mechanism.
-  See :ref:`disableheartbeatpiggyback` for further details.
-
-.. note::
-     This QoS Policy concerns to |DataWriter| entities.
-     :raw-html:`<br />`
-     Only the |DisablePositiveACKsQosPolicy::duration-api| Data Member of the :ref:`disablepositiveacksqospolicy` and the |RTPSReliableWriterQos::times-api|
-     Data Member can be modified on enabled entities.
-
-.. _writertimes:
-
-WriterTimes
-"""""""""""
-
-This structure defines the times associated with the Reliable Writers' events.
-
-List of structure members:
-
-+-----------------------------------------------------------------------------------+------------------+---------------+
-| Member Name                                                                       | Type             | Default Value |
-+===================================================================================+==================+===============+
-| |WriterTimes::initialHeartbeatDelay-api|                                          | |Duration_t-api| | 12ms          |
-+-----------------------------------------------------------------------------------+------------------+---------------+
-| |WriterTimes::heartbeatPeriod-api|                                                | |Duration_t-api| | 3s            |
-+-----------------------------------------------------------------------------------+------------------+---------------+
-| |WriterTimes::nackResponseDelay-api|                                              | |Duration_t-api| | 5ms           |
-+-----------------------------------------------------------------------------------+------------------+---------------+
-| |WriterTimes::nackSupressionDuration-api|                                         | |Duration_t-api| | 0s            |
-+-----------------------------------------------------------------------------------+------------------+---------------+
-
-* |WriterTimes::initialHeartbeatDelay-api|:
-  Defines duration of the initial heartbeat delay.
-* |WriterTimes::heartbeatPeriod-api|:
-  Specifies the interval between periodic heartbeats.
-* |WriterTimes::nackResponseDelay-api|:
-  Establishes the duration of the delay applied to the response of an ACKNACK message.
-* |WriterTimes::nackSupressionDuration-api|:
-  The RTPSWriter ignores the nack messages received after sending the data until the
-  duration time elapses.
-
-.. _disableheartbeatpiggyback:
-
-DisableHeartbeatPiggyback
-"""""""""""""""""""""""""
-
-Besides sending heartbeats periodically using the |WriterTimes::heartbeatPeriod-api| (see :ref:`writertimes`), reliable
-DataWriters also use a mechanism to append a heartbeat submessage in the same message where data is being delivered to
-the DataReaders.
-This mechanism acts in specific situations where the reliable communication state must be up to date to maintain
-optimal communication:
-
-- When the DataWriter sends as many bytes to the *socket* as the length of the *socket* buffer, a heartbeat
-  submessage is appended after the last data.
-- When the DataWriter's history is full, the DataWriter starts to append heartbeat submessages after each data.
-
-This mechanism can be disabled using this policy.
-
-Example
-"""""""
-
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_RTPS_RELIABLE_WRITER_QOS
-   :end-before: //!
-
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->XML_RTPS_RELIABLE_WRITER_QOS<-->
-    :end-before: <!--><-->
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->XML_RTPS_ENDPOINT_QOS<-->
+          :end-before: <!--><-->
 
 .. _threadsettingsqos:
 
@@ -1083,20 +1147,22 @@ List of structure members:
 Example
 """""""
 
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_TRANSPORT_CONFIG_QOS
-   :end-before: //!
+.. tabs::
 
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->CONF-COMMON-TRANSPORT-SETTING<-->
-    :end-before: <!--><-->
+   .. tab:: C++
+
+     .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_TRANSPORT_CONFIG_QOS
+          :end-before: //!
+
+   .. tab:: XML
+
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->CONF-COMMON-TRANSPORT-SETTING<-->
+          :end-before: <!--><-->
 
 .. note::
      :ref:`transportconfigqos` can also be configured modifying the builtin
@@ -1109,7 +1175,6 @@ WireProtocolConfigQos
 ^^^^^^^^^^^^^^^^^^^^^
 
 This QoS Policy allows the configuration of the wire protocol.
-See |WireProtocolConfigQos-api|.
 
 List of QoS Policy data members:
 
@@ -1170,7 +1235,7 @@ List of QoS Policy data members:
   any of the locators announced by this DDS participant.
 
 .. note::
-     This QoS Policy concerns to DomainParticipant entities.
+     This QoS Policy concerns to |DomainParticipant| entities.
 
 .. important::
      The only mutable field on enabled entities is |m_DiscoveryServers|, which is contained in
@@ -1180,59 +1245,20 @@ List of QoS Policy data members:
 Example
 """""""
 
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_WIRE_PROTOCOL_CONFIG_QOS
-   :end-before: //!
+.. tabs::
 
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->XML_WIRE_PROTOCOL_CONFIG_QOS<-->
-    :end-before: <!--><-->
+   .. tab:: C++
 
-.. _writerresourcelimitsqos:
+     .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+          :language: c++
+          :dedent: 8
+          :start-after: //DDS_CHANGE_WIRE_PROTOCOL_CONFIG_QOS
+          :end-before: //!
 
-WriterResourceLimitsQos
-^^^^^^^^^^^^^^^^^^^^^^^
+   .. tab:: XML
 
-This QoS Policy states the limits for the matched |DataReaders|' resource limited collections based on the maximum
-number of DataReaders that are going to match with the |DataWriter|.
-See |WriterResourceLimitsQos-api|.
+      .. literalinclude:: /../code/XMLTester.xml
+          :language: xml
+          :start-after: <!-->XML_WIRE_PROTOCOL_CONFIG_QOS<-->
+          :end-before: <!--><-->
 
-List of QoS Policy data members:
-
-+-----------------------------------------------------------------------------+----------------------------------------+
-| Data Member Name                                                            | Type                                   |
-+=============================================================================+========================================+
-| |WriterResourceLimitsQos::matched_subscriber_allocation-api|                | :ref:`resourcelimitedcontainerconfig`  |
-+-----------------------------------------------------------------------------+----------------------------------------+
-| |WriterResourceLimitsQos::reader_filters_allocation-api|                    | :ref:`resourcelimitedcontainerconfig`  |
-+-----------------------------------------------------------------------------+----------------------------------------+
-
-.. note::
-     This QoS Policy concerns to DataWriter entities.
-     :raw-html:`<br />`
-     It cannot be changed on enabled entities.
-
-Example
-"""""""
-
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_WRITER_RESOURCE_LIMITS_QOS
-   :end-before: //!
-
-XML
-***
-.. literalinclude:: /../code/XMLTester.xml
-    :language: xml
-    :start-after: <!-->XML_WRITER_RESOURCE_LIMITS_QOS<-->
-    :end-before: <!--><-->

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -670,8 +670,9 @@ Example
       .. literalinclude:: /../code/XMLTester.xml
           :language: xml
           :start-after: <!-->CONF-ALLOCATION-QOS-EXAMPLE
+          :dedent: 4
           :end-before: <data_writer
-          :lines: 2-4, 5-
+          :lines: 5-
 
 .. _propertypolicyqos:
 

--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -45,7 +45,7 @@ List of QoS Policy data members:
 
 .. note::
 
-   This QoS Policy concerns to |Topic|, |DataReader| and |DataWriter| entities.
+   This QoS Policy applies to |Topic|, |DataReader| and |DataWriter| entities.
    :raw-html:`<br />`
    It can be changed on enabled entities.
 
@@ -110,7 +110,7 @@ List of QoS Policy data members:
 +----------------------------------------------------+--------------------------------------+--------------------------+
 
 .. note::
-    This QoS Policy concerns to |Topic|, |DataReader| and |DataWriter| entities.
+    This QoS Policy applies to |Topic|, |DataReader| and |DataWriter| entities.
     :raw-html:`<br />`
     It cannot be changed on enabled entities.
 
@@ -187,7 +187,7 @@ List of QoS Policy data members:
 +---------------------------------------+-----------------------+------------------------------------------------------+
 
 .. note::
-     This QoS Policy concerns to |Topic|, |DataReader| and |DataWriter| entities.
+     This QoS Policy applies to |Topic|, |DataReader| and |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -330,7 +330,7 @@ List of QoS Policy data members:
   This value must be lower than the maximum number of samples.
 
 .. note::
-     This QoS Policy concerns to |Topic| and |DataWriter| entities.
+     This QoS Policy applies to |Topic| and |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -352,7 +352,7 @@ List of QoS Policy data members:
 +---------------------------------------------------------------------------+----------+-------------------+
 
 .. note::
-     This QoS Policy concerns to |DomainParticipantFactory| (as factory for |DomainParticipant|), DomainParticipant
+     This QoS Policy applies to |DomainParticipantFactory| (as factory for |DomainParticipant|), DomainParticipant
      (as factory for
      |Publisher|, |Subscriber| and |Topic|), Publisher (as factory for |DataWriter|) and Subscriber (as factory for
      |DataReader|).
@@ -397,7 +397,7 @@ List of QoS Policy data members:
 +--------------------------+-------------------------------+-------------------+
 
 .. note::
-     This QoS Policy concerns to |Publisher| and |Subscriber| entities.
+     This QoS Policy applies to |Publisher| and |Subscriber| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -447,7 +447,7 @@ List of QoS Policy data members:
   :ref:`resourcelimitsqospolicy`, which means that its value must be lower or equal to max_samples_per_instance.
 
 .. note::
-     This QoS Policy concerns to |Topic|, |DataWriter| and |DataReader| entities.
+     This QoS Policy applies to |Topic|, |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -542,7 +542,7 @@ List of QoS Policy data members:
 +----------------------------------------------------------+---------------------------+-------------------------------+
 
 .. note::
-     This QoS Policy concerns to |Topic|, |DataWriter| and |DataReader| entities.
+     This QoS Policy applies to |Topic|, |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -585,7 +585,7 @@ List of QoS Policy data members:
 +-----------------------------------------------------------------------+-----------------------+----------------------+
 
 .. note::
-     This QoS Policy concerns to |Topic|, |DataReader| and |DataWriter| entities.
+     This QoS Policy applies to |Topic|, |DataReader| and |DataWriter| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -645,7 +645,7 @@ List of QoS Policy data members:
   |LivelinessQosPolicy::lease_duration-api|.
 
 .. note::
-     This QoS Policy concerns to |Topic|, |DataReader| and |DataWriter| entities.
+     This QoS Policy applies to |Topic|, |DataReader| and |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -749,7 +749,7 @@ List of QoS Policy data members:
 +--------------------------------+-------------------------------+----------------------------------------------+
 
 .. note::
-     This QoS Policy concerns to |Topic|, |DataReader| and |DataWriter| entities.
+     This QoS Policy applies to |Topic|, |DataReader| and |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -840,7 +840,7 @@ List of QoS Policy data members:
 +-----------------------------------------------------------------+-------------------------------+-------------------+
 
 .. note::
-     This QoS Policy concerns to |DataWriter| entities.
+     This QoS Policy applies to |DataWriter| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -891,7 +891,7 @@ List of QoS Policy data members:
 * |PartitionQosPolicy::names-api|: List of partition names.
 
 .. note::
-     This QoS Policy concerns to |Publisher| and |Subscriber| entities.
+     This QoS Policy applies to |Publisher| and |Subscriber| entities.
      :raw-html:`<br />`
      Partitions can also be explicitly defined at the endpoint level to override this configuration. Information
      to do so can be found :ref:`here<property_policies_partitions>`.
@@ -953,7 +953,7 @@ List of QoS Policy data members:
   order as they occurred on the publishing side.
 
 .. note::
-     This QoS Policy concerns to |Publisher| and |Subscriber| entities.
+     This QoS Policy applies to |Publisher| and |Subscriber| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -1073,7 +1073,7 @@ List of QoS Policy data members:
   After this time elapses, the DataReader purges all the samples for the instance.
 
 .. note::
-     This QoS Policy concerns to |DataReader| entities.
+     This QoS Policy applies to |DataReader| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -1106,7 +1106,7 @@ List of QoS Policy data members:
   blocked.
 
 .. note::
-     This QoS Policy concerns to |Topic|, |DataWriter| and |DataReader| entities.
+     This QoS Policy applies to |Topic|, |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -1233,7 +1233,7 @@ List of QoS Policy data members:
   These extra samples act as a reservoir of samples even when the history is full.
 
 .. note::
-     This QoS Policy concerns to |Topic|, |DataWriter| and |DataReader| entities.
+     This QoS Policy applies to |Topic|, |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -1299,7 +1299,7 @@ List of QoS Policy data members:
 +---------------------------------------------------------------------+-----------------------------+------------------+
 
 .. note::
-     This QoS Policy concerns to |DataReader| entities.
+     This QoS Policy applies to |DataReader| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -1321,7 +1321,7 @@ List of QoS Policy data members:
 +------------------------------------------------------------+----------------------------------------+----------------+
 
 .. note::
-    This QoS Policy concerns to |Topic| entities.
+    This QoS Policy applies to |Topic| entities.
     :raw-html:`<br />`
     It can be changed even if it is already created.
 
@@ -1369,7 +1369,7 @@ List of QoS Policy data members:
 +-------------------------------------------------------------------------------------+----------------+---------------+
 
 .. note::
-     This QoS Policy concerns to |Topic| and |DataWriter| entities.
+     This QoS Policy applies to |Topic| and |DataWriter| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -1393,7 +1393,7 @@ List of QoS Policy data members:
 +-------------------------------------------------------------------+----------------------------------+---------------+
 
 .. note::
-    This QoS Policy concerns to |DomainParticipant|, |DataWriter| and |DataReader| entities.
+    This QoS Policy applies to |DomainParticipant|, |DataWriter| and |DataReader| entities.
     :raw-html:`<br />`
     It can be changed on enabled entities.
 
@@ -1443,6 +1443,6 @@ List of QoS Policy data members:
 +--------------------------------------------------------------------------------------+-----------+-------------------+
 
 .. note::
-     This QoS Policy concerns to |DataWriter| entities.
+     This QoS Policy applies to |DataWriter| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.

--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -110,7 +110,7 @@ List of QoS Policy data members:
 +----------------------------------------------------+--------------------------------------+--------------------------+
 
 .. note::
-    This QoS Policy concerns to Topic, DataReader and DataWriter entities.
+    This QoS Policy concerns to |Topic|, |DataReader| and |DataWriter| entities.
     :raw-html:`<br />`
     It cannot be changed on enabled entities.
 
@@ -187,7 +187,7 @@ List of QoS Policy data members:
 +---------------------------------------+-----------------------+------------------------------------------------------+
 
 .. note::
-     This QoS Policy concerns to Topic, DataReader and DataWriter entities.
+     This QoS Policy concerns to |Topic|, |DataReader| and |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -330,7 +330,7 @@ List of QoS Policy data members:
   This value must be lower than the maximum number of samples.
 
 .. note::
-     This QoS Policy concerns to Topic and DataWriter entities.
+     This QoS Policy concerns to |Topic| and |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -397,7 +397,7 @@ List of QoS Policy data members:
 +--------------------------+-------------------------------+-------------------+
 
 .. note::
-     This QoS Policy concerns to Publisher and Subscriber entities.
+     This QoS Policy concerns to |Publisher| and |Subscriber| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -447,7 +447,7 @@ List of QoS Policy data members:
   :ref:`resourcelimitsqospolicy`, which means that its value must be lower or equal to max_samples_per_instance.
 
 .. note::
-     This QoS Policy concerns to Topic, DataWriter and DataReader entities.
+     This QoS Policy concerns to |Topic|, |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -840,7 +840,7 @@ List of QoS Policy data members:
 +-----------------------------------------------------------------+-------------------------------+-------------------+
 
 .. note::
-     This QoS Policy concerns to DataWriter entities.
+     This QoS Policy concerns to |DataWriter| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -891,12 +891,12 @@ List of QoS Policy data members:
 * |PartitionQosPolicy::names-api|: List of partition names.
 
 .. note::
-     This QoS Policy concerns to Publisher and Subscriber entities.
+     This QoS Policy concerns to |Publisher| and |Subscriber| entities.
      :raw-html:`<br />`
      Partitions can also be explicitly defined at the endpoint level to override this configuration. Information
      to do so can be found :ref:`here<property_policies_partitions>`.
      :raw-html:`<br />`
-     It can be changed on enabled Publishers and Subscribers.
+     It can be changed on enabled entities.
 
 Example
 """""""
@@ -1073,7 +1073,7 @@ List of QoS Policy data members:
   After this time elapses, the DataReader purges all the samples for the instance.
 
 .. note::
-     This QoS Policy concerns to DataReader entities.
+     This QoS Policy concerns to |DataReader| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -1233,7 +1233,7 @@ List of QoS Policy data members:
   These extra samples act as a reservoir of samples even when the history is full.
 
 .. note::
-     This QoS Policy concerns to Topic, DataWriter and DataReader entities.
+     This QoS Policy concerns to |Topic|, |DataWriter| and |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -1299,7 +1299,7 @@ List of QoS Policy data members:
 +---------------------------------------------------------------------+-----------------------------+------------------+
 
 .. note::
-     This QoS Policy concerns to DataReader entities.
+     This QoS Policy concerns to |DataReader| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
@@ -1321,7 +1321,7 @@ List of QoS Policy data members:
 +------------------------------------------------------------+----------------------------------------+----------------+
 
 .. note::
-    This QoS Policy concerns to Topic entities.
+    This QoS Policy concerns to |Topic| entities.
     :raw-html:`<br />`
     It can be changed even if it is already created.
 
@@ -1393,7 +1393,7 @@ List of QoS Policy data members:
 +-------------------------------------------------------------------+----------------------------------+---------------+
 
 .. note::
-    This QoS Policy concerns to all DDS entities.
+    This QoS Policy concerns to |DomainParticipant|, |DataWriter| and |DataReader| entities.
     :raw-html:`<br />`
     It can be changed on enabled entities.
 
@@ -1443,6 +1443,6 @@ List of QoS Policy data members:
 +--------------------------------------------------------------------------------------+-----------+-------------------+
 
 .. note::
-     This QoS Policy concerns to DataWriter entities.
+     This QoS Policy concerns to |DataWriter| entities.
      :raw-html:`<br />`
      It can be changed on enabled entities.

--- a/docs/fastdds/dds_layer/core/policy/xtypesExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/xtypesExtensions.rst
@@ -49,7 +49,7 @@ List of QoS Policy data members:
      - [|XCDR_DATA_REPRESENTATION-api|]
 
 .. note::
-     This QoS Policy concerns to Topic, DataReader and DataWriter entities.
+     This QoS Policy applies to |Topic|, |DataReader| and |DataWriter| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -148,7 +148,7 @@ List of QoS Policy data members:
   If it is enabled, it must have the Complete Type Information, otherwise it is not necessary.
 
 .. note::
-     This QoS Policy concerns to DataReader entities.
+     This QoS Policy applies to |DataReader| entities.
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
@@ -165,19 +165,3 @@ There are two possible values:
 * |ALLOW_TYPE_COERCION-api|:
   The DataWriter and the DataReader do not need to support the same data type in order to
   communicate as long as the DataReader's type is assignable from the DataWriter's type.
-
-.. Uncomment after implementation and update example with correct API
-.. Example
-.. """""""
-
-.. C++
-.. ***
-.. .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-..    :language: c++
-..    :dedent: 8
-..    :start-after: //DDS_CHANGE_TYPE_CONSISTENCY_ENFORCEMENT_QOS
-..    :end-before: //!
-
-.. XML
-.. ***
-.. This QoS Policy cannot be configured using XML for the moment.

--- a/docs/fastdds/dds_layer/core/policy/xtypesExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/xtypesExtensions.rst
@@ -166,17 +166,18 @@ There are two possible values:
   The DataWriter and the DataReader do not need to support the same data type in order to
   communicate as long as the DataReader's type is assignable from the DataWriter's type.
 
-Example
-"""""""
+.. Uncomment after implementation and update example with correct API
+.. Example
+.. """""""
 
-C++
-***
-.. literalinclude:: ../../../../../code/DDSCodeTester.cpp
-   :language: c++
-   :dedent: 8
-   :start-after: //DDS_CHANGE_TYPE_CONSISTENCY_ENFORCEMENT_QOS
-   :end-before: //!
+.. C++
+.. ***
+.. .. literalinclude:: ../../../../../code/DDSCodeTester.cpp
+..    :language: c++
+..    :dedent: 8
+..    :start-after: //DDS_CHANGE_TYPE_CONSISTENCY_ENFORCEMENT_QOS
+..    :end-before: //!
 
-XML
-***
-This QoS Policy cannot be configured using XML for the moment.
+.. XML
+.. ***
+.. This QoS Policy cannot be configured using XML for the moment.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR updates the code examples of the QoS Policy to be more illustrative and include how the modified QoS should be used after editing it.
Additionally, it reviews that the API of QoS is identical for all entities that share a common QoS. It also makes the PropertyPolicyQoS of DataWriters and DataReader unmutable (such as the one of Participants), until a deeper study is made on what Policies should be mutable on enabled entities.

It also includes minor improvements in the readability of the docs (references, tabs, etc).

- It must be merged after: https://github.com/eProsima/Fast-DDS/pull/4842


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
