### PR TITLE
[21054] Make explicit the need to keep alive the flow controller descriptor name

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4097,7 +4097,7 @@ void dds_qos_examples()
 
         // Optionally, select the flow controller name
         //Important: the flow_controller_name must be kept alive during the Participant's lifetime.
-        static std::string flow_controller_name{"example_flow_controller"}
+        static std::string flow_controller_name{"example_flow_controller"};
         publish_mode.flow_controller_name = flow_controller_name.c_str();
         //!--
     }

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4096,7 +4096,7 @@ void dds_qos_examples()
         publish_mode.kind = ASYNCHRONOUS_PUBLISH_MODE;
 
         // Optionally, select the flow controller name
-        //Important: the flow_controller_name must be kept alive during the Participant's lifetime.
+        // Important: the flow_controller_name must be kept alive during the Participant's lifetime.
         static std::string flow_controller_name{"example_flow_controller"};
         publish_mode.flow_controller_name = flow_controller_name.c_str();
         //!--
@@ -5412,7 +5412,7 @@ void dds_usecase_examples()
     {
         //CONF-QOS-FLOWCONTROLLER
         // Limit to 300kb per second.
-        //Important: the flow_controller_name must be kept alive during the Participant's lifetime.
+        // Important: the flow_controller_name must be kept alive during the Participant's lifetime.
         static const char* flow_controller_name = "example_flow_controller";
         auto flow_control_300k_per_sec = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
         flow_control_300k_per_sec->name = flow_controller_name;

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4094,8 +4094,11 @@ void dds_qos_examples()
         //The PublishModeQosPolicy is default constructed with kind = SYNCHRONOUS
         //Change the kind to ASYNCHRONOUS
         publish_mode.kind = ASYNCHRONOUS_PUBLISH_MODE;
+
         // Optionally, select the flow controller name
-        publish_mode.flow_controller_name = "example_flow_controller";
+        //Important: the flow_controller_name must be kept alive during the Participant's lifetime.
+        static std::string flow_controller_name{"example_flow_controller"}
+        publish_mode.flow_controller_name = flow_controller_name.c_str();
         //!--
     }
 
@@ -5409,6 +5412,7 @@ void dds_usecase_examples()
     {
         //CONF-QOS-FLOWCONTROLLER
         // Limit to 300kb per second.
+        //Important: the flow_controller_name must be kept alive during the Participant's lifetime.
         static const char* flow_controller_name = "example_flow_controller";
         auto flow_control_300k_per_sec = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
         flow_control_300k_per_sec->name = flow_controller_name;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
#793 Introduced an ABI break changing `const char*` to `std:.string` in the flow controller descriptor name. This PR warns the user in the sample snippets that the name must be kept alive during participants lifetime.

**Important** This PR has to be cherry picked on the following backports:
* #802 
* #803 
* #804
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- __NO__ (see PR description) Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
