### PR TITLE
[21114] Check suprocess return codes on RDT generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -293,10 +293,13 @@ if read_the_docs_build:
         project_source_dir
     )
     # Generate doxygen documentation
-    subprocess.call('doxygen {}'.format(doxyfile_out), shell=True)
+    doxygen_ret = subprocess.call('doxygen {}'.format(doxyfile_out), shell=True)
+    if doxygen_ret != 0:
+        print('Doxygen failed with return code {}'.format(doxygen_ret))
+        sys.exit(doxygen_ret)
 
     # Generate SWIG code.
-    subprocess.call('swig -python -doxygen -I{}/include \
+    swig_ret = subprocess.call('swig -python -doxygen -I{}/include \
             -outdir {}/fastdds_python/src/swig -c++ -interface \
             _fastdds_python -o \
             {}/fastdds_python/src/swig/fastddsPYTHON_wrap.cxx \
@@ -306,6 +309,10 @@ if read_the_docs_build:
                 fastdds_python_repo_name,
                 fastdds_python_repo_name
                 ), shell=True)
+    if swig_ret != 0:
+        print('SWIG failed with return code {}'.format(swig_ret))
+        sys.exit(swig_ret)
+
     fastdds_python_imported_location = '{}/fastdds_python/src/swig'.format(
             fastdds_python_repo_name)
     autodoc_mock_imports = ["_fastdds_python"]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR makes the RDT generation to fail if either of the `doxygen` or `swig` commands fails. Not checking them was causing the documentation to build with API reference errors.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#4896

**NOTE**: As RTD build is not ready to take the appropriate Fast DDS branch and will choose `master`, the build will failed until eProsima/Fast-DDS#4896 is merged. I've verified on a Ubuntu 20.04 docker that the doxygen is generated without errors with that Fast DDS PR.

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_: Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
