### PR TITLE
[21054] Add XML configuration for FlowControllerDescriptor

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4230,6 +4230,8 @@ void dds_qos_examples()
         //The PublishModeQosPolicy is default constructed with kind = SYNCHRONOUS
         //Change the kind to ASYNCHRONOUS
         publish_mode.kind = ASYNCHRONOUS_PUBLISH_MODE;
+        // Optionally, select the flow controller name
+        publish_mode.flow_controller_name = "example_flow_controller_name";
         //!--
     }
 

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -827,6 +827,12 @@
                     <scheduler>FIFO</scheduler>
                     <max_bytes_per_period>4096</max_bytes_per_period>
                     <period_ms>500</period_ms>
+                    <sender_thread>
+                        <scheduling_policy>-1</scheduling_policy>
+                        <priority>0</priority>
+                        <affinity>0</affinity>
+                        <stack_size>-1</stack_size>
+                    </sender_thread>
                 </flow_controller_descriptor>
             </flow_controller_descriptor_list>
         </rtps>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -819,8 +819,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <profiles xmlns="http://www.eprosima.com">
 -->
+    <participant profile_name="participant_profile_qos_flowcontroller">
+        <rtps>
+            <flow_controller_descriptor_list>
+                <flow_controller_descriptor>
+                    <name>example_flow_controller</name>
+                    <scheduler>FIFO</scheduler>
+                    <max_bytes_per_period>4096</max_bytes_per_period>
+                    <period_ms>500</period_ms>
+                </flow_controller_descriptor>
+            </flow_controller_descriptor_list>
+        </rtps>
+    </participant>
+
     <data_writer profile_name="writer_profile_qos_flowcontroller">
-        <!-- TODO: Configure FlowController through XML -->
+        <qos>
+            <publishMode>
+                <kind>ASYNCHRONOUS</kind>
+                <flow_controller_name>example_flow_controller</flow_controller_name>
+            </publishMode>
+        </qos>
     </data_writer>
 <!--><-->
 
@@ -829,6 +847,7 @@
     <qos>
         <publishMode>
             <kind>ASYNCHRONOUS</kind>
+            <flow_controller_name>example_flow_controller</flow_controller_name>
         </publishMode>
     </qos>
 </data_writer>

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -548,6 +548,8 @@ There are two possible values (see |PublishModeQosPolicyKind-api|):
 * |ASYNCHRONOUS_PUBLISH_MODE-api|: An internal thread takes the responsibility of sending the data asynchronously.
   The write operation returns before the data is actually sent.
 
+Also, the |PublishModeQosPolicy::flow_ctrl_name-api| has to be set to the name of a valid :ref:`flow-controllers` descriptor name.
+
 Example
 """""""
 

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -548,7 +548,8 @@ There are two possible values (see |PublishModeQosPolicyKind-api|):
 * |ASYNCHRONOUS_PUBLISH_MODE-api|: An internal thread takes the responsibility of sending the data asynchronously.
   The write operation returns before the data is actually sent.
 
-Also, the |PublishModeQosPolicy::flow_ctrl_name-api| has to be set to the name of a valid :ref:`flow-controllers` descriptor name.
+Also, the |PublishModeQosPolicy::flow_ctrl_name-api| has to be set to the name of a valid :ref:`flow-controllers`
+descriptor name.
 
 Example
 """""""

--- a/docs/fastdds/use_cases/large_data/large_data.rst
+++ b/docs/fastdds/use_cases/large_data/large_data.rst
@@ -258,8 +258,10 @@ Example configuration
 
    .. tab:: XML
 
-      There is currently no way of configuring flow controllers with XML.
-      This will be added in future releases of the product.
+      .. literalinclude:: /../code/XMLTester.xml
+         :language: xml
+         :start-after: <!-->CONF-QOS-FLOWCONTROLLER
+         :end-before: <!--><-->
 
 .. Warning::
 

--- a/docs/fastdds/use_cases/large_data/large_data.rst
+++ b/docs/fastdds/use_cases/large_data/large_data.rst
@@ -262,6 +262,8 @@ Example configuration
          :language: xml
          :start-after: <!-->CONF-QOS-FLOWCONTROLLER
          :end-before: <!--><-->
+         :lines: 2-3, 5-25
+         :append: </profiles>
 
 .. Warning::
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adds the XML configuration for FlowControllerDescriptor.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#4837

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- __NO__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
