### PR TITLE
[21098] Change default logconsumer to StdoutErr

### DIFF
--- a/docs/fastdds/logging/consumer.rst
+++ b/docs/fastdds/logging/consumer.rst
@@ -22,8 +22,6 @@ StdoutConsumer
 
 |StdoutConsumer-api| outputs log entries to STDOUT stream following the convection specified in
 :ref:`dds_layer_log_logging_spec`.
-It is the default and only log consumer of the logging module if the CMake option |LOG_CONSUMER_DEFAULT| is set to
-``AUTO``, ``STDOUT``, or not set at all.
 It can be registered and unregistered using the methods explained in
 :ref:`dds_layer_log_register_consumers` and :ref:`dds_layer_log_reset`.
 
@@ -42,6 +40,8 @@ StdoutErrConsumer
 |StdoutErrConsumer-api| uses a |Log::Kind-api| threshold to filter the output of the log entries.
 Those log entries whose |Log::Kind-api| is equal to or more severe than the given threshold output to STDERR.
 Other log entries output to STDOUT.
+It is the default and only log consumer of the logging module if the CMake option |LOG_CONSUMER_DEFAULT| is set to
+``AUTO``, ``STDOUTERR``, or not set at all.
 By default, the threshold is set to |Log::Kind::Warning-api|.
 |StdoutErrConsumer::stderr_threshold-api| allows the user to modify the default threshold.
 

--- a/docs/fastdds/logging/consumer.rst
+++ b/docs/fastdds/logging/consumer.rst
@@ -22,6 +22,7 @@ StdoutConsumer
 
 |StdoutConsumer-api| outputs log entries to STDOUT stream following the convection specified in
 :ref:`dds_layer_log_logging_spec`.
+It is the default logging module if the CMake option |LOG_CONSUMER_DEFAULT| is set to ``STDOUT``.
 It can be registered and unregistered using the methods explained in
 :ref:`dds_layer_log_register_consumers` and :ref:`dds_layer_log_reset`.
 

--- a/docs/installation/configuration/cmake_options.rst
+++ b/docs/installation/configuration/cmake_options.rst
@@ -171,7 +171,7 @@ This module can be configured using *Fast DDS* CMake arguments regarding the fol
         - Default
     *   - :class:`LOG_CONSUMER_DEFAULT`
         - Selects the default log consumer for the logging module. |br|
-          ``AUTO`` has the same behavior as ``STDOUT``. |br|
+          ``AUTO`` has the same behavior as ``STDOUTERR``. |br|
           For more information, please refer to :ref:`Log consumers <dds_layer_log_consumer>`.
         - ``AUTO`` ``STDOUT`` |br|
           ``STDOUTERR``


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR documents the change of making `StdoutErr` the default `LogConsumer`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#4873


## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- __NO__ Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- __NO__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
