### PR TITLE
[21106] Add missing documentation of netmask filter and max_msg_size_no_frag in TransportConfigQos

### DIFF
--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -16,7 +16,6 @@
 using namespace eprosima::fastdds::dds;
 using namespace eprosima::fastrtps;
 using namespace ::rtps;
-using namespace ::security;
 
 class HelloWorld
 {

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4359,6 +4359,10 @@ void dds_qos_examples()
         transport.use_builtin_transports = false;
         // [OPTIONAL] Set ThreadSettings for the builtin transports reception threads
         transport.builtin_transports_reception_threads_ = eprosima::fastdds::rtps::ThreadSettings{2, 2, 2, 2};
+        // Set max_msg_size_no_frag to a value > 65500 KB
+        transport.max_msg_size_no_frag = 70000;
+        // Configure netmask filter
+        transport.netmask_filter = NetmaskFilterKind::ON;
         //!--
     }
 

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4362,7 +4362,7 @@ void dds_qos_examples()
         // Set max_msg_size_no_frag to a value > 65500 KB
         transport.max_msg_size_no_frag = 70000;
         // Configure netmask filter
-        transport.netmask_filter = NetmaskFilterKind::ON;
+        transport.netmask_filter = eprosima::fastdds::rtps::NetmaskFilterKind::ON;
         //!--
     }
 

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -281,6 +281,7 @@
             <transport_id>my_transport</transport_id>
         </userTransports>
         <useBuiltinTransports>false</useBuiltinTransports>
+        <netmask_filter>ON</netmask_filter>
     </rtps>
 </participant>
 <!--><-->

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -588,6 +588,8 @@
 .. |TransportConfigQos::send_socket_buffer_size-api| replace:: :cpp:member:`send_socket_buffer_size<eprosima::fastdds::dds::TransportConfigQos::send_socket_buffer_size>`
 .. |TransportConfigQos::listen_socket_buffer_size-api| replace:: :cpp:member:`listen_socket_buffer_size<eprosima::fastdds::dds::TransportConfigQos::listen_socket_buffer_size>`
 .. |TransportConfigQos::builtin_transports_reception_threads-api| replace:: :cpp:func:`builtin_transports_reception_threads()<eprosima::fastdds::dds::TransportConfigQos::builtin_transports_reception_threads>`
+.. |TransportConfigQos::max_msg_size_no_frag-api| replace:: :cpp:member:`max_msg_size_no_frag<eprosima::fastdds::dds::TransportConfigQos::max_msg_size_no_frag>`
+.. |TransportConfigQos::netmask_filter-api| replace:: :cpp:member:`netmask_filter<eprosima::fastdds::dds::TransportConfigQos::netmask_filter>`
 
 .. |TransportDescriptorInterface-api| replace:: :cpp:struct:`TransportDescriptorInterface<eprosima::fastdds::rtps::TransportDescriptorInterface>`
 .. |TransportDescriptorInterface::maxMessageSize-api| replace:: :cpp:member:`maxMessageSize<eprosima::fastdds::rtps::TransportDescriptorInterface::maxMessageSize>`

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1027,7 +1027,8 @@ List of QoS Policy data members:
 * |TransportConfigQos::builtin_transports_reception_threads-api|:
   The |ThreadSettings| for the reception threads of the builtin transports.
 * |TransportConfigQos::max_msg_size_no_frag-api|:
-  Maximum message size used to avoid fragmentation, set only in LARGE_DATA.
+  Maximum message size used to avoid fragmentation.
+  Useful when the configured transports allow for big datagrams to be sent (i.e. SHM or TCP).
 * |TransportConfigQos::netmask_filter-api|:
   :ref:`Network filter<netmask_filtering>` configuration.
 

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1005,6 +1005,12 @@ List of QoS Policy data members:
    * - |TransportConfigQos::builtin_transports_reception_threads-api|
      - |ThreadSettings|
      -
+   * - |TransportConfigQos::max_msg_size_no_frag-api|
+     - ``uint32_t``
+     - 0
+   * - |TransportConfigQos::netmask_filter-api|
+     - ``fastdds::rtps::NetmaskFilterKind``
+     - ``AUTO``
 
 
 * |TransportConfigQos::user_transports-api|:
@@ -1020,6 +1026,10 @@ List of QoS Policy data members:
   be changed using this data member.
 * |TransportConfigQos::builtin_transports_reception_threads-api|:
   The |ThreadSettings| for the reception threads of the builtin transports.
+* |TransportConfigQos::max_msg_size_no_frag-api|:
+  Maximum message size used to avoid fragmentation, set only in LARGE_DATA.
+* |TransportConfigQos::netmask_filter-api|:
+  :ref:`Network filter<netmask_filtering>` configuration.
 
 .. note::
      This QoS Policy concerns to |DomainParticipant| entities.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
In TransportConfigQos is missing the documentation of 
* Netmask filter ( introduced in https://github.com/eProsima/Fast-DDS/pull/4241 )
* max_msg_size_no_frag


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->

@Mergifyio backport 2.14.x <!-- 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
