### PR TITLE
TypeObjectRegistry refactor [21135]

### DIFF
--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.cxx
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.cxx
@@ -219,9 +219,9 @@ bool HelloWorldPubSubType::getKey(
     return true;
 }
 
-void HelloWorldPubSubType::register_type_object_representation() const
+void HelloWorldPubSubType::register_type_object_representation()
 {
-    register_HelloWorld_type_objects();
+    register_HelloWorld_type_identifier(type_identifiers_);
 }
 
 

--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.h
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.h
@@ -89,7 +89,7 @@ public:
             void* data) override;
 
     //Register TypeObject representation in Fast DDS TypeObjectRegistry
-    eProsima_user_DllExport void register_type_object_representation() const override;
+    eProsima_user_DllExport void register_type_object_representation() override;
 
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override

--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldTypeObjectSupport.cxx
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldTypeObjectSupport.cxx
@@ -38,26 +38,19 @@
 
 using namespace eprosima::fastdds::dds::xtypes;
 
-void register_HelloWorld_type_objects()
-{
-    static std::once_flag once_flag;
-    std::call_once(once_flag, []()
-            {
-                TypeIdentifier type_id;
-                register_HelloWorld_type_identifier(type_id);
-
-            });
-}
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HelloWorld_type_identifier(
-        TypeIdentifier& type_id)
+        TypeIdentifierPair& type_ids_HelloWorld)
 {
+
+    ReturnCode_t return_code_HelloWorld {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_HelloWorld =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "HelloWorld", type_ids_HelloWorld);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_HelloWorld)
     {
         StructTypeFlag struct_flags_HelloWorld = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::NOT_APPLIED,
                 false, false);
-        ReturnCode_t return_code_HelloWorld;
-        TypeIdentifierPair type_ids_HelloWorld;
         QualifiedTypeName type_name_HelloWorld = "HelloWorld";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HelloWorld;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HelloWorld;
@@ -66,62 +59,26 @@ void register_HelloWorld_type_identifier(
         header_HelloWorld = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HelloWorld);
         CompleteStructMemberSeq member_seq_HelloWorld;
         {
-            return_code_HelloWorld =
+            TypeIdentifierPair type_ids_index;
+            ReturnCode_t return_code_index {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_index =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "_uint32_t", type_ids_HelloWorld);
+                "_uint32_t", type_ids_index);
 
-            if (return_code_HelloWorld != eprosima::fastdds::dds::RETCODE_OK)
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_index)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                         "index Structure member TypeIdentifier unknown to TypeObjectRegistry.");
-                type_id = TypeIdentifier();
                 return;
             }
             StructMemberFlag member_flags_index = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructKind::NOT_APPLIED,
                     false, false, false, false);
-            CommonStructMember common_index;
             MemberId member_id_index = 0x00000000;
-            if (EK_COMPLETE == type_ids_HelloWorld.type_identifier1()._d() || TK_NONE == type_ids_HelloWorld.type_identifier2()._d() ||
-                    (TI_PLAIN_SEQUENCE_SMALL == type_ids_HelloWorld.type_identifier1()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().seq_sdefn().header().equiv_kind()) ||
-                    (TI_PLAIN_SEQUENCE_LARGE == type_ids_HelloWorld.type_identifier1()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().seq_ldefn().header().equiv_kind()) ||
-                    (TI_PLAIN_ARRAY_SMALL == type_ids_HelloWorld.type_identifier1()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().array_sdefn().header().equiv_kind()) ||
-                    (TI_PLAIN_ARRAY_LARGE == type_ids_HelloWorld.type_identifier1()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().array_ldefn().header().equiv_kind()) ||
-                    (TI_PLAIN_MAP_SMALL == type_ids_HelloWorld.type_identifier1()._d() &&
-                    (EK_COMPLETE == type_ids_HelloWorld.type_identifier1().map_sdefn().header().equiv_kind() ||
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().map_sdefn().key_identifier()->_d())) ||
-                    (TI_PLAIN_MAP_LARGE == type_ids_HelloWorld.type_identifier1()._d() &&
-                    (EK_COMPLETE == type_ids_HelloWorld.type_identifier1().map_ldefn().header().equiv_kind() ||
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().map_ldefn().key_identifier()->_d())))
+            bool common_index_ec {false};
+            CommonStructMember common_index {TypeObjectUtils::build_common_struct_member(member_id_index, member_flags_index, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_index, common_index_ec))};
+            if (!common_index_ec)
             {
-                common_index = TypeObjectUtils::build_common_struct_member(member_id_index, member_flags_index, type_ids_HelloWorld.type_identifier1());
-            }
-            else if (EK_COMPLETE == type_ids_HelloWorld.type_identifier2()._d() ||
-                    (TI_PLAIN_SEQUENCE_SMALL == type_ids_HelloWorld.type_identifier2()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().seq_sdefn().header().equiv_kind()) ||
-                    (TI_PLAIN_SEQUENCE_LARGE == type_ids_HelloWorld.type_identifier2()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().seq_ldefn().header().equiv_kind()) ||
-                    (TI_PLAIN_ARRAY_SMALL == type_ids_HelloWorld.type_identifier2()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().array_sdefn().header().equiv_kind()) ||
-                    (TI_PLAIN_ARRAY_LARGE == type_ids_HelloWorld.type_identifier2()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().array_ldefn().header().equiv_kind()) ||
-                    (TI_PLAIN_MAP_SMALL == type_ids_HelloWorld.type_identifier2()._d() &&
-                    (EK_COMPLETE == type_ids_HelloWorld.type_identifier2().map_sdefn().header().equiv_kind() ||
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().map_sdefn().key_identifier()->_d())) ||
-                    (TI_PLAIN_MAP_LARGE == type_ids_HelloWorld.type_identifier2()._d() &&
-                    (EK_COMPLETE == type_ids_HelloWorld.type_identifier2().map_ldefn().header().equiv_kind() ||
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().map_ldefn().key_identifier()->_d())))
-            {
-                common_index = TypeObjectUtils::build_common_struct_member(member_id_index, member_flags_index, type_ids_HelloWorld.type_identifier2());
-            }
-            else
-            {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure index member TypeIdentifier inconsistent.");
-                type_id = TypeIdentifier();
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure index member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_index = "index";
@@ -132,79 +89,34 @@ void register_HelloWorld_type_identifier(
             TypeObjectUtils::add_complete_struct_member(member_seq_HelloWorld, member_index);
         }
         {
-            return_code_HelloWorld =
+            TypeIdentifierPair type_ids_message;
+            ReturnCode_t return_code_message {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_message =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_string_unbounded", type_ids_HelloWorld);
+                "anonymous_string_unbounded", type_ids_message);
 
-            if (return_code_HelloWorld != eprosima::fastdds::dds::RETCODE_OK)
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_message)
             {
                 {
                     SBound bound = 0;
                     StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
                             TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
-                            "anonymous_string_unbounded"))
+                            "anonymous_string_unbounded", type_ids_message))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                             "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
-                return_code_HelloWorld =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                    "anonymous_string_unbounded", type_ids_HelloWorld);
-                if (return_code_HelloWorld != eprosima::fastdds::dds::RETCODE_OK)
-                {
-                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded: Given String TypeIdentifier unknown to TypeObjectRegistry.");
-                    type_id = TypeIdentifier();
-                    return;
-                }
             }
             StructMemberFlag member_flags_message = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructKind::NOT_APPLIED,
                     false, false, false, false);
-            CommonStructMember common_message;
             MemberId member_id_message = 0x00000001;
-            if (EK_COMPLETE == type_ids_HelloWorld.type_identifier1()._d() || TK_NONE == type_ids_HelloWorld.type_identifier2()._d() ||
-                    (TI_PLAIN_SEQUENCE_SMALL == type_ids_HelloWorld.type_identifier1()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().seq_sdefn().header().equiv_kind()) ||
-                    (TI_PLAIN_SEQUENCE_LARGE == type_ids_HelloWorld.type_identifier1()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().seq_ldefn().header().equiv_kind()) ||
-                    (TI_PLAIN_ARRAY_SMALL == type_ids_HelloWorld.type_identifier1()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().array_sdefn().header().equiv_kind()) ||
-                    (TI_PLAIN_ARRAY_LARGE == type_ids_HelloWorld.type_identifier1()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().array_ldefn().header().equiv_kind()) ||
-                    (TI_PLAIN_MAP_SMALL == type_ids_HelloWorld.type_identifier1()._d() &&
-                    (EK_COMPLETE == type_ids_HelloWorld.type_identifier1().map_sdefn().header().equiv_kind() ||
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().map_sdefn().key_identifier()->_d())) ||
-                    (TI_PLAIN_MAP_LARGE == type_ids_HelloWorld.type_identifier1()._d() &&
-                    (EK_COMPLETE == type_ids_HelloWorld.type_identifier1().map_ldefn().header().equiv_kind() ||
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier1().map_ldefn().key_identifier()->_d())))
+            bool common_message_ec {false};
+            CommonStructMember common_message {TypeObjectUtils::build_common_struct_member(member_id_message, member_flags_message, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_message, common_message_ec))};
+            if (!common_message_ec)
             {
-                common_message = TypeObjectUtils::build_common_struct_member(member_id_message, member_flags_message, type_ids_HelloWorld.type_identifier1());
-            }
-            else if (EK_COMPLETE == type_ids_HelloWorld.type_identifier2()._d() ||
-                    (TI_PLAIN_SEQUENCE_SMALL == type_ids_HelloWorld.type_identifier2()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().seq_sdefn().header().equiv_kind()) ||
-                    (TI_PLAIN_SEQUENCE_LARGE == type_ids_HelloWorld.type_identifier2()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().seq_ldefn().header().equiv_kind()) ||
-                    (TI_PLAIN_ARRAY_SMALL == type_ids_HelloWorld.type_identifier2()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().array_sdefn().header().equiv_kind()) ||
-                    (TI_PLAIN_ARRAY_LARGE == type_ids_HelloWorld.type_identifier2()._d() &&
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().array_ldefn().header().equiv_kind()) ||
-                    (TI_PLAIN_MAP_SMALL == type_ids_HelloWorld.type_identifier2()._d() &&
-                    (EK_COMPLETE == type_ids_HelloWorld.type_identifier2().map_sdefn().header().equiv_kind() ||
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().map_sdefn().key_identifier()->_d())) ||
-                    (TI_PLAIN_MAP_LARGE == type_ids_HelloWorld.type_identifier2()._d() &&
-                    (EK_COMPLETE == type_ids_HelloWorld.type_identifier2().map_ldefn().header().equiv_kind() ||
-                    EK_COMPLETE == type_ids_HelloWorld.type_identifier2().map_ldefn().key_identifier()->_d())))
-            {
-                common_message = TypeObjectUtils::build_common_struct_member(member_id_message, member_flags_message, type_ids_HelloWorld.type_identifier2());
-            }
-            else
-            {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure message member TypeIdentifier inconsistent.");
-                type_id = TypeIdentifier();
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure message member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_message = "message";
@@ -216,20 +128,10 @@ void register_HelloWorld_type_identifier(
         }
         CompleteStructType struct_type_HelloWorld = TypeObjectUtils::build_complete_struct_type(struct_flags_HelloWorld, header_HelloWorld, member_seq_HelloWorld);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HelloWorld, type_name_HelloWorld.to_string(), type_id))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HelloWorld, type_name_HelloWorld.to_string(), type_ids_HelloWorld))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HelloWorld already registered in TypeObjectRegistry for a different type.");
-        }
-        return_code_HelloWorld =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-            "HelloWorld", type_ids_HelloWorld);
-        if (return_code_HelloWorld != eprosima::fastdds::dds::RETCODE_OK)
-        {
-            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "HelloWorld: Given Struct TypeIdentifier unknown to TypeObjectRegistry.");
-            type_id = TypeIdentifier();
-            return;
         }
     }
 }

--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldTypeObjectSupport.cxx
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldTypeObjectSupport.cxx
@@ -49,7 +49,7 @@ void register_HelloWorld_type_identifier(
         "HelloWorld", type_ids_HelloWorld);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HelloWorld)
     {
-        StructTypeFlag struct_flags_HelloWorld = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::NOT_APPLIED,
+        StructTypeFlag struct_flags_HelloWorld = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
                 false, false);
         QualifiedTypeName type_name_HelloWorld = "HelloWorld";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HelloWorld;
@@ -71,7 +71,7 @@ void register_HelloWorld_type_identifier(
                         "index Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_index = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructKind::NOT_APPLIED,
+            StructMemberFlag member_flags_index = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
                     false, false, false, false);
             MemberId member_id_index = 0x00000000;
             bool common_index_ec {false};
@@ -109,7 +109,7 @@ void register_HelloWorld_type_identifier(
                     }
                 }
             }
-            StructMemberFlag member_flags_message = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructKind::NOT_APPLIED,
+            StructMemberFlag member_flags_message = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
                     false, false, false, false);
             MemberId member_id_message = 0x00000001;
             bool common_message_ec {false};

--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldTypeObjectSupport.hpp
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldTypeObjectSupport.hpp
@@ -35,11 +35,6 @@
 #define eProsima_user_DllExport
 #endif  // _WIN32
 
-/**
- * @brief Register every TypeObject representation defined in the IDL file in Fast DDS TypeObjectRegistry.
- */
-eProsima_user_DllExport void register_HelloWorld_type_objects();
-
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 /**
@@ -53,7 +48,7 @@ eProsima_user_DllExport void register_HelloWorld_type_objects();
  *             Invalid TypeIdentifier is returned in case of error.
  */
 eProsima_user_DllExport void register_HelloWorld_type_identifier(
-        eprosima::fastdds::dds::xtypes::TypeIdentifier& type_id);
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
 
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/docs/fastdds/api_reference/spelling_wordlist.txt
+++ b/docs/fastdds/api_reference/spelling_wordlist.txt
@@ -276,6 +276,7 @@ typedef
 typeid
 TypeIdentfierWithSizePubSubType
 TypeIdentifier
+TypeIdentifierPair
 TypeIdentifierPairPubSubType
 TypeIdentifierTypeObjectPairPubSubType
 TypeIdentifierWithDependenciesPubSubType


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description

This PR only regenerate the IDL files.

Related implementation PR:

- eprosima/fast-dds#4874
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- *N/A* Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
