### PR TITLE
[21052] Remove public ChangeForReader* from api reference

### DIFF
--- a/docs/fastdds/api_reference/rtps/common/CacheChange/ChangeForReaderCmp.rst
+++ b/docs/fastdds/api_reference/rtps/common/CacheChange/ChangeForReaderCmp.rst
@@ -1,8 +1,0 @@
-.. rst-class:: api-ref
-
-ChangeForReaderCmp
---------------------------------
-
-.. doxygenstruct:: eprosima::fastrtps::rtps::ChangeForReaderCmp
-    :project: FastDDS
-    :members:

--- a/docs/fastdds/api_reference/rtps/common/CacheChange/ChangeForReaderStatus_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/CacheChange/ChangeForReaderStatus_t.rst
@@ -1,7 +1,0 @@
-.. rst-class:: api-ref
-
-ChangeForReaderStatus_t
---------------------------------
-
-.. doxygenenum:: eprosima::fastrtps::rtps::ChangeForReaderStatus_t
-    :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/CacheChange/ChangeForReader_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/CacheChange/ChangeForReader_t.rst
@@ -1,8 +1,0 @@
-.. rst-class:: api-ref
-
-ChangeForReader_t
---------------------------------
-
-.. doxygenclass:: eprosima::fastrtps::rtps::ChangeForReader_t
-    :project: FastDDS
-    :members:

--- a/docs/fastdds/api_reference/rtps/common/CacheChange/cachechange_toc.rst
+++ b/docs/fastdds/api_reference/rtps/common/CacheChange/cachechange_toc.rst
@@ -7,7 +7,4 @@ CacheChange
     :titlesonly:
 
     /fastdds/api_reference/rtps/common/CacheChange/CacheChange_t
-    /fastdds/api_reference/rtps/common/CacheChange/ChangeForReader_t
-    /fastdds/api_reference/rtps/common/CacheChange/ChangeForReaderCmp
-    /fastdds/api_reference/rtps/common/CacheChange/ChangeForReaderStatus_t
     /fastdds/api_reference/rtps/common/CacheChange/ChangeKind_t


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR removes some public api reference regarding ChangeForReader* that is no longer available.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#4923

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- __NO__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
