### PR TITLE
[21121] IPayloadPool refactor

### DIFF
--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -192,7 +192,7 @@ void rtps_api_example_create_entities_with_custom_pool()
         }
 
         bool get_payload(
-                SerializedPayload_t& data,
+                const SerializedPayload_t& data,
                 SerializedPayload_t& payload)
         {
             // Reserve new memory for the payload buffer

--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -175,64 +175,63 @@ void rtps_api_example_create_entities_with_custom_pool()
     {
         bool get_payload(
                 uint32_t size,
-                CacheChange_t& cache_change) override
+                SerializedPayload_t& payload) override
         {
             // Reserve new memory for the payload buffer
-            octet* payload = new octet[size];
+            octet* payload_buff = new octet[size];
 
             // Assign the payload buffer to the CacheChange and update sizes
-            cache_change.serializedPayload.data = payload;
-            cache_change.serializedPayload.length = size;
-            cache_change.serializedPayload.max_size = size;
+            payload.data = payload_buff;
+            payload.length = size;
+            payload.max_size = size;
 
             // Tell the CacheChange who needs to release its payload
-            cache_change.payload_owner(this);
+            payload.payload_owner(this);
 
             return true;
         }
 
         bool get_payload(
                 SerializedPayload_t& data,
-                IPayloadPool*& /*data_owner*/,
-                CacheChange_t& cache_change)
+                SerializedPayload_t& payload)
         {
             // Reserve new memory for the payload buffer
-            octet* payload = new octet[data.length];
+            octet* payload_buff = new octet[data.length];
 
             // Copy the data
-            memcpy(payload, data.data, data.length);
+            memcpy(payload_buff, data.data, data.length);
 
             // Tell the CacheChange who needs to release its payload
-            cache_change.payload_owner(this);
+            payload.payload_owner(this);
 
             // Assign the payload buffer to the CacheChange and update sizes
-            cache_change.serializedPayload.data = payload;
-            cache_change.serializedPayload.length = data.length;
-            cache_change.serializedPayload.max_size = data.length;
+            payload.data = payload_buff;
+            payload.length = data.length;
+            payload.max_size = data.length;
 
             return true;
         }
 
         bool release_payload(
-                CacheChange_t& cache_change) override
+                SerializedPayload_t& payload) override
         {
             // Ensure precondition
-            if (this != cache_change.payload_owner())
+            if (this != payload.payload_owner())
             {
                 std::cerr << "Trying to release a payload buffer allocated by a different PayloadPool." << std::endl;
                 return false;
             }
 
             // Dealloc the buffer of the payload
-            delete[] cache_change.serializedPayload.data;
+            delete[] payload.data;
 
             // Reset sizes and pointers
-            cache_change.serializedPayload.data = nullptr;
-            cache_change.serializedPayload.length = 0;
-            cache_change.serializedPayload.max_size = 0;
+            payload.data = nullptr;
+            payload.length = 0;
+            payload.max_size = 0;
 
             // Reset the owner of the payload
-            cache_change.payload_owner(nullptr);
+            payload.payload_owner(nullptr);
 
             return true;
         }

--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -186,7 +186,7 @@ void rtps_api_example_create_entities_with_custom_pool()
             payload.max_size = size;
 
             // Tell the CacheChange who needs to release its payload
-            payload.payload_owner(this);
+            payload.payload_owner = this;
 
             return true;
         }
@@ -202,7 +202,7 @@ void rtps_api_example_create_entities_with_custom_pool()
             memcpy(payload_buff, data.data, data.length);
 
             // Tell the CacheChange who needs to release its payload
-            payload.payload_owner(this);
+            payload.payload_owner = this;
 
             // Assign the payload buffer to the CacheChange and update sizes
             payload.data = payload_buff;
@@ -216,7 +216,7 @@ void rtps_api_example_create_entities_with_custom_pool()
                 SerializedPayload_t& payload) override
         {
             // Ensure precondition
-            if (this != payload.payload_owner())
+            if (this != payload.payload_owner)
             {
                 std::cerr << "Trying to release a payload buffer allocated by a different PayloadPool." << std::endl;
                 return false;
@@ -231,7 +231,7 @@ void rtps_api_example_create_entities_with_custom_pool()
             payload.max_size = 0;
 
             // Reset the owner of the payload
-            payload.payload_owner(nullptr);
+            payload.payload_owner = nullptr;
 
             return true;
         }

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -266,7 +266,7 @@ public:
     }
 
     bool get_payload(
-            eprosima::fastrtps::rtps::SerializedPayload_t& data,
+            const eprosima::fastrtps::rtps::SerializedPayload_t& data,
             eprosima::fastrtps::rtps::SerializedPayload_t& payload)
     {
         return true;

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -260,21 +260,20 @@ public:
     ~CustomPayloadPool() = default;
     bool get_payload(
             unsigned int size,
-            eprosima::fastrtps::rtps::CacheChange_t& cache_change)
+            eprosima::fastrtps::rtps::SerializedPayload_t& payload)
     {
         return true;
     }
 
     bool get_payload(
             eprosima::fastrtps::rtps::SerializedPayload_t& data,
-            eprosima::fastrtps::rtps::IPayloadPool*& data_owner,
-            eprosima::fastrtps::rtps::CacheChange_t& cache_change)
+            eprosima::fastrtps::rtps::SerializedPayload_t& payload)
     {
         return true;
     }
 
     bool release_payload(
-            eprosima::fastrtps::rtps::CacheChange_t& cache_change)
+            eprosima::fastrtps::rtps::SerializedPayload_t& payload)
     {
         return true;
     }

--- a/docs/fastdds/rtps_layer/rtps_layer.rst
+++ b/docs/fastdds/rtps_layer/rtps_layer.rst
@@ -305,8 +305,8 @@ IPayloadPool interface
 * |IPayloadPool::get_payload-api| overload with SerializadPayload parameter:
 
   Copies the given Payload data to a new Payload from the pool and ties it to the :class:`CacheChange_t` instance.
-  This overload also takes a pointer to the pool that owns the original Payload.
-  This allows certain optimizations, like sharing the Payload if the original one comes form this same pool,
+  Each :cpp:member:`SerializedPayload_t` contains a pointer to the pool that owns the original Payload.
+  This allows certain certain optimizations, like sharing the Payload if the original one comes from this same pool,
   therefore avoiding the copy operation.
 
 * |IPayloadPool::release_payload-api|:

--- a/docs/fastdds/rtps_layer/rtps_layer.rst
+++ b/docs/fastdds/rtps_layer/rtps_layer.rst
@@ -304,8 +304,8 @@ IPayloadPool interface
 
 * |IPayloadPool::get_payload-api| overload with SerializadPayload parameter:
 
-  Copies the given Payload data to a new Payload from the pool and ties it to the :class:`CacheChange_t` instance.
-  Each :cpp:member:`SerializedPayload_t` contains a pointer to the pool that owns the original Payload.
+  Copies the given Payload data to a new Payload from the pool.
+  Each :cpp:member:`SerializedPayload_t` contains a pointer to the pool that allocated its data.
   This allows certain certain optimizations, like sharing the Payload if the original one comes from this same pool,
   therefore avoiding the copy operation.
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR updates the code examples that implement a CustomPayloadPool after the changes in `IPayloadPool` and derived classes. 

- It must be merged after: https://github.com/eProsima/Fast-DDS/pull/4892

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
