### PR TITLE
[21155] Improve build steps in the installation from sources sections

### DIFF
--- a/docs/installation/sources/sources_linux.rst
+++ b/docs/installation/sources/sources_linux.rst
@@ -23,6 +23,7 @@ The following packages will be installed:
 
 * :code:`foonathan_memory_vendor`, an STL compatible C++ memory allocator
   `library <https://github.com/foonathan/memory>`_.
+* :code:`fastdds_gen`, a Java application that generates source code using the data types defined in an IDL file.
 * :code:`fastcdr`, a C++ library that serializes according to the
   `standard CDR <https://www.omg.org/cgi-bin/doc?formal/02-06-51>`_ serialization mechanism.
 * :code:`fastdds`, the core library of *eProsima Fast DDS* library.
@@ -227,7 +228,7 @@ This section explains how to use it to compile *eProsima Fast DDS* and its depen
 
    .. code-block:: bash
 
-       colcon build
+       colcon build --packages-up-to fastdds
 
 .. note::
 
@@ -445,7 +446,7 @@ This section explains how to use it to compile *Fast DDS Python bindings* and it
 
    .. code-block:: bash
 
-       colcon build
+       colcon build --packages-up-to fastdds_python
 
 .. note::
 
@@ -590,7 +591,8 @@ Fast DDS-Gen installation
 This section provides the instructions for installing *Fast DDS-Gen* in a Linux environment from
 sources.
 *Fast DDS-Gen* is a Java application that generates source code using the data types defined in an IDL file.
-Please refer to :ref:`fastddsgen_intro` for more information.
+Please refer to :ref:`fastddsgen_intro` for more information, and to
+:ref:`dependencies_compatibilities_product_compatibility` for the compatibility matrix against Fast DDS versions.
 
 Requirements
 ------------
@@ -645,9 +647,10 @@ Please, follow the steps below to build *Fast DDS-Gen*:
 
 .. code-block:: bash
 
-    cd ~
-    git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git
-    cd Fast-DDS-Gen
+    mkdir -p ~/Fast-DDS/src
+    cd ~/Fast-DDS/src
+    git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git fastddsgen
+    cd fastddsgen
     ./gradlew assemble
 
 .. note::

--- a/docs/installation/sources/sources_mac.rst
+++ b/docs/installation/sources/sources_mac.rst
@@ -22,6 +22,7 @@ sources. The following packages will be installed:
 
 * :code:`foonathan_memory_vendor`, an STL compatible C++ memory allocator
   `library <https://github.com/foonathan/memory>`_.
+* :code:`fastdds_gen`, a Java application that generates source code using the data types defined in an IDL file.
 * :code:`fastcdr`, a C++ library that serializes according to the
   `standard CDR <https://www.omg.org/cgi-bin/doc?formal/02-06-51>`_ serialization mechanism.
 * :code:`fastdds`, the core library of *eProsima Fast DDS* library.
@@ -181,7 +182,7 @@ This section explains how to use it to compile *eProsima Fast DDS* and its depen
 
    .. code-block:: bash
 
-       colcon build
+       colcon build --packages-up-to fastdds
 
 .. note::
 
@@ -323,7 +324,8 @@ Fast DDS-Gen installation
 This section provides the instructions for installing *Fast DDS-Gen* in a Mac OS environment from
 sources.
 *Fast DDS-Gen* is a Java application that generates source code using the data types defined in an IDL file.
-Please refer to :ref:`fastddsgen_intro` for more information.
+Please refer to :ref:`fastddsgen_intro` for more information, and to
+:ref:`dependencies_compatibilities_product_compatibility` for the compatibility matrix against Fast DDS versions.
 
 Requirements
 ------------
@@ -374,9 +376,10 @@ Please, follow the steps below to build *Fast DDS-Gen*:
 
 .. code-block:: bash
 
-    cd ~
-    git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git
-    cd Fast-DDS-Gen
+    mkdir -p ~/Fast-DDS/src
+    cd ~/Fast-DDS/src
+    git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git fastddsgen
+    cd fastddsgen
     ./gradlew assemble
 
 .. note::

--- a/docs/installation/sources/sources_qnx.rst
+++ b/docs/installation/sources/sources_qnx.rst
@@ -22,6 +22,7 @@ sources. The following packages will be installed:
 
 * :code:`foonathan_memory_vendor`, an STL compatible C++ memory allocator
   `library <https://github.com/foonathan/memory>`_.
+* :code:`fastdds_gen`, a Java application that generates source code using the data types defined in an IDL file.
 * :code:`fastcdr`, a C++ library that serializes according to the
   `standard CDR <https://www.omg.org/cgi-bin/doc?formal/02-06-51>`_ serialization mechanism.
 * :code:`fastdds`, the core library of *eProsima Fast DDS* library.

--- a/docs/installation/sources/sources_windows.rst
+++ b/docs/installation/sources/sources_windows.rst
@@ -22,6 +22,7 @@ The following packages will be installed:
 
 * :code:`foonathan_memory_vendor`, an STL compatible C++ memory allocator
   `library <https://github.com/foonathan/memory>`_.
+* :code:`fastdds_gen`, a Java application that generates source code using the data types defined in an IDL file.
 * :code:`fastcdr`, a C++ library that serializes according to the
   `standard CDR <https://www.omg.org/cgi-bin/doc?formal/02-06-51>`_ serialization mechanism.
 * :code:`fastdds`, the core library of *eProsima Fast DDS* library.
@@ -277,7 +278,7 @@ This section explains how to use it to compile *eProsima Fast DDS* and its depen
 
    .. code-block:: bash
 
-       colcon build
+       colcon build --packages-up-to fastdds
 
 .. note::
 
@@ -474,7 +475,7 @@ This section explains how to use it to compile *Fast DDS Python bindings* and it
 
    .. code-block:: bash
 
-       colcon build
+       colcon build --packages-up-to fastdds_python
 
 .. note::
 
@@ -612,7 +613,8 @@ Fast DDS-Gen installation
 This section outlines the instructions for installing *Fast DDS-Gen* in a Windows environment from
 sources.
 *Fast DDS-Gen* is a Java application that generates source code using the data types defined in an IDL file.
-Please refer to :ref:`fastddsgen_intro` for more information.
+Please refer to :ref:`fastddsgen_intro` for more information, and to
+:ref:`dependencies_compatibilities_product_compatibility` for the compatibility matrix against Fast DDS versions.
 
 Requirements
 ------------
@@ -663,9 +665,10 @@ Please, follow the steps below to build *Fast DDS-Gen*:
 
 .. code-block:: bash
 
-    cd ~
-    git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git
-    cd Fast-DDS-Gen
+    mkdir -p ~/Fast-DDS/src
+    cd ~/Fast-DDS/src
+    git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git fastddsgen
+    cd fastddsgen
     gradlew.bat assemble
 
 .. note::


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR clarifies the `colcon build` command in the installation from sources sections avoiding the warning prompted while trying to build FastDDS Gen (non-CMake project dependency).
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes eProsima/Fast-DDS/issues/4933

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
