### PR TITLE
[21129] Migrate fastrtps namespace

### DIFF
--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -14,7 +14,7 @@
 #include <fastdds/utils/IPLocator.h>
 
 using namespace eprosima::fastdds::dds;
-using namespace eprosima::fastrtps;
+using namespace eprosima::fastdds;
 using namespace ::rtps;
 
 class HelloWorld
@@ -295,7 +295,7 @@ bool permissions_test(
         std::string governance_file,
         std::string permissions_file)
 {
-    eprosima::fastrtps::rtps::RTPSParticipantAttributes part_attr;
+    eprosima::fastdds::rtps::RTPSParticipantAttributes part_attr;
 
     // Activate Auth:PKI-DH plugin
     part_attr.properties.properties().emplace_back("dds.sec.auth.plugin",

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -1141,7 +1141,7 @@ void dds_discovery_examples()
     using Locator_t = eprosima::fastdds::rtps::Locator_t;
     using RemoteServerAttributes = eprosima::fastdds::rtps::RemoteServerAttributes;
     using IPLocator = eprosima::fastdds::rtps::IPLocator;
-    using DiscoveryProtocol_t = eprosima::fastdds::rtps::DiscoveryProtocol_t;
+    using DiscoveryProtocol = eprosima::fastdds::rtps::DiscoveryProtocol;
     using ParticipantFilteringFlags_t = eprosima::fastdds::rtps::ParticipantFilteringFlags_t;
     {
         //SET-DISCOVERY-CALLBACKS
@@ -1161,7 +1161,7 @@ void dds_discovery_examples()
         DomainParticipantQos pqos;
 
         pqos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                DiscoveryProtocol_t::SIMPLE;
+                DiscoveryProtocol::SIMPLE;
         //!--
     }
     {
@@ -1246,13 +1246,13 @@ void dds_discovery_examples()
         DomainParticipantQos pqos;
 
         pqos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                DiscoveryProtocol_t::CLIENT;
+                DiscoveryProtocol::CLIENT;
         pqos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                DiscoveryProtocol_t::SUPER_CLIENT;
+                DiscoveryProtocol::SUPER_CLIENT;
         pqos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                DiscoveryProtocol_t::SERVER;
+                DiscoveryProtocol::SERVER;
         pqos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                DiscoveryProtocol_t::BACKUP;
+                DiscoveryProtocol::BACKUP;
         //!--
     }
     {
@@ -1372,7 +1372,7 @@ void dds_discovery_examples()
 
         // Set participant as SERVER
         server_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                DiscoveryProtocol_t::SERVER;
+                DiscoveryProtocol::SERVER;
 
         // Set SERVER's GUID prefix
         std::istringstream("44.53.00.5f.45.50.52.4f.53.49.4d.41") >> server_qos.wire_protocol().prefix;
@@ -1415,7 +1415,7 @@ void dds_discovery_examples()
 
         // Set participant as CLIENT
         client_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                DiscoveryProtocol_t::CLIENT;
+                DiscoveryProtocol::CLIENT;
 
         // Set SERVER's GUID prefix
         RemoteServerAttributes remote_server_att;
@@ -4375,7 +4375,7 @@ void dds_qos_examples()
         std::istringstream("72.61.73.70.66.61.72.6d.74.65.73.74") >> wire_protocol.prefix;
         //Configure Builtin Attributes
         wire_protocol.builtin.discovery_config.discoveryProtocol =
-                eprosima::fastdds::rtps::DiscoveryProtocol_t::SERVER;
+                eprosima::fastdds::rtps::DiscoveryProtocol::SERVER;
         //Add locator to unicast list
         eprosima::fastdds::rtps::Locator_t server_locator;
         eprosima::fastdds::rtps::IPLocator::setIPv4(server_locator, "192.168.10.57");
@@ -6059,7 +6059,7 @@ void dds_usecase_examples()
     using Locator_t = eprosima::fastdds::rtps::Locator_t;
     using RemoteServerAttributes = eprosima::fastdds::rtps::RemoteServerAttributes;
     using IPLocator = eprosima::fastdds::rtps::IPLocator;
-    using DiscoveryProtocol_t = eprosima::fastdds::rtps::DiscoveryProtocol_t;
+    using DiscoveryProtocol = eprosima::fastdds::rtps::DiscoveryProtocol;
 
     {
         //CONF_INITIAL_PEERS_BASIC
@@ -6093,7 +6093,7 @@ void dds_usecase_examples()
         DomainParticipantQos qos;
 
         // Configure the current participant as SERVER
-        qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+        qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::SERVER;
 
         // Define the listening locator to be on interface 192.168.10.57 and port 56542
         Locator_t server_locator;
@@ -6111,7 +6111,7 @@ void dds_usecase_examples()
         DomainParticipantQos qos;
 
         // Configure the current participant as CLIENT
-        qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
+        qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::CLIENT;
 
         // Define a locator for the SERVER Participant on address 192.168.10.57 and port 56542
         Locator_t remote_server_locator;
@@ -6138,7 +6138,7 @@ void dds_usecase_examples()
 
         // Configure participant_1 as SERVER listening on the previous locator
         DomainParticipantQos server_1_qos;
-        server_1_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+        server_1_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::SERVER;
         std::istringstream("75.63.2D.73.76.72.63.6C.6E.74.2D.31") >> server_1_qos.wire_protocol().prefix;
         server_1_qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(server_locator_1);
 
@@ -6149,7 +6149,7 @@ void dds_usecase_examples()
 
         // Configure participant_2 as SERVER listening on the previous locator
         DomainParticipantQos server_2_qos;
-        server_2_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+        server_2_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::SERVER;
         std::istringstream("75.63.2D.73.76.72.63.6C.6E.74.2D.32") >> server_2_qos.wire_protocol().prefix;
         server_2_qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(server_locator_2);
         //!--
@@ -6177,7 +6177,7 @@ void dds_usecase_examples()
 
         // Configure the current participant as CLIENT connecting to the SERVERS at the previous locators
         DomainParticipantQos client_qos;
-        client_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
+        client_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::CLIENT;
         client_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(remote_server_attr_1);
         client_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(remote_server_attr_2);
         //!--
@@ -6192,7 +6192,7 @@ void dds_usecase_examples()
         IPLocator::setIPv4(server_locator, "192.168.10.60");
         server_locator.port = 56543;
 
-        qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+        qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::SERVER;
         std::istringstream("75.63.2D.73.76.72.63.6C.6E.74.2D.31") >> qos.wire_protocol().prefix;
         qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(server_locator);
 
@@ -6218,7 +6218,7 @@ void dds_usecase_examples()
         IPLocator::setIPv4(server_locator, "192.168.10.54");
         server_locator.port = 56541;
 
-        qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+        qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::SERVER;
         std::istringstream("75.63.2D.73.76.72.63.6C.6E.74.2D.33") >> qos.wire_protocol().prefix;
         qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(server_locator);
 
@@ -7343,7 +7343,7 @@ void tcp_use_cases()
 
         // Configure the current participant as SERVER
         qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                eprosima::fastdds::rtps::DiscoveryProtocol_t::SERVER;
+                eprosima::fastdds::rtps::DiscoveryProtocol::SERVER;
 
         // Add custom user transport with TCP port 12345
         auto data_transport = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
@@ -7369,7 +7369,7 @@ void tcp_use_cases()
 
         // Configure the current participant as SERVER
         qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                eprosima::fastdds::rtps::DiscoveryProtocol_t::CLIENT;
+                eprosima::fastdds::rtps::DiscoveryProtocol::CLIENT;
 
         // Add custom user transport with TCP port 0 (automatic port assignation)
         auto data_transport = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -1142,7 +1142,7 @@ void dds_discovery_examples()
     using RemoteServerAttributes = eprosima::fastdds::rtps::RemoteServerAttributes;
     using IPLocator = eprosima::fastdds::rtps::IPLocator;
     using DiscoveryProtocol = eprosima::fastdds::rtps::DiscoveryProtocol;
-    using ParticipantFilteringFlags_t = eprosima::fastdds::rtps::ParticipantFilteringFlags_t;
+    using ParticipantFilteringFlags = eprosima::fastdds::rtps::ParticipantFilteringFlags;
     {
         //SET-DISCOVERY-CALLBACKS
         // Create the participant QoS and configure values
@@ -1169,9 +1169,9 @@ void dds_discovery_examples()
         DomainParticipantQos pqos;
 
         pqos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
-                static_cast<eprosima::fastdds::rtps::ParticipantFilteringFlags_t>(
-            ParticipantFilteringFlags_t::FILTER_DIFFERENT_PROCESS |
-            ParticipantFilteringFlags_t::FILTER_SAME_PROCESS);
+                static_cast<eprosima::fastdds::rtps::ParticipantFilteringFlags>(
+            ParticipantFilteringFlags::FILTER_DIFFERENT_PROCESS |
+            ParticipantFilteringFlags::FILTER_SAME_PROCESS);
         //!--
     }
     {

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -105,11 +105,11 @@ public:
     }
 
     bool send(
-            eprosima::fastrtps::rtps::SenderResource* low_sender_resource,
+            eprosima::fastdds::rtps::SenderResource* low_sender_resource,
             const std::vector<eprosima::fastdds::rtps::NetworkBuffer>& buffers,
             uint32_t total_bytes,
-            eprosima::fastrtps::rtps::LocatorsIterator* destination_locators_begin,
-            eprosima::fastrtps::rtps::LocatorsIterator* destination_locators_end,
+            eprosima::fastdds::rtps::LocatorsIterator* destination_locators_begin,
+            eprosima::fastdds::rtps::LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point& timeout) override
     {
         //
@@ -123,10 +123,10 @@ public:
 
     void receive(
             eprosima::fastdds::rtps::TransportReceiverInterface* next_receiver,
-            const eprosima::fastrtps::rtps::octet* receive_buffer,
+            const eprosima::fastdds::rtps::octet* receive_buffer,
             uint32_t receive_buffer_size,
-            const eprosima::fastrtps::rtps::Locator_t& local_locator,
-            const eprosima::fastrtps::rtps::Locator_t& remote_locator) override
+            const eprosima::fastdds::rtps::Locator_t& local_locator,
+            const eprosima::fastdds::rtps::Locator_t& remote_locator) override
     {
         //
         // Preprocess incoming buffer.
@@ -164,11 +164,11 @@ public:
 
     void on_participant_discovery(
             DomainParticipant* participant,
-            eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&& info,
+            eprosima::fastdds::rtps::ParticipantDiscoveryInfo&& info,
             bool& should_be_ignored) override
     {
         should_be_ignored = false;
-        if (info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
+        if (info.status == eprosima::fastdds::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
         {
             std::cout << "New participant discovered" << std::endl;
             // The following line can be modified to evaluate whether the discovered participant should be ignored
@@ -179,8 +179,8 @@ public:
                 should_be_ignored = true; // Request the ignoring of the discovered participant
             }
         }
-        else if (info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT ||
-                info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DROPPED_PARTICIPANT)
+        else if (info.status == eprosima::fastdds::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT ||
+                info.status == eprosima::fastdds::rtps::ParticipantDiscoveryInfo::DROPPED_PARTICIPANT)
         {
             std::cout << "Participant lost" << std::endl;
         }
@@ -189,13 +189,13 @@ public:
 #if HAVE_SECURITY
     void onParticipantAuthentication(
             DomainParticipant* participant,
-            eprosima::fastrtps::rtps::ParticipantAuthenticationInfo&& info) override
+            eprosima::fastdds::rtps::ParticipantAuthenticationInfo&& info) override
     {
-        if (info.status == eprosima::fastrtps::rtps::ParticipantAuthenticationInfo::AUTHORIZED_PARTICIPANT)
+        if (info.status == eprosima::fastdds::rtps::ParticipantAuthenticationInfo::AUTHORIZED_PARTICIPANT)
         {
             std::cout << "A participant was authorized" << std::endl;
         }
-        else if (info.status == eprosima::fastrtps::rtps::ParticipantAuthenticationInfo::UNAUTHORIZED_PARTICIPANT)
+        else if (info.status == eprosima::fastdds::rtps::ParticipantAuthenticationInfo::UNAUTHORIZED_PARTICIPANT)
         {
             std::cout << "A participant failed authorization" << std::endl;
         }
@@ -205,11 +205,11 @@ public:
 
     void on_data_reader_discovery(
             DomainParticipant* participant,
-            eprosima::fastrtps::rtps::ReaderDiscoveryInfo&& info,
+            eprosima::fastdds::rtps::ReaderDiscoveryInfo&& info,
             bool& should_be_ignored) override
     {
         should_be_ignored = false;
-        if (info.status == eprosima::fastrtps::rtps::ReaderDiscoveryInfo::DISCOVERED_READER)
+        if (info.status == eprosima::fastdds::rtps::ReaderDiscoveryInfo::DISCOVERED_READER)
         {
             std::cout << "New datareader discovered" << std::endl;
             // The following line can be modified to evaluate whether the discovered datareader should be ignored
@@ -220,7 +220,7 @@ public:
                 should_be_ignored = true; // Request the ignoring of the discovered datareader
             }
         }
-        else if (info.status == eprosima::fastrtps::rtps::ReaderDiscoveryInfo::REMOVED_READER)
+        else if (info.status == eprosima::fastdds::rtps::ReaderDiscoveryInfo::REMOVED_READER)
         {
             std::cout << "Datareader lost" << std::endl;
         }
@@ -228,11 +228,11 @@ public:
 
     void on_data_writer_discovery(
             DomainParticipant* participant,
-            eprosima::fastrtps::rtps::WriterDiscoveryInfo&& info,
+            eprosima::fastdds::rtps::WriterDiscoveryInfo&& info,
             bool& should_be_ignored) override
     {
         should_be_ignored = false;
-        if (info.status == eprosima::fastrtps::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER)
+        if (info.status == eprosima::fastdds::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER)
         {
             std::cout << "New datawriter discovered" << std::endl;
             // The following line can be modified to evaluate whether the discovered datawriter should be ignored
@@ -243,7 +243,7 @@ public:
                 should_be_ignored = true; // Request the ignoring of the discovered datawriter
             }
         }
-        else if (info.status == eprosima::fastrtps::rtps::WriterDiscoveryInfo::REMOVED_WRITER)
+        else if (info.status == eprosima::fastdds::rtps::WriterDiscoveryInfo::REMOVED_WRITER)
         {
             std::cout << "Datawriter lost" << std::endl;
         }
@@ -253,7 +253,7 @@ public:
 //!--
 
 // Custom Payload pool example for documentation
-class CustomPayloadPool : public eprosima::fastrtps::rtps::IPayloadPool
+class CustomPayloadPool : public eprosima::fastdds::rtps::IPayloadPool
 {
 public:
 
@@ -261,20 +261,20 @@ public:
     ~CustomPayloadPool() = default;
     bool get_payload(
             unsigned int size,
-            eprosima::fastrtps::rtps::SerializedPayload_t& payload)
+            eprosima::fastdds::rtps::SerializedPayload_t& payload)
     {
         return true;
     }
 
     bool get_payload(
-            const eprosima::fastrtps::rtps::SerializedPayload_t& data,
-            eprosima::fastrtps::rtps::SerializedPayload_t& payload)
+            const eprosima::fastdds::rtps::SerializedPayload_t& data,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload)
     {
         return true;
     }
 
     bool release_payload(
-            eprosima::fastrtps::rtps::SerializedPayload_t& payload)
+            eprosima::fastdds::rtps::SerializedPayload_t& payload)
     {
         return true;
     }
@@ -933,13 +933,13 @@ class DiscoveryDomainParticipantListener : public DomainParticipantListener
     /* Custom Callback on_participant_discovery */
     void on_participant_discovery(
             DomainParticipant* participant,
-            eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&& info,
+            eprosima::fastdds::rtps::ParticipantDiscoveryInfo&& info,
             bool& should_be_ignored) override
     {
         should_be_ignored = false;
         static_cast<void>(participant);
         switch (info.status){
-            case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT:
+            case eprosima::fastdds::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT:
             {
                 /* Process the case when a new DomainParticipant was found in the domain */
                 std::cout << "New DomainParticipant '" << info.info.m_participantName <<
@@ -953,10 +953,10 @@ class DiscoveryDomainParticipantListener : public DomainParticipantListener
                 }
             }
             break;
-            case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::CHANGED_QOS_PARTICIPANT:
+            case eprosima::fastdds::rtps::ParticipantDiscoveryInfo::CHANGED_QOS_PARTICIPANT:
                 /* Process the case when a DomainParticipant changed its QOS */
                 break;
-            case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
+            case eprosima::fastdds::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
                 /* Process the case when a DomainParticipant was removed from the domain */
                 std::cout << "DomainParticipant '" << info.info.m_participantName <<
                     "' with ID '" << info.info.m_guid.entityId << "' and GuidPrefix '" <<
@@ -968,13 +968,13 @@ class DiscoveryDomainParticipantListener : public DomainParticipantListener
     /* Custom Callback on_data_reader_discovery */
     void on_data_reader_discovery(
             DomainParticipant* participant,
-            eprosima::fastrtps::rtps::ReaderDiscoveryInfo&& info,
+            eprosima::fastdds::rtps::ReaderDiscoveryInfo&& info,
             bool& should_be_ignored) override
     {
         should_be_ignored = false;
         static_cast<void>(participant);
         switch (info.status){
-            case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::DISCOVERED_READER:
+            case eprosima::fastdds::rtps::ReaderDiscoveryInfo::DISCOVERED_READER:
             {
                 /* Process the case when a new datareader was found in the domain */
                 std::cout << "New DataReader subscribed to topic '" << info.info.topicName() <<
@@ -987,10 +987,10 @@ class DiscoveryDomainParticipantListener : public DomainParticipantListener
                 }
             }
             break;
-            case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::CHANGED_QOS_READER:
+            case eprosima::fastdds::rtps::ReaderDiscoveryInfo::CHANGED_QOS_READER:
                 /* Process the case when a datareader changed its QOS */
                 break;
-            case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::REMOVED_READER:
+            case eprosima::fastdds::rtps::ReaderDiscoveryInfo::REMOVED_READER:
                 /* Process the case when a datareader was removed from the domain */
                 std::cout << "DataReader subscribed to topic '" << info.info.topicName() <<
                     "' of type '" << info.info.typeName() << "' left the domain.";
@@ -1001,13 +1001,13 @@ class DiscoveryDomainParticipantListener : public DomainParticipantListener
     /* Custom Callback on_data_writer_discovery */
     void on_data_writer_discovery(
             DomainParticipant* participant,
-            eprosima::fastrtps::rtps::WriterDiscoveryInfo&& info,
+            eprosima::fastdds::rtps::WriterDiscoveryInfo&& info,
             bool& should_be_ignored) override
     {
         should_be_ignored = false;
         static_cast<void>(participant);
         switch (info.status){
-            case eprosima::fastrtps::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER:
+            case eprosima::fastdds::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER:
             {
                 /* Process the case when a new datawriter was found in the domain */
                 std::cout << "New DataWriter publishing under topic '" << info.info.topicName() <<
@@ -1020,10 +1020,10 @@ class DiscoveryDomainParticipantListener : public DomainParticipantListener
                 }
             }
             break;
-            case eprosima::fastrtps::rtps::WriterDiscoveryInfo::CHANGED_QOS_WRITER:
+            case eprosima::fastdds::rtps::WriterDiscoveryInfo::CHANGED_QOS_WRITER:
                 /* Process the case when a datawriter changed its QOS */
                 break;
-            case eprosima::fastrtps::rtps::WriterDiscoveryInfo::REMOVED_WRITER:
+            case eprosima::fastdds::rtps::WriterDiscoveryInfo::REMOVED_WRITER:
                 /* Process the case when a datawriter was removed from the domain */
                 std::cout << "DataWriter publishing under topic '" << info.info.topicName() <<
                     "' of type '" << info.info.typeName() << "' left the domain.";
@@ -1040,7 +1040,7 @@ class RemoteDiscoveryDomainParticipantListener : public DomainParticipantListene
     /* Custom Callback on_data_reader_discovery */
     void on_data_reader_discovery(
             DomainParticipant* participant,
-            eprosima::fastrtps::rtps::ReaderDiscoveryInfo&& info,
+            eprosima::fastdds::rtps::ReaderDiscoveryInfo&& info,
             bool& should_be_ignored) override
     {
         should_be_ignored = false;
@@ -1088,7 +1088,7 @@ class RemoteDiscoveryDomainParticipantListener : public DomainParticipantListene
     /* Custom Callback on_data_writer_discovery */
     void on_data_writer_discovery(
             DomainParticipant* participant,
-            eprosima::fastrtps::rtps::WriterDiscoveryInfo&& info,
+            eprosima::fastdds::rtps::WriterDiscoveryInfo&& info,
             bool& should_be_ignored) override
     {
         should_be_ignored = false;
@@ -1138,11 +1138,11 @@ class RemoteDiscoveryDomainParticipantListener : public DomainParticipantListene
 
 void dds_discovery_examples()
 {
-    using Locator_t = eprosima::fastrtps::rtps::Locator_t;
-    using RemoteServerAttributes = eprosima::fastrtps::rtps::RemoteServerAttributes;
-    using IPLocator = eprosima::fastrtps::rtps::IPLocator;
-    using DiscoveryProtocol_t = eprosima::fastrtps::rtps::DiscoveryProtocol_t;
-    using ParticipantFilteringFlags_t = eprosima::fastrtps::rtps::ParticipantFilteringFlags_t;
+    using Locator_t = eprosima::fastdds::rtps::Locator_t;
+    using RemoteServerAttributes = eprosima::fastdds::rtps::RemoteServerAttributes;
+    using IPLocator = eprosima::fastdds::rtps::IPLocator;
+    using DiscoveryProtocol_t = eprosima::fastdds::rtps::DiscoveryProtocol_t;
+    using ParticipantFilteringFlags_t = eprosima::fastdds::rtps::ParticipantFilteringFlags_t;
     {
         //SET-DISCOVERY-CALLBACKS
         // Create the participant QoS and configure values
@@ -1169,7 +1169,7 @@ void dds_discovery_examples()
         DomainParticipantQos pqos;
 
         pqos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
-                static_cast<eprosima::fastrtps::rtps::ParticipantFilteringFlags_t>(
+                static_cast<eprosima::fastdds::rtps::ParticipantFilteringFlags_t>(
             ParticipantFilteringFlags_t::FILTER_DIFFERENT_PROCESS |
             ParticipantFilteringFlags_t::FILTER_SAME_PROCESS);
         //!--
@@ -1257,19 +1257,19 @@ void dds_discovery_examples()
     }
     {
         //CONF_SERVER_SERVER_GUIDPREFIX_OPTION_1
-        eprosima::fastrtps::rtps::GuidPrefix_t serverGuidPrefix;
-        serverGuidPrefix.value[0] = eprosima::fastrtps::rtps::octet(0x44);
-        serverGuidPrefix.value[1] = eprosima::fastrtps::rtps::octet(0x53);
-        serverGuidPrefix.value[2] = eprosima::fastrtps::rtps::octet(0x00);
-        serverGuidPrefix.value[3] = eprosima::fastrtps::rtps::octet(0x5f);
-        serverGuidPrefix.value[4] = eprosima::fastrtps::rtps::octet(0x45);
-        serverGuidPrefix.value[5] = eprosima::fastrtps::rtps::octet(0x50);
-        serverGuidPrefix.value[6] = eprosima::fastrtps::rtps::octet(0x52);
-        serverGuidPrefix.value[7] = eprosima::fastrtps::rtps::octet(0x4f);
-        serverGuidPrefix.value[8] = eprosima::fastrtps::rtps::octet(0x53);
-        serverGuidPrefix.value[9] = eprosima::fastrtps::rtps::octet(0x49);
-        serverGuidPrefix.value[10] = eprosima::fastrtps::rtps::octet(0x4d);
-        serverGuidPrefix.value[11] = eprosima::fastrtps::rtps::octet(0x41);
+        eprosima::fastdds::rtps::GuidPrefix_t serverGuidPrefix;
+        serverGuidPrefix.value[0] = eprosima::fastdds::rtps::octet(0x44);
+        serverGuidPrefix.value[1] = eprosima::fastdds::rtps::octet(0x53);
+        serverGuidPrefix.value[2] = eprosima::fastdds::rtps::octet(0x00);
+        serverGuidPrefix.value[3] = eprosima::fastdds::rtps::octet(0x5f);
+        serverGuidPrefix.value[4] = eprosima::fastdds::rtps::octet(0x45);
+        serverGuidPrefix.value[5] = eprosima::fastdds::rtps::octet(0x50);
+        serverGuidPrefix.value[6] = eprosima::fastdds::rtps::octet(0x52);
+        serverGuidPrefix.value[7] = eprosima::fastdds::rtps::octet(0x4f);
+        serverGuidPrefix.value[8] = eprosima::fastdds::rtps::octet(0x53);
+        serverGuidPrefix.value[9] = eprosima::fastdds::rtps::octet(0x49);
+        serverGuidPrefix.value[10] = eprosima::fastdds::rtps::octet(0x4d);
+        serverGuidPrefix.value[11] = eprosima::fastdds::rtps::octet(0x41);
 
         DomainParticipantQos serverQos;
         serverQos.wire_protocol().prefix = serverGuidPrefix;
@@ -1354,7 +1354,7 @@ void dds_discovery_examples()
     {
         //CONF_SERVER_DNS_LOCATORS
         Locator_t locator;
-        auto response = eprosima::fastrtps::rtps::IPLocator::resolveNameDNS("localhost");
+        auto response = eprosima::fastdds::rtps::IPLocator::resolveNameDNS("localhost");
         // Get the first returned IPv4
         if (response.first.size() > 0)
         {
@@ -1523,13 +1523,13 @@ public:
 
     bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload) override
+            eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return true;
     }
 
     bool deserialize(
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override
     {
         return true;
@@ -1553,7 +1553,7 @@ public:
 
     bool getKey(
             void* data,
-            eprosima::fastrtps::rtps::InstanceHandle_t* ihandle,
+            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5) override
     {
         return true;
@@ -2777,8 +2777,8 @@ void dds_dataWriter_examples()
         DataWriterQos qos;
 
         // Create PayloadPool
-        std::shared_ptr<eprosima::fastrtps::rtps::IPayloadPool> payload_pool =
-                std::dynamic_pointer_cast<eprosima::fastrtps::rtps::IPayloadPool>(std::make_shared<CustomPayloadPool>());
+        std::shared_ptr<eprosima::fastdds::rtps::IPayloadPool> payload_pool =
+                std::dynamic_pointer_cast<eprosima::fastdds::rtps::IPayloadPool>(std::make_shared<CustomPayloadPool>());
 
         DataWriter* data_writer = publisher->create_datawriter(topic, qos, nullptr, StatusMask::all(), payload_pool);
         if (nullptr == data_writer)
@@ -2962,7 +2962,7 @@ void dds_dataWriter_examples()
         // (...)
 
         // Publish the new value, deduce the instance handle
-        if (data_writer->write(data, eprosima::fastrtps::rtps::InstanceHandle_t()) != RETCODE_OK)
+        if (data_writer->write(data, eprosima::fastdds::rtps::InstanceHandle_t()) != RETCODE_OK)
         {
             // Error
             return;
@@ -2992,7 +2992,7 @@ void dds_dataWriter_examples()
                 }
 
                 // Publish the new value
-                if (data_writer->write(data, eprosima::fastrtps::rtps::InstanceHandle_t()) != RETCODE_OK)
+                if (data_writer->write(data, eprosima::fastdds::rtps::InstanceHandle_t()) != RETCODE_OK)
                 {
                     // Error
                     return;
@@ -3051,7 +3051,7 @@ void dds_dataWriter_examples()
             first_flight_position.flight_number(1234);
 
             // Register instance
-            eprosima::fastrtps::rtps::InstanceHandle_t first_flight_handle =
+            eprosima::fastdds::rtps::InstanceHandle_t first_flight_handle =
                     data_writer->register_instance(&first_flight_position);
             //!
 
@@ -3763,7 +3763,7 @@ void dds_dataReader_examples()
         SampleInfo info;
 
         //Define a timeout of 5 seconds
-        eprosima::fastrtps::Duration_t timeout (5, 0);
+        eprosima::fastdds::Duration_t timeout (5, 0);
 
         // Loop reading data as it arrives
         // This will make the current thread to be dedicated exclusively to
@@ -3815,7 +3815,7 @@ void dds_dataReader_examples()
         SampleInfo info;
 
         //Define a timeout of 5 seconds
-        eprosima::fastrtps::Duration_t timeout (5, 0);
+        eprosima::fastdds::Duration_t timeout (5, 0);
 
         // Loop reading data as it arrives
         // This will make the current thread to be dedicated exclusively to
@@ -4003,11 +4003,11 @@ void dds_qos_examples()
         //The GroupDataQosPolicy is default constructed with an empty collection
         //Collection is a private member so you need to use getters and setters to access
         //Add data to the collection
-        std::vector<eprosima::fastrtps::rtps::octet> vec;
+        std::vector<eprosima::fastdds::rtps::octet> vec;
         vec = group_data.data_vec(); // Getter function
 
         //Add two new octets to group data vector
-        eprosima::fastrtps::rtps::octet val = 3;
+        eprosima::fastdds::rtps::octet val = 3;
         vec.push_back(val);
         val = 10;
         vec.push_back(val);
@@ -4119,11 +4119,11 @@ void dds_qos_examples()
         //DDS_CHANGE_TOPIC_DATA_QOS_POLICY
         //The TopicDataQosPolicy is default constructed with an empty vector.
         TopicDataQosPolicy topic_data;
-        std::vector<eprosima::fastrtps::rtps::octet> vec;
+        std::vector<eprosima::fastdds::rtps::octet> vec;
         vec = topic_data.data_vec(); // Getter Function
 
         //Add two new octets to topic data vector
-        eprosima::fastrtps::rtps::octet val = 3;
+        eprosima::fastdds::rtps::octet val = 3;
         vec.push_back(val);
         val = 10;
         vec.push_back(val);
@@ -4136,11 +4136,11 @@ void dds_qos_examples()
         //DDS_CHANGE_USER_DATA_QOS_POLICY
         //The TopicDataQosPolicy is default constructed with an empty vector.
         UserDataQosPolicy user_data;
-        std::vector<eprosima::fastrtps::rtps::octet> vec;
+        std::vector<eprosima::fastdds::rtps::octet> vec;
         vec = user_data.data_vec(); // Getter Function
 
         //Add two new octets to user data vector
-        eprosima::fastrtps::rtps::octet val = 3;
+        eprosima::fastdds::rtps::octet val = 3;
         vec.push_back(val);
         val = 10;
         vec.push_back(val);
@@ -4190,12 +4190,12 @@ void dds_qos_examples()
         //DDS_CHANGE_PARTICIPANT_RESOURCE_LIMITS_QOS_POLICY
         ParticipantResourceLimitsQos participant_limits;
         //Set the maximum size of participant resource limits collection to 3 and it allocation configuration to fixed size
-        participant_limits.participants = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(
+        participant_limits.participants = eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(
             3u);
         //Set the maximum size of reader's resource limits collection to 2 and its allocation configuration to fixed size
-        participant_limits.readers = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
+        participant_limits.readers = eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
         //Set the maximum size of writer's resource limits collection to 1 and its allocation configuration to fixed size
-        participant_limits.writers = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+        participant_limits.writers = eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
         //Set the maximum size of the partition data to 256
         participant_limits.data_limits.max_partitions = 256u;
         //Set the maximum size of the user data to 256
@@ -4206,7 +4206,7 @@ void dds_qos_examples()
         participant_limits.content_filter.expression_initial_size = 512u;
         //Set the maximum number of expression parameters to 4 and its allocation configuration to fixed size
         participant_limits.content_filter.expression_parameters =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(4u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(4u);
         //!--
     }
 
@@ -4216,7 +4216,7 @@ void dds_qos_examples()
         //Add new property for the Auth:PKI-DH plugin
         property_policy.properties().emplace_back("dds.sec.auth.plugin", "builtin.PKI-DH");
         //Add new property for the Access:Permissions plugin
-        property_policy.properties().emplace_back(eprosima::fastrtps::rtps::Property("dds.sec.access.plugin",
+        property_policy.properties().emplace_back(eprosima::fastdds::rtps::Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
 
         //Add new user custom property to send to external Participants
@@ -4240,7 +4240,7 @@ void dds_qos_examples()
         ReaderResourceLimitsQos reader_limits;
         //Set the maximum size for writer matched resource limits collection to 1 and its allocation configuration to fixed size
         reader_limits.matched_publisher_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
         //!--
     }
 
@@ -4249,10 +4249,10 @@ void dds_qos_examples()
         WriterResourceLimitsQos writer_limits;
         //Set the maximum size for reader matched resource limits collection to 3 and its allocation configuration to fixed size
         writer_limits.matched_subscriber_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
         // Set the maximum number of writer side content filters to 1 and its allocation configuration to fixed size
         writer_limits.reader_filters_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
         //!--
     }
 
@@ -4260,12 +4260,12 @@ void dds_qos_examples()
         //DDS_CHANGE_RTPS_ENDPOINT_QOS
         RTPSEndpointQos endpoint;
         //Add new unicast locator with port 7800
-        eprosima::fastrtps::rtps::Locator_t new_unicast_locator;
+        eprosima::fastdds::rtps::Locator_t new_unicast_locator;
         new_unicast_locator.port = 7800;
         endpoint.unicast_locator_list.push_back(new_unicast_locator);
         //Add new multicast locator with IP 239.255.0.4 and port 7900
-        eprosima::fastrtps::rtps::Locator_t new_multicast_locator;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(new_multicast_locator, "239.255.0.4");
+        eprosima::fastdds::rtps::Locator_t new_multicast_locator;
+        eprosima::fastdds::rtps::IPLocator::setIPv4(new_multicast_locator, "239.255.0.4");
         new_multicast_locator.port = 7900;
         endpoint.multicast_locator_list.push_back(new_multicast_locator);
         // Add an external locator with IP 100.100.100.10, port 12345, mask 24, externality 1, and cost 0
@@ -4282,7 +4282,7 @@ void dds_qos_examples()
         endpoint.entity_id = 4;
         //The RTPSEndpointQos is default constructed with history_memory_policy = PREALLOCATED
         //Change the history_memory_policy to DYNAMIC_RESERVE
-        endpoint.history_memory_policy = eprosima::fastrtps::rtps::DYNAMIC_RESERVE_MEMORY_MODE;
+        endpoint.history_memory_policy = eprosima::fastdds::rtps::DYNAMIC_RESERVE_MEMORY_MODE;
         //!--
     }
 
@@ -4375,10 +4375,10 @@ void dds_qos_examples()
         std::istringstream("72.61.73.70.66.61.72.6d.74.65.73.74") >> wire_protocol.prefix;
         //Configure Builtin Attributes
         wire_protocol.builtin.discovery_config.discoveryProtocol =
-                eprosima::fastrtps::rtps::DiscoveryProtocol_t::SERVER;
+                eprosima::fastdds::rtps::DiscoveryProtocol_t::SERVER;
         //Add locator to unicast list
-        eprosima::fastrtps::rtps::Locator_t server_locator;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(server_locator, "192.168.10.57");
+        eprosima::fastdds::rtps::Locator_t server_locator;
+        eprosima::fastdds::rtps::IPLocator::setIPv4(server_locator, "192.168.10.57");
         server_locator.port = 56542;
         wire_protocol.builtin.metatrafficUnicastLocatorList.push_back(server_locator);
         // Add a metatraffic external locator with IP 100.100.100.10, port 34567, mask 24, externality 1, and cost 0
@@ -4388,13 +4388,13 @@ void dds_qos_examples()
         meta_external_locator.mask(24);
         wire_protocol.builtin.metatraffic_external_unicast_locators[1][0].push_back(meta_external_locator);
         //Add locator to default unicast locator list
-        eprosima::fastrtps::rtps::Locator_t unicast_locator;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(unicast_locator, 192, 168, 1, 41);
+        eprosima::fastdds::rtps::Locator_t unicast_locator;
+        eprosima::fastdds::rtps::IPLocator::setIPv4(unicast_locator, 192, 168, 1, 41);
         unicast_locator.port = 7400;
         wire_protocol.default_unicast_locator_list.push_back(unicast_locator);
         //Add locator to default multicast locator list
-        eprosima::fastrtps::rtps::Locator_t multicast_locator;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(multicast_locator, 192, 168, 1, 41);
+        eprosima::fastdds::rtps::Locator_t multicast_locator;
+        eprosima::fastdds::rtps::IPLocator::setIPv4(multicast_locator, 192, 168, 1, 41);
         multicast_locator.port = 7400;
         wire_protocol.default_multicast_locator_list.push_back(multicast_locator);
         // Add a default external locator with IP 100.100.100.10, port 23456, mask 24, externality 1, and cost 0
@@ -4460,19 +4460,19 @@ void dds_qos_examples()
 
     {
         //CONF_GUIDPREFIX_OPTION_1
-        eprosima::fastrtps::rtps::GuidPrefix_t guid_prefix;
-        guid_prefix.value[0] = eprosima::fastrtps::rtps::octet(0x77);
-        guid_prefix.value[1] = eprosima::fastrtps::rtps::octet(0x73);
-        guid_prefix.value[2] = eprosima::fastrtps::rtps::octet(0x71);
-        guid_prefix.value[3] = eprosima::fastrtps::rtps::octet(0x85);
-        guid_prefix.value[4] = eprosima::fastrtps::rtps::octet(0x69);
-        guid_prefix.value[5] = eprosima::fastrtps::rtps::octet(0x76);
-        guid_prefix.value[6] = eprosima::fastrtps::rtps::octet(0x95);
-        guid_prefix.value[7] = eprosima::fastrtps::rtps::octet(0x66);
-        guid_prefix.value[8] = eprosima::fastrtps::rtps::octet(0x65);
-        guid_prefix.value[9] = eprosima::fastrtps::rtps::octet(0x82);
-        guid_prefix.value[10] = eprosima::fastrtps::rtps::octet(0x82);
-        guid_prefix.value[11] = eprosima::fastrtps::rtps::octet(0x79);
+        eprosima::fastdds::rtps::GuidPrefix_t guid_prefix;
+        guid_prefix.value[0] = eprosima::fastdds::rtps::octet(0x77);
+        guid_prefix.value[1] = eprosima::fastdds::rtps::octet(0x73);
+        guid_prefix.value[2] = eprosima::fastdds::rtps::octet(0x71);
+        guid_prefix.value[3] = eprosima::fastdds::rtps::octet(0x85);
+        guid_prefix.value[4] = eprosima::fastdds::rtps::octet(0x69);
+        guid_prefix.value[5] = eprosima::fastdds::rtps::octet(0x76);
+        guid_prefix.value[6] = eprosima::fastdds::rtps::octet(0x95);
+        guid_prefix.value[7] = eprosima::fastdds::rtps::octet(0x66);
+        guid_prefix.value[8] = eprosima::fastdds::rtps::octet(0x65);
+        guid_prefix.value[9] = eprosima::fastdds::rtps::octet(0x82);
+        guid_prefix.value[10] = eprosima::fastdds::rtps::octet(0x82);
+        guid_prefix.value[11] = eprosima::fastdds::rtps::octet(0x79);
 
         DomainParticipantQos participant_qos;
         participant_qos.wire_protocol().prefix = guid_prefix;
@@ -5561,8 +5561,8 @@ void dds_transport_examples ()
     using TCPv4TransportDescriptor = eprosima::fastdds::rtps::TCPv4TransportDescriptor;
     using TCPv6TransportDescriptor = eprosima::fastdds::rtps::TCPv6TransportDescriptor;
     using SharedMemTransportDescriptor = eprosima::fastdds::rtps::SharedMemTransportDescriptor;
-    using Locator_t = eprosima::fastrtps::rtps::Locator_t;
-    using IPLocator = eprosima::fastrtps::rtps::IPLocator;
+    using Locator_t = eprosima::fastdds::rtps::Locator_t;
+    using IPLocator = eprosima::fastdds::rtps::IPLocator;
 
     {
         //CONF-IPLOCATOR-USAGE
@@ -5588,7 +5588,7 @@ void dds_transport_examples ()
 
         // This locator will open a socket to listen network messages
         // on UDPv4 port 22222 over multicast address 239.255.0.1
-        eprosima::fastrtps::rtps::Locator_t locator;
+        eprosima::fastdds::rtps::Locator_t locator;
         IPLocator::setIPv4(locator, 239, 255, 0, 1);
         locator.port = 22222;
 
@@ -5603,7 +5603,7 @@ void dds_transport_examples ()
 
         // This locator will open a socket to listen network messages
         // on UDPv4 port 22223 over address 192.168.0.1
-        eprosima::fastrtps::rtps::Locator_t locator;
+        eprosima::fastdds::rtps::Locator_t locator;
         IPLocator::setIPv4(locator, 192, 168, 0, 1);
         locator.port = 22223;
 
@@ -5618,7 +5618,7 @@ void dds_transport_examples ()
 
         // This locator will open a socket to listen network messages
         // on UDPv4 port 22224 over multicast address 239.255.0.1
-        eprosima::fastrtps::rtps::Locator_t locator;
+        eprosima::fastdds::rtps::Locator_t locator;
         IPLocator::setIPv4(locator, 239, 255, 0, 1);
         locator.port = 22224;
 
@@ -5633,7 +5633,7 @@ void dds_transport_examples ()
 
         // This locator will open a socket to listen network messages
         // on UDPv4 port 22225 over address 192.168.0.1
-        eprosima::fastrtps::rtps::Locator_t locator;
+        eprosima::fastdds::rtps::Locator_t locator;
         IPLocator::setIPv4(locator, 192, 168, 0, 1);
         locator.port = 22225;
 
@@ -5692,12 +5692,12 @@ void dds_transport_examples ()
         qos.transport().use_builtin_transports = false;
 
         // [OPTIONAL] Set unicast locators
-        eprosima::fastrtps::rtps::Locator_t locator;
+        eprosima::fastdds::rtps::Locator_t locator;
         locator.kind = LOCATOR_KIND_TCPv4;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(locator, "192.168.1.10");
-        eprosima::fastrtps::rtps::IPLocator::setPhysicalPort(locator, 5100);
+        eprosima::fastdds::rtps::IPLocator::setIPv4(locator, "192.168.1.10");
+        eprosima::fastdds::rtps::IPLocator::setPhysicalPort(locator, 5100);
         // [OPTIONAL] Logical port default value is 0, automatically assigned.
-        eprosima::fastrtps::rtps::IPLocator::setLogicalPort(locator, 5100);
+        eprosima::fastdds::rtps::IPLocator::setLogicalPort(locator, 5100);
 
         qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator);
         qos.wire_protocol().default_unicast_locator_list.push_back(locator);
@@ -5723,13 +5723,13 @@ void dds_transport_examples ()
         tcp_transport->accept_thread = eprosima::fastdds::rtps::ThreadSettings{-1, 0, 0, -1};
 
         // Set initial peers.
-        eprosima::fastrtps::rtps::Locator_t initial_peer_locator;
+        eprosima::fastdds::rtps::Locator_t initial_peer_locator;
         initial_peer_locator.kind = LOCATOR_KIND_TCPv4;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(initial_peer_locator, "192.168.1.10");
-        eprosima::fastrtps::rtps::IPLocator::setPhysicalPort(initial_peer_locator, 5100);
+        eprosima::fastdds::rtps::IPLocator::setIPv4(initial_peer_locator, "192.168.1.10");
+        eprosima::fastdds::rtps::IPLocator::setPhysicalPort(initial_peer_locator, 5100);
         // If the logical port is set in the server side, it must be also set here with the same value.
         // If not set in the server side in a unicast locator, do not set it here.
-        eprosima::fastrtps::rtps::IPLocator::setLogicalPort(initial_peer_locator, 5100);
+        eprosima::fastdds::rtps::IPLocator::setLogicalPort(initial_peer_locator, 5100);
 
         qos.wire_protocol().builtin.initialPeersList.push_back(initial_peer_locator);
         //!--
@@ -5757,16 +5757,16 @@ void dds_transport_examples ()
         qos.transport().use_builtin_transports = false;
 
         // [OPTIONAL] Set unicast locators (do not use setWAN(), set_WAN_address() overwrites it)
-        eprosima::fastrtps::rtps::Locator_t locator;
+        eprosima::fastdds::rtps::Locator_t locator;
         locator.kind = LOCATOR_KIND_TCPv4;
         // [RECOMMENDED] Use the LAN address of the server
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(locator, "192.168.1.10");
+        eprosima::fastdds::rtps::IPLocator::setIPv4(locator, "192.168.1.10");
         // [ALTERNATIVE] Use server's WAN address. In that case, initial peers must be configured
         // only with server's WAN address.
-        // eprosima::fastrtps::rtps::IPLocator::setIPv4(locator, "80.80.99.45");
-        eprosima::fastrtps::rtps::IPLocator::setPhysicalPort(locator, 5100);
+        // eprosima::fastdds::rtps::IPLocator::setIPv4(locator, "80.80.99.45");
+        eprosima::fastdds::rtps::IPLocator::setPhysicalPort(locator, 5100);
         // [OPTIONAL] Logical port default value is 0, automatically assigned.
-        eprosima::fastrtps::rtps::IPLocator::setLogicalPort(locator, 5100);
+        eprosima::fastdds::rtps::IPLocator::setLogicalPort(locator, 5100);
 
         qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator);
         qos.wire_protocol().default_unicast_locator_list.push_back(locator);
@@ -5794,18 +5794,18 @@ void dds_transport_examples ()
         tcp_transport->accept_thread = eprosima::fastdds::rtps::ThreadSettings{-1, 0, 0, -1};
 
         // Set initial peers.
-        eprosima::fastrtps::rtps::Locator_t initial_peer_locator;
+        eprosima::fastdds::rtps::Locator_t initial_peer_locator;
         initial_peer_locator.kind = LOCATOR_KIND_TCPv4;
         // [RECOMMENDED] Use both WAN and LAN server addresses
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(initial_peer_locator, "192.168.1.10");
-        eprosima::fastrtps::rtps::IPLocator::setWan(initial_peer_locator, "80.80.99.45");
+        eprosima::fastdds::rtps::IPLocator::setIPv4(initial_peer_locator, "192.168.1.10");
+        eprosima::fastdds::rtps::IPLocator::setWan(initial_peer_locator, "80.80.99.45");
         // [ALTERNATIVE] Use server's WAN address only. Valid if server specified its unicast locators
         // with its LAN or WAN address.
-        // eprosima::fastrtps::rtps::IPLocator::setIPv4(initial_peer_locator, "80.80.99.45");
-        eprosima::fastrtps::rtps::IPLocator::setPhysicalPort(initial_peer_locator, 5100);
+        // eprosima::fastdds::rtps::IPLocator::setIPv4(initial_peer_locator, "80.80.99.45");
+        eprosima::fastdds::rtps::IPLocator::setPhysicalPort(initial_peer_locator, 5100);
         // If the logical port is set in the server side, it must be also set here with the same value.
         // If not set in the server side in a unicast locator, do not set it here.
-        eprosima::fastrtps::rtps::IPLocator::setLogicalPort(initial_peer_locator, 5100);
+        eprosima::fastdds::rtps::IPLocator::setLogicalPort(initial_peer_locator, 5100);
 
         qos.wire_protocol().builtin.initialPeersList.push_back(initial_peer_locator);
         //!--
@@ -6056,10 +6056,10 @@ void dds_transport_examples ()
 
 void dds_usecase_examples()
 {
-    using Locator_t = eprosima::fastrtps::rtps::Locator_t;
-    using RemoteServerAttributes = eprosima::fastrtps::rtps::RemoteServerAttributes;
-    using IPLocator = eprosima::fastrtps::rtps::IPLocator;
-    using DiscoveryProtocol_t = eprosima::fastrtps::rtps::DiscoveryProtocol_t;
+    using Locator_t = eprosima::fastdds::rtps::Locator_t;
+    using RemoteServerAttributes = eprosima::fastdds::rtps::RemoteServerAttributes;
+    using IPLocator = eprosima::fastdds::rtps::IPLocator;
+    using DiscoveryProtocol_t = eprosima::fastdds::rtps::DiscoveryProtocol_t;
 
     {
         //CONF_INITIAL_PEERS_BASIC
@@ -6406,8 +6406,8 @@ void dds_usecase_examples()
         DataReaderQos qos;
 
         // Add new multicast locator with IP 239.255.0.4 and port 7900
-        eprosima::fastrtps::rtps::Locator_t new_multicast_locator;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(new_multicast_locator, "239.255.0.4");
+        eprosima::fastdds::rtps::Locator_t new_multicast_locator;
+        eprosima::fastdds::rtps::IPLocator::setIPv4(new_multicast_locator, "239.255.0.4");
         new_multicast_locator.port = 7900;
         qos.endpoint().multicast_locator_list.push_back(new_multicast_locator);
         //!--
@@ -6420,15 +6420,15 @@ void dds_usecase_examples()
         // Fix the size of discovered participants to 3
         // This will effectively preallocate the memory during initialization
         qos.allocation().participants =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
 
         // Fix the size of discovered DataWriters to 1 per DomainParticipant
         // Fix the size of discovered DataReaders to 3 per DomainParticipant
         // This will effectively preallocate the memory during initialization
         qos.allocation().writers =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
         qos.allocation().readers =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
         //!--
     }
 
@@ -6446,7 +6446,7 @@ void dds_usecase_examples()
         qos.allocation().content_filter.expression_initial_size = 512u;
         // Set the maximum number of expression parameters to 4 and its allocation configuration to fixed size
         qos.allocation().content_filter.expression_parameters =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(4u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(4u);
         //!--
     }
 
@@ -6457,11 +6457,11 @@ void dds_usecase_examples()
         // Fix the size of matched DataReaders to 3
         // This will effectively preallocate the memory during initialization
         qos.writer_resource_limits().matched_subscriber_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
         // Fix the size of writer side content filters to 1
         // This will effectively preallocate the memory during initialization
         qos.writer_resource_limits().reader_filters_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
         //!--
     }
 
@@ -6472,7 +6472,7 @@ void dds_usecase_examples()
         // Fix the size of matched DataWriters to 1
         // This will effectively preallocate the memory during initialization
         qos.reader_resource_limits().matched_publisher_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
         //!--
     }
 
@@ -6484,13 +6484,13 @@ void dds_usecase_examples()
 
         // We know we have 3 participants on the domain
         participant_qos.allocation().participants =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
         // We know we have at most 2 readers on each participant
         participant_qos.allocation().readers =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
         // We know we have at most 1 writer on each participant
         participant_qos.allocation().writers =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
 
         // We know the maximum size of partition data
         participant_qos.allocation().data_limits.max_partitions = 256u;
@@ -6502,7 +6502,7 @@ void dds_usecase_examples()
         // Content filtering is not being used
         participant_qos.allocation().content_filter.expression_initial_size = 0u;
         participant_qos.allocation().content_filter.expression_parameters =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(0u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(0u);
 
         // DataWriter configuration for Topic 1
         ///////////////////////////////////////
@@ -6510,9 +6510,9 @@ void dds_usecase_examples()
 
         // We know we will only have three matching subscribers, and no content filters
         writer1_qos.writer_resource_limits().matched_subscriber_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(3u);
         writer1_qos.writer_resource_limits().reader_filters_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(0u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(0u);
 
         // DataWriter configuration for Topic 2
         ///////////////////////////////////////
@@ -6520,9 +6520,9 @@ void dds_usecase_examples()
 
         // We know we will only have two matching subscribers
         writer2_qos.writer_resource_limits().matched_subscriber_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
         writer2_qos.writer_resource_limits().reader_filters_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(0u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(0u);
 
 
         // DataReader configuration for both Topics
@@ -6531,7 +6531,7 @@ void dds_usecase_examples()
 
         // We know we will only have one matching publisher
         reader_qos.reader_resource_limits().matched_publisher_allocation =
-                eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+                eprosima::fastdds::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
         //!--
     }
 
@@ -6561,7 +6561,7 @@ void dds_usecase_examples()
     {
         //CONF-MEMORY-QOS-ENDPOINTS
         RTPSEndpointQos endpoint;
-        endpoint.history_memory_policy = eprosima::fastrtps::rtps::DYNAMIC_REUSABLE_MEMORY_MODE;
+        endpoint.history_memory_policy = eprosima::fastdds::rtps::DYNAMIC_REUSABLE_MEMORY_MODE;
         //!--
     }
 
@@ -6754,13 +6754,13 @@ public:
 
     bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload) override
+            eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return true;
     }
 
     bool deserialize(
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override
     {
         return true;
@@ -6784,7 +6784,7 @@ public:
 
     bool getKey(
             void* data,
-            eprosima::fastrtps::rtps::InstanceHandle_t* ihandle,
+            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5) override
     {
         return true;
@@ -7006,7 +7006,7 @@ void dds_request_reply_example_client()
 
         //!
 
-        eprosima::fastrtps::rtps::SampleIdentity my_request_sample_identity;
+        eprosima::fastdds::rtps::SampleIdentity my_request_sample_identity;
 
     }
     listener;
@@ -7039,13 +7039,13 @@ void dds_request_reply_example_client()
     //!
 
     //REQUEST_REPLY_EXAMPLE_CLIENT_RETRIEVE_ID
-    eprosima::fastrtps::rtps::SampleIdentity my_request_sample_identity;
+    eprosima::fastdds::rtps::SampleIdentity my_request_sample_identity;
     RequestType request;
 
     // Fill the request
 
     // Publish request
-    eprosima::fastrtps::rtps::WriteParams write_params;
+    eprosima::fastdds::rtps::WriteParams write_params;
     request_writer->write(static_cast<void*>(&request), write_params);
 
     // Store sample identity
@@ -7071,7 +7071,7 @@ void dds_request_reply_example_server()
             if (eprosima::fastdds::dds::InstanceStateKind::ALIVE_INSTANCE_STATE == sample_info.instance_state)
             {
                 // Store the request identity.
-                eprosima::fastrtps::rtps::SampleIdentity client_request_identity = sample_info.sample_identity;
+                eprosima::fastdds::rtps::SampleIdentity client_request_identity = sample_info.sample_identity;
             }
         }
 
@@ -7107,14 +7107,14 @@ void dds_request_reply_example_server()
     DataReader* request_reader = subscriber->create_datareader(request_topic, DATAREADER_QOS_DEFAULT, &listener);
     //!
 
-    eprosima::fastrtps::rtps::SampleIdentity client_request_identity;
+    eprosima::fastdds::rtps::SampleIdentity client_request_identity;
     //REQUEST_REPLY_EXAMPLE_SERVER_SEND_REPLY
     ReplyType reply;
 
     // Fill reply
 
     // Send reply associating it with the client request.
-    eprosima::fastrtps::rtps::WriteParams write_params;
+    eprosima::fastdds::rtps::WriteParams write_params;
     write_params.related_sample_identity() = client_request_identity;
     reply_writer->write(reinterpret_cast<void*>(&reply), write_params);
     //!
@@ -7146,7 +7146,7 @@ void dds_waitset_example()
                 // Wait for any of the conditions to be triggered
                 ReturnCode_t ret_code;
                 ConditionSeq triggered_conditions;
-                ret_code = wait_set_.wait(triggered_conditions, eprosima::fastrtps::c_TimeInfinite);
+                ret_code = wait_set_.wait(triggered_conditions, eprosima::fastdds::c_TimeInfinite);
                 if (RETCODE_OK != ret_code)
                 {
                     // ... handle error
@@ -7317,17 +7317,17 @@ void tcp_use_cases()
 
         /* Locators */
         // Define locator for PDP over multicast
-        eprosima::fastrtps::rtps::Locator_t pdp_locator;
+        eprosima::fastdds::rtps::Locator_t pdp_locator;
         pdp_locator.kind = LOCATOR_KIND_UDPv4;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(pdp_locator, "239.255.0.1");
+        eprosima::fastdds::rtps::IPLocator::setIPv4(pdp_locator, "239.255.0.1");
         pqos.wire_protocol().builtin.metatrafficMulticastLocatorList.push_back(pdp_locator);
 
         // Define locator for EDP and user data
-        eprosima::fastrtps::rtps::Locator_t tcp_locator;
+        eprosima::fastdds::rtps::Locator_t tcp_locator;
         tcp_locator.kind = LOCATOR_KIND_TCPv4;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(tcp_locator, "0.0.0.0");
-        eprosima::fastrtps::rtps::IPLocator::setPhysicalPort(tcp_locator, tcp_listening_port);
-        eprosima::fastrtps::rtps::IPLocator::setLogicalPort(tcp_locator, tcp_listening_port);
+        eprosima::fastdds::rtps::IPLocator::setIPv4(tcp_locator, "0.0.0.0");
+        eprosima::fastdds::rtps::IPLocator::setPhysicalPort(tcp_locator, tcp_listening_port);
+        eprosima::fastdds::rtps::IPLocator::setLogicalPort(tcp_locator, tcp_listening_port);
         pqos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(tcp_locator);
         pqos.wire_protocol().default_unicast_locator_list.push_back(tcp_locator);
 
@@ -7343,7 +7343,7 @@ void tcp_use_cases()
 
         // Configure the current participant as SERVER
         qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                eprosima::fastrtps::rtps::DiscoveryProtocol_t::SERVER;
+                eprosima::fastdds::rtps::DiscoveryProtocol_t::SERVER;
 
         // Add custom user transport with TCP port 12345
         auto data_transport = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
@@ -7352,10 +7352,10 @@ void tcp_use_cases()
 
         // Define the listening locator to be on interface 192.168.10.57 and port 12345
         constexpr uint16_t tcp_listening_port = 12345;
-        eprosima::fastrtps::rtps::Locator_t listening_locator;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(listening_locator, "192.168.10.57");
-        eprosima::fastrtps::rtps::IPLocator::setPhysicalPort(listening_locator, tcp_listening_port);
-        eprosima::fastrtps::rtps::IPLocator::setLogicalPort(listening_locator, tcp_listening_port);
+        eprosima::fastdds::rtps::Locator_t listening_locator;
+        eprosima::fastdds::rtps::IPLocator::setIPv4(listening_locator, "192.168.10.57");
+        eprosima::fastdds::rtps::IPLocator::setPhysicalPort(listening_locator, tcp_listening_port);
+        eprosima::fastdds::rtps::IPLocator::setLogicalPort(listening_locator, tcp_listening_port);
         qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(listening_locator);
 
         // Set the GUID prefix to identify this server
@@ -7369,7 +7369,7 @@ void tcp_use_cases()
 
         // Configure the current participant as SERVER
         qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-                eprosima::fastrtps::rtps::DiscoveryProtocol_t::CLIENT;
+                eprosima::fastdds::rtps::DiscoveryProtocol_t::CLIENT;
 
         // Add custom user transport with TCP port 0 (automatic port assignation)
         auto data_transport = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
@@ -7378,13 +7378,13 @@ void tcp_use_cases()
 
         // Define the server locator to be on interface 192.168.10.57 and port 12345
         constexpr uint16_t server_port = 12345;
-        eprosima::fastrtps::rtps::Locator_t server_locator;
-        eprosima::fastrtps::rtps::IPLocator::setIPv4(server_locator, "192.168.10.57");
-        eprosima::fastrtps::rtps::IPLocator::setPhysicalPort(server_locator, server_port);
-        eprosima::fastrtps::rtps::IPLocator::setLogicalPort(server_locator, server_port);
+        eprosima::fastdds::rtps::Locator_t server_locator;
+        eprosima::fastdds::rtps::IPLocator::setIPv4(server_locator, "192.168.10.57");
+        eprosima::fastdds::rtps::IPLocator::setPhysicalPort(server_locator, server_port);
+        eprosima::fastdds::rtps::IPLocator::setLogicalPort(server_locator, server_port);
 
         // Define the server attributes
-        eprosima::fastrtps::rtps::RemoteServerAttributes remote_server_att;
+        eprosima::fastdds::rtps::RemoteServerAttributes remote_server_att;
         remote_server_att.metatrafficUnicastLocatorList.push_back(server_locator);
 
         // Set the GUID prefix to identify this server

--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.cxx
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.cxx
@@ -27,8 +27,8 @@
 #include "HelloWorldCdrAux.hpp"
 #include "HelloWorldTypeObjectSupport.hpp"
 
-using SerializedPayload_t = eprosima::fastrtps::rtps::SerializedPayload_t;
-using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+using SerializedPayload_t = eprosima::fastdds::rtps::SerializedPayload_t;
+using InstanceHandle_t = eprosima::fastdds::rtps::InstanceHandle_t;
 using DataRepresentationId_t = eprosima::fastdds::dds::DataRepresentationId_t;
 
 HelloWorldPubSubType::HelloWorldPubSubType()

--- a/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.h
+++ b/code/Examples/C++/DDSHelloWorld/src/HelloWorldPubSubTypes.h
@@ -54,18 +54,18 @@ public:
 
     eProsima_user_DllExport bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload) override
+            eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool deserialize(
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
@@ -80,7 +80,7 @@ public:
 
     eProsima_user_DllExport bool getKey(
             void* data,
-            eprosima::fastrtps::rtps::InstanceHandle_t* ihandle,
+            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
     eProsima_user_DllExport void* createData() override;

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -289,7 +289,7 @@
 .. |TypeSupport-api| replace:: :cpp:class:`TypeSupport<eprosima::fastdds::dds::TypeSupport>`
 .. |TypeSupport::is_plain-api| replace:: :cpp:func:`TypeSupport::is_plain() <eprosima::fastdds::dds::TypeSupport::is_plain>`
 .. |TypeSupport::register_type-api| replace:: :cpp:func:`register_type() <eprosima::fastdds::dds::TypeSupport::register_type>`
-.. |SampleIdentity-api| replace:: :cpp:class:`SampleIdentity<eprosima::fastrtps::rtps::SampleIdentity>`
+.. |SampleIdentity-api| replace:: :cpp:class:`SampleIdentity<eprosima::fastdds::rtps::SampleIdentity>`
 .. |SampleInfo-api| replace:: :cpp:class:`SampleInfo<eprosima::fastdds::dds::SampleInfo>`
 
 .. |SampleInfo::sample_state-api| replace:: :cpp:member:`sample_state<eprosima::fastdds::dds::SampleInfo::sample_state>`
@@ -379,7 +379,7 @@
 .. |autoenable_created_entities-api| replace:: :cpp:member:`autoenable_created_entities<eprosima::fastdds::dds::EntityFactoryQosPolicy::autoenable_created_entities>`
 
 .. |GroupDataQosPolicy-api| replace:: :cpp:class:`GroupDataQosPolicy<eprosima::fastdds::dds::GroupDataQosPolicy>`
-.. |octet-api| replace:: :cpp:type:`octet<eprosima::fastrtps::rtps::octet>`
+.. |octet-api| replace:: :cpp:type:`octet<eprosima::fastdds::rtps::octet>`
 
 .. |PartitionQosPolicy-api| replace:: :cpp:class:`PartitionQosPolicy<eprosima::fastdds::dds::PartitionQosPolicy>`
 .. |PartitionQosPolicy::max_size-api| replace:: :cpp:func:`max_size<eprosima::fastdds::dds::PartitionQosPolicy::max_size>`
@@ -462,16 +462,16 @@
 .. |SHARED-xml-api| replace:: :cpp:enumerator:`SHARED<eprosima::fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS>`
 .. |EXCLUSIVE-xml-api| replace:: :cpp:enumerator:`EXCLUSIVE<eprosima::fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS>`
 
-.. |Duration_t-api| replace:: :cpp:type:`Duration_t<eprosima::fastrtps::Duration_t>`
-.. |c_TimeInfinite-api| replace:: :cpp:var:`c_TimeInfinite<eprosima::fastrtps::c_TimeInfinite>`
-.. |c_TimeZero-api| replace:: :cpp:var:`c_TimeZero<eprosima::fastrtps::c_TimeInfinite>`
-.. |c_TimeInvalid-api| replace:: :cpp:var:`c_TimeInvalid<eprosima::fastrtps::c_TimeInfinite>`
+.. |Duration_t-api| replace:: :cpp:type:`Duration_t<eprosima::fastdds::Duration_t>`
+.. |c_TimeInfinite-api| replace:: :cpp:var:`c_TimeInfinite<eprosima::fastdds::c_TimeInfinite>`
+.. |c_TimeZero-api| replace:: :cpp:var:`c_TimeZero<eprosima::fastdds::c_TimeInfinite>`
+.. |c_TimeInvalid-api| replace:: :cpp:var:`c_TimeInvalid<eprosima::fastdds::c_TimeInfinite>`
 .. |LocatorList_t-api| replace:: :cpp:type:`LocatorList<eprosima::fastdds::rtps::LocatorList>`
 .. |ExternalLocators-api| replace:: :cpp:type:`ExternalLocators<eprosima::fastdds::rtps::ExternalLocators>`
-.. |Locator_t-api| replace:: :cpp:class:`Locator_t<eprosima::fastrtps::rtps::Locator_t>`
-.. |Locator_t::kind-api| replace:: :cpp:var:`kind<eprosima::fastrtps::rtps::Locator_t::kind>`
-.. |Locator_t::address-api| replace:: :cpp:var:`address<eprosima::fastrtps::rtps::Locator_t::address>`
-.. |Locator_t::port-api| replace:: :cpp:var:`port<eprosima::fastrtps::rtps::Locator_t::port>`
+.. |Locator_t-api| replace:: :cpp:class:`Locator_t<eprosima::fastdds::rtps::Locator_t>`
+.. |Locator_t::kind-api| replace:: :cpp:var:`kind<eprosima::fastdds::rtps::Locator_t::kind>`
+.. |Locator_t::address-api| replace:: :cpp:var:`address<eprosima::fastdds::rtps::Locator_t::address>`
+.. |Locator_t::port-api| replace:: :cpp:var:`port<eprosima::fastdds::rtps::Locator_t::port>`
 
 .. |LOCATOR_KIND_RESERVED-api| replace:: :c:macro:`LOCATOR_KIND_RESERVED<LOCATOR_KIND_RESERVED>`
 .. |LOCATOR_KIND_UDPv4-api| replace:: :c:macro:`LOCATOR_KIND_UDPv4<LOCATOR_KIND_UDPv4>`
@@ -481,22 +481,22 @@
 .. |LOCATOR_KIND_SHM-api| replace:: :c:macro:`LOCATOR_KIND_SHM<LOCATOR_KIND_SHM>`
 
 
-.. |SerializedPayload_t-api| replace:: :cpp:struct:`SerializedPayload_t<eprosima::fastrtps::rtps::SerializedPayload_t>`
+.. |SerializedPayload_t-api| replace:: :cpp:struct:`SerializedPayload_t<eprosima::fastdds::rtps::SerializedPayload_t>`
 
 .. |InconsistentTopicStatus-api| replace:: :cpp:type:`InconsistentTopicStatus<eprosima::fastdds::dds::InconsistentTopicStatus>`
 .. |SampleLostStatus-api| replace:: :cpp:type:`SampleLostStatus<eprosima::fastdds::dds::SampleLostStatus>`
 
 
-.. |MemoryManagementPolicy-api| replace:: :cpp:enum:`MemoryManagementPolicy<eprosima::fastrtps::rtps::MemoryManagementPolicy>`
-.. |PREALLOCATED_MEMORY_MODE-api| replace:: :cpp:enumerator:`PREALLOCATED_MEMORY_MODE<eprosima::fastrtps::rtps::MemoryManagementPolicy::PREALLOCATED_MEMORY_MODE>`
-.. |PREALLOCATED_WITH_REALLOC_MEMORY_MODE-api| replace:: :cpp:enumerator:`PREALLOCATED_WITH_REALLOC_MEMORY_MODE<eprosima::fastrtps::rtps::MemoryManagementPolicy::PREALLOCATED_WITH_REALLOC_MEMORY_MODE>`
-.. |DYNAMIC_RESERVE_MEMORY_MODE-api| replace:: :cpp:enumerator:`DYNAMIC_RESERVE_MEMORY_MODE<eprosima::fastrtps::rtps::MemoryManagementPolicy::DYNAMIC_RESERVE_MEMORY_MODE>`
-.. |DYNAMIC_REUSABLE_MEMORY_MODE-api| replace:: :cpp:enumerator:`DYNAMIC_REUSABLE_MEMORY_MODE<eprosima::fastrtps::rtps::MemoryManagementPolicy::DYNAMIC_REUSABLE_MEMORY_MODE>`
+.. |MemoryManagementPolicy-api| replace:: :cpp:enum:`MemoryManagementPolicy<eprosima::fastdds::rtps::MemoryManagementPolicy>`
+.. |PREALLOCATED_MEMORY_MODE-api| replace:: :cpp:enumerator:`PREALLOCATED_MEMORY_MODE<eprosima::fastdds::rtps::MemoryManagementPolicy::PREALLOCATED_MEMORY_MODE>`
+.. |PREALLOCATED_WITH_REALLOC_MEMORY_MODE-api| replace:: :cpp:enumerator:`PREALLOCATED_WITH_REALLOC_MEMORY_MODE<eprosima::fastdds::rtps::MemoryManagementPolicy::PREALLOCATED_WITH_REALLOC_MEMORY_MODE>`
+.. |DYNAMIC_RESERVE_MEMORY_MODE-api| replace:: :cpp:enumerator:`DYNAMIC_RESERVE_MEMORY_MODE<eprosima::fastdds::rtps::MemoryManagementPolicy::DYNAMIC_RESERVE_MEMORY_MODE>`
+.. |DYNAMIC_REUSABLE_MEMORY_MODE-api| replace:: :cpp:enumerator:`DYNAMIC_REUSABLE_MEMORY_MODE<eprosima::fastdds::rtps::MemoryManagementPolicy::DYNAMIC_REUSABLE_MEMORY_MODE>`
 
-.. |PREALLOCATED-xml-api| replace:: :cpp:enumerator:`PREALLOCATED<eprosima::fastrtps::rtps::MemoryManagementPolicy::PREALLOCATED_MEMORY_MODE>`
-.. |PREALLOCATED_WITH_REALLOC-xml-api| replace:: :cpp:enumerator:`PREALLOCATED_WITH_REALLOC<eprosima::fastrtps::rtps::MemoryManagementPolicy::PREALLOCATED_WITH_REALLOC_MEMORY_MODE>`
-.. |DYNAMIC-xml-api| replace:: :cpp:enumerator:`DYNAMIC<eprosima::fastrtps::rtps::MemoryManagementPolicy::DYNAMIC_RESERVE_MEMORY_MODE>`
-.. |DYNAMIC_REUSABLE-xml-api| replace:: :cpp:enumerator:`DYNAMIC_REUSABLE<eprosima::fastrtps::rtps::MemoryManagementPolicy::DYNAMIC_REUSABLE_MEMORY_MODE>`
+.. |PREALLOCATED-xml-api| replace:: :cpp:enumerator:`PREALLOCATED<eprosima::fastdds::rtps::MemoryManagementPolicy::PREALLOCATED_MEMORY_MODE>`
+.. |PREALLOCATED_WITH_REALLOC-xml-api| replace:: :cpp:enumerator:`PREALLOCATED_WITH_REALLOC<eprosima::fastdds::rtps::MemoryManagementPolicy::PREALLOCATED_WITH_REALLOC_MEMORY_MODE>`
+.. |DYNAMIC-xml-api| replace:: :cpp:enumerator:`DYNAMIC<eprosima::fastdds::rtps::MemoryManagementPolicy::DYNAMIC_RESERVE_MEMORY_MODE>`
+.. |DYNAMIC_REUSABLE-xml-api| replace:: :cpp:enumerator:`DYNAMIC_REUSABLE<eprosima::fastdds::rtps::MemoryManagementPolicy::DYNAMIC_REUSABLE_MEMORY_MODE>`
 
 .. |RTPSReliableReaderQos-api| replace:: :cpp:class:`RTPSReliableReaderQos<eprosima::fastdds::dds::RTPSReliableReaderQos>`
 .. |RTPSReliableReaderQos::times-api| replace:: :cpp:member:`times<eprosima::fastdds::dds::RTPSReliableReaderQos::times>`
@@ -507,41 +507,41 @@
 .. |DisablePositiveACKsQosPolicy::duration-api| replace:: :cpp:member:`duration<eprosima::fastdds::dds::DisablePositiveACKsQosPolicy::duration>`
 
 .. |ParticipantResourceLimitsQos-api| replace:: :cpp:type:`ParticipantResourceLimitsQos<eprosima::fastdds::dds::ParticipantResourceLimitsQos>`
-.. |ParticipantResourceLimitsQos::locators-api| replace:: :cpp:member:`locators<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::locators>`
-.. |ParticipantResourceLimitsQos::participants-api| replace:: :cpp:member:`participants<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::participants>`
-.. |ParticipantResourceLimitsQos::readers-api| replace:: :cpp:member:`readers<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::readers>`
-.. |ParticipantResourceLimitsQos::writers-api| replace:: :cpp:member:`writers<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::writers>`
-.. |ParticipantResourceLimitsQos::send_buffers-api| replace:: :cpp:member:`send_buffers<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::send_buffers>`
-.. |ParticipantResourceLimitsQos::data_limits-api| replace:: :cpp:member:`data_limits<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::data_limits>`
-.. |ParticipantResourceLimitsQos::content_filter-api| replace:: :cpp:member:`content_filter<eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes::content_filter>`
+.. |ParticipantResourceLimitsQos::locators-api| replace:: :cpp:member:`locators<eprosima::fastdds::rtps::RTPSParticipantAllocationAttributes::locators>`
+.. |ParticipantResourceLimitsQos::participants-api| replace:: :cpp:member:`participants<eprosima::fastdds::rtps::RTPSParticipantAllocationAttributes::participants>`
+.. |ParticipantResourceLimitsQos::readers-api| replace:: :cpp:member:`readers<eprosima::fastdds::rtps::RTPSParticipantAllocationAttributes::readers>`
+.. |ParticipantResourceLimitsQos::writers-api| replace:: :cpp:member:`writers<eprosima::fastdds::rtps::RTPSParticipantAllocationAttributes::writers>`
+.. |ParticipantResourceLimitsQos::send_buffers-api| replace:: :cpp:member:`send_buffers<eprosima::fastdds::rtps::RTPSParticipantAllocationAttributes::send_buffers>`
+.. |ParticipantResourceLimitsQos::data_limits-api| replace:: :cpp:member:`data_limits<eprosima::fastdds::rtps::RTPSParticipantAllocationAttributes::data_limits>`
+.. |ParticipantResourceLimitsQos::content_filter-api| replace:: :cpp:member:`content_filter<eprosima::fastdds::rtps::RTPSParticipantAllocationAttributes::content_filter>`
 
-.. |RemoteLocatorsAllocationAttributes-api| replace:: :cpp:struct:`RemoteLocatorsAllocationAttributes<eprosima::fastrtps::rtps::RemoteLocatorsAllocationAttributes>`
-.. |RemoteLocatorsAllocationAttributes::max_unicast_locators-api| replace:: :cpp:member:`max_unicast_locators<eprosima::fastrtps::rtps::RemoteLocatorsAllocationAttributes::max_unicast_locators>`
-.. |RemoteLocatorsAllocationAttributes::max_multicast_locators-api| replace:: :cpp:member:`max_multicast_locators<eprosima::fastrtps::rtps::RemoteLocatorsAllocationAttributes::max_multicast_locators>`
+.. |RemoteLocatorsAllocationAttributes-api| replace:: :cpp:struct:`RemoteLocatorsAllocationAttributes<eprosima::fastdds::rtps::RemoteLocatorsAllocationAttributes>`
+.. |RemoteLocatorsAllocationAttributes::max_unicast_locators-api| replace:: :cpp:member:`max_unicast_locators<eprosima::fastdds::rtps::RemoteLocatorsAllocationAttributes::max_unicast_locators>`
+.. |RemoteLocatorsAllocationAttributes::max_multicast_locators-api| replace:: :cpp:member:`max_multicast_locators<eprosima::fastdds::rtps::RemoteLocatorsAllocationAttributes::max_multicast_locators>`
 
-.. |ResourceLimitedContainerConfig-api| replace:: :cpp:struct:`ResourceLimitedContainerConfig<eprosima::fastrtps::ResourceLimitedContainerConfig>`
-.. |ResourceLimitedContainerConfig::initial-api| replace:: :cpp:member:`initial<eprosima::fastrtps::ResourceLimitedContainerConfig::initial>`
-.. |ResourceLimitedContainerConfig::maximum-api| replace:: :cpp:member:`maximum<eprosima::fastrtps::ResourceLimitedContainerConfig::maximum>`
-.. |ResourceLimitedContainerConfig::increment-api| replace:: :cpp:member:`increment<eprosima::fastrtps::ResourceLimitedContainerConfig::increment>`
+.. |ResourceLimitedContainerConfig-api| replace:: :cpp:struct:`ResourceLimitedContainerConfig<eprosima::fastdds::ResourceLimitedContainerConfig>`
+.. |ResourceLimitedContainerConfig::initial-api| replace:: :cpp:member:`initial<eprosima::fastdds::ResourceLimitedContainerConfig::initial>`
+.. |ResourceLimitedContainerConfig::maximum-api| replace:: :cpp:member:`maximum<eprosima::fastdds::ResourceLimitedContainerConfig::maximum>`
+.. |ResourceLimitedContainerConfig::increment-api| replace:: :cpp:member:`increment<eprosima::fastdds::ResourceLimitedContainerConfig::increment>`
 
-.. |SendBuffersAllocationAttributes-api| replace:: :cpp:struct:`SendBuffersAllocationAttributes<eprosima::fastrtps::rtps::SendBuffersAllocationAttributes>`
-.. |SendBuffersAllocationAttributes::preallocated_number-api| replace:: :cpp:member:`preallocated_number<eprosima::fastrtps::rtps::SendBuffersAllocationAttributes::preallocated_number>`
-.. |SendBuffersAllocationAttributes::dynamic-api| replace:: :cpp:member:`dynamic<eprosima::fastrtps::rtps::SendBuffersAllocationAttributes::dynamic>`
-.. |SendBuffersAllocationAttributes::network_buffers_config-api| replace:: :cpp:member:`network_buffers_config<eprosima::fastrtps::rtps::SendBuffersAllocationAttributes::network_buffers_config>`
+.. |SendBuffersAllocationAttributes-api| replace:: :cpp:struct:`SendBuffersAllocationAttributes<eprosima::fastdds::rtps::SendBuffersAllocationAttributes>`
+.. |SendBuffersAllocationAttributes::preallocated_number-api| replace:: :cpp:member:`preallocated_number<eprosima::fastdds::rtps::SendBuffersAllocationAttributes::preallocated_number>`
+.. |SendBuffersAllocationAttributes::dynamic-api| replace:: :cpp:member:`dynamic<eprosima::fastdds::rtps::SendBuffersAllocationAttributes::dynamic>`
+.. |SendBuffersAllocationAttributes::network_buffers_config-api| replace:: :cpp:member:`network_buffers_config<eprosima::fastdds::rtps::SendBuffersAllocationAttributes::network_buffers_config>`
 
-.. |ReaderTimes-api| replace:: :cpp:class:`ReaderTimes<eprosima::fastrtps::rtps::ReaderTimes>`
-.. |ReaderTimes::initial_acknack_delay-api| replace:: :cpp:member:`initial_acknack_delay<eprosima::fastrtps::rtps::ReaderTimes::initial_acknack_delay>`
-.. |ReaderTimes::heartbeat_response_delay-api| replace:: :cpp:member:`heartbeat_response_delay<eprosima::fastrtps::rtps::ReaderTimes::heartbeat_response_delay>`
+.. |ReaderTimes-api| replace:: :cpp:class:`ReaderTimes<eprosima::fastdds::rtps::ReaderTimes>`
+.. |ReaderTimes::initial_acknack_delay-api| replace:: :cpp:member:`initial_acknack_delay<eprosima::fastdds::rtps::ReaderTimes::initial_acknack_delay>`
+.. |ReaderTimes::heartbeat_response_delay-api| replace:: :cpp:member:`heartbeat_response_delay<eprosima::fastdds::rtps::ReaderTimes::heartbeat_response_delay>`
 
 .. |RTPSReliableWriterQos-api| replace:: :cpp:class:`RTPSReliableWriterQos<eprosima::fastdds::dds::RTPSReliableWriterQos>`
 .. |RTPSReliableWriterQos::times-api| replace:: :cpp:member:`times<eprosima::fastdds::dds::RTPSReliableWriterQos::times>`
 .. |RTPSReliableWriterQos::disable_positive_acks-api| replace:: :cpp:member:`disable_positive_acks<eprosima::fastdds::dds::RTPSReliableWriterQos::disable_positive_acks>`
 .. |RTPSReliableWriterQos::disable_heartbeat_piggyback-api| replace:: :cpp:member:`disable_heartbeat_piggyback<eprosima::fastdds::dds::RTPSReliableWriterQos::disable_heartbeat_piggyback>`
 
-.. |VariableLengthDataLimits-api| replace:: :cpp:struct:`VariableLengthDataLimits<eprosima::fastrtps::rtps::VariableLengthDataLimits>`
-.. |VariableLengthDataLimits::max_user_data-api| replace:: :cpp:member:`max_user_data<eprosima::fastrtps::rtps::VariableLengthDataLimits::max_user_data>`
-.. |VariableLengthDataLimits::max_properties-api| replace:: :cpp:member:`max_properties<eprosima::fastrtps::rtps::VariableLengthDataLimits::max_properties>`
-.. |VariableLengthDataLimits::max_partitions-api| replace:: :cpp:member:`max_partitions<eprosima::fastrtps::rtps::VariableLengthDataLimits::max_partitions>`
+.. |VariableLengthDataLimits-api| replace:: :cpp:struct:`VariableLengthDataLimits<eprosima::fastdds::rtps::VariableLengthDataLimits>`
+.. |VariableLengthDataLimits::max_user_data-api| replace:: :cpp:member:`max_user_data<eprosima::fastdds::rtps::VariableLengthDataLimits::max_user_data>`
+.. |VariableLengthDataLimits::max_properties-api| replace:: :cpp:member:`max_properties<eprosima::fastdds::rtps::VariableLengthDataLimits::max_properties>`
+.. |VariableLengthDataLimits::max_partitions-api| replace:: :cpp:member:`max_partitions<eprosima::fastdds::rtps::VariableLengthDataLimits::max_partitions>`
 
 .. |ContentFilterProperty::AllocationConfiguration-api| replace:: :cpp:struct:`ContentFilterProperty::AllocationConfiguration<eprosima::fastdds::rtps::ContentFilterProperty::AllocationConfiguration>`
 .. |ContentFilterProperty::AllocationConfiguration::expression_initial_size-api| replace:: :cpp:member:`expression_initial_size<eprosima::fastdds::rtps::ContentFilterProperty::AllocationConfiguration::expression_initial_size>`
@@ -577,11 +577,11 @@
 .. |RTPSEndpointQos::entity_id-api| replace:: :cpp:member:`entity_id<eprosima::fastdds::dds::RTPSEndpointQos::entity_id>`
 .. |RTPSEndpointQos::history_memory_policy-api| replace:: :cpp:member:`history_memory_policy<eprosima::fastdds::dds::RTPSEndpointQos::history_memory_policy>`
 
-.. |WriterTimes-api| replace:: :cpp:struct:`WriterTimes<eprosima::fastrtps::rtps::WriterTimes>`
-.. |WriterTimes::initialHeartbeatDelay-api| replace:: :cpp:member:`initialHeartbeatDelay<eprosima::fastrtps::rtps::WriterTimes::initialHeartbeatDelay>`
-.. |WriterTimes::heartbeatPeriod-api| replace:: :cpp:member:`heartbeatPeriod<eprosima::fastrtps::rtps::WriterTimes::heartbeatPeriod>`
-.. |WriterTimes::nackResponseDelay-api| replace:: :cpp:member:`nackResponseDelay<eprosima::fastrtps::rtps::WriterTimes::nackResponseDelay>`
-.. |WriterTimes::nackSupressionDuration-api| replace:: :cpp:member:`nackSupressionDuration<eprosima::fastrtps::rtps::WriterTimes::nackSupressionDuration>`
+.. |WriterTimes-api| replace:: :cpp:struct:`WriterTimes<eprosima::fastdds::rtps::WriterTimes>`
+.. |WriterTimes::initialHeartbeatDelay-api| replace:: :cpp:member:`initialHeartbeatDelay<eprosima::fastdds::rtps::WriterTimes::initialHeartbeatDelay>`
+.. |WriterTimes::heartbeatPeriod-api| replace:: :cpp:member:`heartbeatPeriod<eprosima::fastdds::rtps::WriterTimes::heartbeatPeriod>`
+.. |WriterTimes::nackResponseDelay-api| replace:: :cpp:member:`nackResponseDelay<eprosima::fastdds::rtps::WriterTimes::nackResponseDelay>`
+.. |WriterTimes::nackSupressionDuration-api| replace:: :cpp:member:`nackSupressionDuration<eprosima::fastdds::rtps::WriterTimes::nackSupressionDuration>`
 
 .. |TransportConfigQos-api| replace:: :cpp:class:`TransportConfigQos<eprosima::fastdds::dds::TransportConfigQos>`
 .. |TransportConfigQos::user_transports-api| replace:: :cpp:member:`user_transports<eprosima::fastdds::dds::TransportConfigQos::user_transports>`
@@ -707,14 +707,14 @@
 .. |WireProtocolConfigQos::default_external_unicast_locators-api| replace:: :cpp:member:`default_external_unicast_locators<eprosima::fastdds::dds::WireProtocolConfigQos::default_external_unicast_locators>`
 .. |WireProtocolConfigQos::ignore_non_matching_locators-api| replace:: :cpp:member:`ignore_non_matching_locators<eprosima::fastdds::dds::WireProtocolConfigQos::ignore_non_matching_locators>`
 
-.. |PortParameters-api| replace:: :cpp:class:`PortParameters<eprosima::fastrtps::rtps::PortParameters>`
-.. |PortParameters::domainIDGain-qos-api| replace:: :cpp:member:`wire_protocol().port.domainIDGain<eprosima::fastrtps::rtps::PortParameters::domainIDGain>`
-.. |PortParameters::participantIDGain-qos-api| replace:: :cpp:member:`wire_protocol().port.participantIDGain<eprosima::fastrtps::rtps::PortParameters::participantIDGain>`
-.. |PortParameters::portBase-qos-api| replace:: :cpp:member:`wire_protocol().port.portBase<eprosima::fastrtps::rtps::PortParameters::portBase>`
-.. |PortParameters::offsetd0-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd0<eprosima::fastrtps::rtps::PortParameters::offsetd0>`
-.. |PortParameters::offsetd1-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd1<eprosima::fastrtps::rtps::PortParameters::offsetd1>`
-.. |PortParameters::offsetd2-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd2<eprosima::fastrtps::rtps::PortParameters::offsetd2>`
-.. |PortParameters::offsetd3-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd3<eprosima::fastrtps::rtps::PortParameters::offsetd3>`
+.. |PortParameters-api| replace:: :cpp:class:`PortParameters<eprosima::fastdds::rtps::PortParameters>`
+.. |PortParameters::domainIDGain-qos-api| replace:: :cpp:member:`wire_protocol().port.domainIDGain<eprosima::fastdds::rtps::PortParameters::domainIDGain>`
+.. |PortParameters::participantIDGain-qos-api| replace:: :cpp:member:`wire_protocol().port.participantIDGain<eprosima::fastdds::rtps::PortParameters::participantIDGain>`
+.. |PortParameters::portBase-qos-api| replace:: :cpp:member:`wire_protocol().port.portBase<eprosima::fastdds::rtps::PortParameters::portBase>`
+.. |PortParameters::offsetd0-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd0<eprosima::fastdds::rtps::PortParameters::offsetd0>`
+.. |PortParameters::offsetd1-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd1<eprosima::fastdds::rtps::PortParameters::offsetd1>`
+.. |PortParameters::offsetd2-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd2<eprosima::fastdds::rtps::PortParameters::offsetd2>`
+.. |PortParameters::offsetd3-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd3<eprosima::fastdds::rtps::PortParameters::offsetd3>`
 
 .. |WriterResourceLimitsQos-api| replace:: :cpp:class:`WriterResourceLimitsQos<eprosima::fastdds::dds::WriterResourceLimitsQos>`
 .. |WriterResourceLimitsQos::matched_subscriber_allocation-api| replace:: :cpp:member:`matched_subscriber_allocation<eprosima::fastdds::dds::WriterResourceLimitsQos::matched_subscriber_allocation>`
@@ -757,7 +757,7 @@
 .. |LivelinessChangedStatus::not_alive_count_change-api| replace:: :cpp:member:`not_alive_count_change<eprosima::fastdds::dds::LivelinessChangedStatus::not_alive_count_change>`
 .. |LivelinessChangedStatus::last_publication_handle-api| replace:: :cpp:member:`last_publication_handle<eprosima::fastdds::dds::LivelinessChangedStatus::last_publication_handle>`
 
-.. |InstanceHandle_t-api| replace:: :cpp:struct:`InstanceHandle_t<eprosima::fastrtps::rtps::InstanceHandle_t>`
+.. |InstanceHandle_t-api| replace:: :cpp:struct:`InstanceHandle_t<eprosima::fastdds::rtps::InstanceHandle_t>`
 
 .. |DeadlineMissedStatus-api| replace:: :cpp:struct:`DeadlineMissedStatus<eprosima::fastdds::dds::DeadlineMissedStatus>`
 .. |DeadlineMissedStatus::total_count-api| replace:: :cpp:member:`total_count<eprosima::fastdds::dds::DeadlineMissedStatus::total_count>`
@@ -817,88 +817,88 @@
 .. |DATAREADER_QOS_USE_TOPIC_QOS-api| replace:: :cpp:member:`DATAREADER_QOS_USE_TOPIC_QOS <eprosima::fastdds::dds::DATAREADER_QOS_USE_TOPIC_QOS>`
 
 .. |DomainId-api| replace:: :cpp:type:`DomainId <eprosima::fastdds::dds::DomainId_t>`
-.. |c_InstanceHandle_Unknown-api| replace:: :cpp:member:`c_InstanceHandle_Unknown <eprosima::fastrtps::rtps::c_InstanceHandle_Unknown>`
+.. |c_InstanceHandle_Unknown-api| replace:: :cpp:member:`c_InstanceHandle_Unknown <eprosima::fastdds::rtps::c_InstanceHandle_Unknown>`
 
-.. |RTPSDomain-api| replace:: :cpp:class:`RTPSDomain <eprosima::fastrtps::rtps::RTPSDomain>`
-.. |RTPSDomain::createParticipant-api| replace:: :cpp:func:`RTPSDomain::createParticipant() <eprosima::fastrtps::rtps::RTPSDomain::createParticipant>`
-.. |RTPSDomain::createRTPSWriter-api| replace:: :cpp:func:`RTPSDomain::createRTPSWriter() <eprosima::fastrtps::rtps::RTPSDomain::createRTPSWriter>`
-.. |RTPSDomain::createRTPSReader-api| replace:: :cpp:func:`RTPSDomain::createRTPSReader() <eprosima::fastrtps::rtps::RTPSDomain::createRTPSReader>`
+.. |RTPSDomain-api| replace:: :cpp:class:`RTPSDomain <eprosima::fastdds::rtps::RTPSDomain>`
+.. |RTPSDomain::createParticipant-api| replace:: :cpp:func:`RTPSDomain::createParticipant() <eprosima::fastdds::rtps::RTPSDomain::createParticipant>`
+.. |RTPSDomain::createRTPSWriter-api| replace:: :cpp:func:`RTPSDomain::createRTPSWriter() <eprosima::fastdds::rtps::RTPSDomain::createRTPSWriter>`
+.. |RTPSDomain::createRTPSReader-api| replace:: :cpp:func:`RTPSDomain::createRTPSReader() <eprosima::fastdds::rtps::RTPSDomain::createRTPSReader>`
 
-.. |RTPSParticipants-api| replace:: :cpp:class:`RTPSParticipants <eprosima::fastrtps::rtps::RTPSParticipant>`
-.. |RTPSParticipant-api| replace:: :cpp:class:`RTPSParticipant <eprosima::fastrtps::rtps::RTPSParticipant>`
-.. |RTPSParticipantAttributes-api| replace:: :cpp:class:`RTPSParticipantAttributes<eprosima::fastrtps::rtps::RTPSParticipantAttributes>`
+.. |RTPSParticipants-api| replace:: :cpp:class:`RTPSParticipants <eprosima::fastdds::rtps::RTPSParticipant>`
+.. |RTPSParticipant-api| replace:: :cpp:class:`RTPSParticipant <eprosima::fastdds::rtps::RTPSParticipant>`
+.. |RTPSParticipantAttributes-api| replace:: :cpp:class:`RTPSParticipantAttributes<eprosima::fastdds::rtps::RTPSParticipantAttributes>`
 
-.. |RTPSReaders-api| replace:: :cpp:class:`RTPSReaders <eprosima::fastrtps::rtps::RTPSReader>`
-.. |ReaderAttributes-api| replace:: :cpp:class:`ReaderAttributes<eprosima::fastrtps::rtps::ReaderAttributes>`
-.. |ReaderListener-api| replace:: :cpp:class:`ReaderListener<eprosima::fastrtps::rtps::ReaderListener>`
-.. |ReaderListener::onNewCacheChangeAdded-api| replace:: :cpp:func:`ReaderListener::onNewCacheChangeAdded<eprosima::fastrtps::rtps::ReaderListener::onNewCacheChangeAdded>`
+.. |RTPSReaders-api| replace:: :cpp:class:`RTPSReaders <eprosima::fastdds::rtps::RTPSReader>`
+.. |ReaderAttributes-api| replace:: :cpp:class:`ReaderAttributes<eprosima::fastdds::rtps::ReaderAttributes>`
+.. |ReaderListener-api| replace:: :cpp:class:`ReaderListener<eprosima::fastdds::rtps::ReaderListener>`
+.. |ReaderListener::onNewCacheChangeAdded-api| replace:: :cpp:func:`ReaderListener::onNewCacheChangeAdded<eprosima::fastdds::rtps::ReaderListener::onNewCacheChangeAdded>`
 
-.. |RTPSWriters-api| replace:: :cpp:class:`RTPSWriters <eprosima::fastrtps::rtps::RTPSWriter>`
-.. |WriterAttributes-api| replace:: :cpp:class:`WriterAttributes<eprosima::fastrtps::rtps::WriterAttributes>`
-.. |RTPSWriters::new_change-api| replace:: :cpp:func:`RTPSWriter::new_change() <eprosima::fastrtps::rtps::RTPSWriter::new_change>`
+.. |RTPSWriters-api| replace:: :cpp:class:`RTPSWriters <eprosima::fastdds::rtps::RTPSWriter>`
+.. |WriterAttributes-api| replace:: :cpp:class:`WriterAttributes<eprosima::fastdds::rtps::WriterAttributes>`
+.. |RTPSWriters::new_change-api| replace:: :cpp:func:`RTPSWriter::new_change() <eprosima::fastdds::rtps::RTPSWriter::new_change>`
 
-.. |History-api| replace:: :cpp:class:`History <eprosima::fastrtps::rtps::History>`
-.. |WriterHistory-api| replace:: :cpp:class:`WriterHistory <eprosima::fastrtps::rtps::WriterHistory>`
-.. |WriterHistory::add_change-api| replace:: :cpp:func:`WriterHistory::add_change() <eprosima::fastrtps::rtps::WriterHistory::add_change>`
-.. |ReaderHistory-api| replace:: :cpp:class:`ReaderHistory <eprosima::fastrtps::rtps::ReaderHistory>`
-.. |CacheChange_t-api| replace:: :cpp:class:`CacheChange_t<eprosima::fastrtps::rtps::CacheChange_t>`
+.. |History-api| replace:: :cpp:class:`History <eprosima::fastdds::rtps::History>`
+.. |WriterHistory-api| replace:: :cpp:class:`WriterHistory <eprosima::fastdds::rtps::WriterHistory>`
+.. |WriterHistory::add_change-api| replace:: :cpp:func:`WriterHistory::add_change() <eprosima::fastdds::rtps::WriterHistory::add_change>`
+.. |ReaderHistory-api| replace:: :cpp:class:`ReaderHistory <eprosima::fastdds::rtps::ReaderHistory>`
+.. |CacheChange_t-api| replace:: :cpp:class:`CacheChange_t<eprosima::fastdds::rtps::CacheChange_t>`
 
-.. |HistoryAttributes-api| replace:: :cpp:class:`HistoryAttributes<eprosima::fastrtps::rtps::HistoryAttributes>`
-.. |HistoryAttributes::memoryPolicy-api| replace:: :cpp:member:`memoryPolicy<eprosima::fastrtps::rtps::HistoryAttributes::memoryPolicy>`
-.. |HistoryAttributes::payloadMaxSize-api| replace:: :cpp:member:`payloadMaxSize<eprosima::fastrtps::rtps::HistoryAttributes::payloadMaxSize>`
-.. |HistoryAttributes::initialReservedCaches-api| replace:: :cpp:member:`initialReservedCaches<eprosima::fastrtps::rtps::HistoryAttributes::initialReservedCaches>`
+.. |HistoryAttributes-api| replace:: :cpp:class:`HistoryAttributes<eprosima::fastdds::rtps::HistoryAttributes>`
+.. |HistoryAttributes::memoryPolicy-api| replace:: :cpp:member:`memoryPolicy<eprosima::fastdds::rtps::HistoryAttributes::memoryPolicy>`
+.. |HistoryAttributes::payloadMaxSize-api| replace:: :cpp:member:`payloadMaxSize<eprosima::fastdds::rtps::HistoryAttributes::payloadMaxSize>`
+.. |HistoryAttributes::initialReservedCaches-api| replace:: :cpp:member:`initialReservedCaches<eprosima::fastdds::rtps::HistoryAttributes::initialReservedCaches>`
 
-.. |IPayloadPool-api| replace:: :cpp:class:`IPayloadPool <eprosima::fastrtps::rtps::IPayloadPool>`
-.. |IPayloadPool::get_payload-api| replace:: :cpp:func:`IPayloadPool::get_payload <eprosima::fastrtps::rtps::IPayloadPool::get_payload>`
-.. |IPayloadPool::release_payload-api| replace:: :cpp:func:`IPayloadPool::release_payload <eprosima::fastrtps::rtps::IPayloadPool::release_payload>`
+.. |IPayloadPool-api| replace:: :cpp:class:`IPayloadPool <eprosima::fastdds::rtps::IPayloadPool>`
+.. |IPayloadPool::get_payload-api| replace:: :cpp:func:`IPayloadPool::get_payload <eprosima::fastdds::rtps::IPayloadPool::get_payload>`
+.. |IPayloadPool::release_payload-api| replace:: :cpp:func:`IPayloadPool::release_payload <eprosima::fastdds::rtps::IPayloadPool::release_payload>`
 
 
-.. |DiscoverySettings-api| replace:: :cpp:class:`DiscoverySettings <eprosima::fastrtps::rtps::DiscoverySettings>`
-.. |leaseDuration_announcementperiod| replace:: :cpp:member:`leaseDuration_announcementperiod <eprosima::fastrtps::rtps::DiscoverySettings::leaseDuration_announcementperiod>`
-.. |DiscoveryProtocol_t| replace:: :cpp:member:`DiscoveryProtocol_t <eprosima::fastrtps::rtps::DiscoverySettings::DiscoveryProtocol_t>`
-.. |ParticipantFilteringFlags_t| replace:: :cpp:member:`ParticipantFilteringFlags_t <eprosima::fastrtps::rtps::DiscoverySettings::ParticipantFilteringFlags_t>`
-.. |discoveryProtocol| replace:: :cpp:member:`discoveryProtocol <eprosima::fastrtps::rtps::DiscoverySettings::discoveryProtocol>`
-.. |m_DiscoveryServers| replace:: :cpp:member:`m_DiscoveryServers <eprosima::fastrtps::rtps::DiscoverySettings::m_DiscoveryServers>`
-.. |discoveryServer_client_syncperiod| replace:: :cpp:member:`discoveryServer_client_syncperiod <eprosima::fastrtps::rtps::DiscoverySettings::discoveryServer_client_syncperiod>`
+.. |DiscoverySettings-api| replace:: :cpp:class:`DiscoverySettings <eprosima::fastdds::rtps::DiscoverySettings>`
+.. |leaseDuration_announcementperiod| replace:: :cpp:member:`leaseDuration_announcementperiod <eprosima::fastdds::rtps::DiscoverySettings::leaseDuration_announcementperiod>`
+.. |DiscoveryProtocol_t| replace:: :cpp:member:`DiscoveryProtocol_t <eprosima::fastdds::rtps::DiscoverySettings::DiscoveryProtocol_t>`
+.. |ParticipantFilteringFlags_t| replace:: :cpp:member:`ParticipantFilteringFlags_t <eprosima::fastdds::rtps::DiscoverySettings::ParticipantFilteringFlags_t>`
+.. |discoveryProtocol| replace:: :cpp:member:`discoveryProtocol <eprosima::fastdds::rtps::DiscoverySettings::discoveryProtocol>`
+.. |m_DiscoveryServers| replace:: :cpp:member:`m_DiscoveryServers <eprosima::fastdds::rtps::DiscoverySettings::m_DiscoveryServers>`
+.. |discoveryServer_client_syncperiod| replace:: :cpp:member:`discoveryServer_client_syncperiod <eprosima::fastdds::rtps::DiscoverySettings::discoveryServer_client_syncperiod>`
 
-.. |DiscoveryProtocol-api| replace:: :cpp:enum:`DiscoveryProtocol<eprosima::fastrtps::rtps::DiscoveryProtocol>`
-.. |SIMPLE| replace:: :cpp:enumerator:`SIMPLE<eprosima::fastrtps::rtps::DiscoveryProtocol::SIMPLE>`
-.. |STATIC| replace:: :cpp:enumerator:`STATIC<eprosima::fastrtps::rtps::DiscoveryProtocol::STATIC>`
-.. |SERVER| replace:: :cpp:enumerator:`SERVER<eprosima::fastrtps::rtps::DiscoveryProtocol::SERVER>`
-.. |CLIENT| replace:: :cpp:enumerator:`CLIENT<eprosima::fastrtps::rtps::DiscoveryProtocol::CLIENT>`
-.. |CLIENTS| replace:: :cpp:enumerator:`CLIENTS<eprosima::fastrtps::rtps::DiscoveryProtocol::CLIENT>`
-.. |SUPER_CLIENT| replace:: :cpp:enumerator:`SUPER_CLIENT<eprosima::fastrtps::rtps::DiscoveryProtocol::SUPER_CLIENT>`
-.. |BACKUP| replace:: :cpp:enumerator:`BACKUP<eprosima::fastrtps::rtps::DiscoveryProtocol::BACKUP>`
-.. |NONE| replace:: :cpp:enumerator:`NONE<eprosima::fastrtps::rtps::DiscoveryProtocol::NONE>`
+.. |DiscoveryProtocol-api| replace:: :cpp:enum:`DiscoveryProtocol<eprosima::fastdds::rtps::DiscoveryProtocol>`
+.. |SIMPLE| replace:: :cpp:enumerator:`SIMPLE<eprosima::fastdds::rtps::DiscoveryProtocol::SIMPLE>`
+.. |STATIC| replace:: :cpp:enumerator:`STATIC<eprosima::fastdds::rtps::DiscoveryProtocol::STATIC>`
+.. |SERVER| replace:: :cpp:enumerator:`SERVER<eprosima::fastdds::rtps::DiscoveryProtocol::SERVER>`
+.. |CLIENT| replace:: :cpp:enumerator:`CLIENT<eprosima::fastdds::rtps::DiscoveryProtocol::CLIENT>`
+.. |CLIENTS| replace:: :cpp:enumerator:`CLIENTS<eprosima::fastdds::rtps::DiscoveryProtocol::CLIENT>`
+.. |SUPER_CLIENT| replace:: :cpp:enumerator:`SUPER_CLIENT<eprosima::fastdds::rtps::DiscoveryProtocol::SUPER_CLIENT>`
+.. |BACKUP| replace:: :cpp:enumerator:`BACKUP<eprosima::fastdds::rtps::DiscoveryProtocol::BACKUP>`
+.. |NONE| replace:: :cpp:enumerator:`NONE<eprosima::fastdds::rtps::DiscoveryProtocol::NONE>`
 
-.. |ParticipantFilteringFlags-api| replace:: :cpp:enum:`ParticipantFilteringFlags<eprosima::fastrtps::rtps::ParticipantFilteringFlags>`
-.. |NO_FILTER| replace:: :cpp:enumerator:`NO_FILTER<eprosima::fastrtps::rtps::ParticipantFilteringFlags::NO_FILTER>`
-.. |FILTER_DIFFERENT_HOST| replace:: :cpp:enumerator:`FILTER_DIFFERENT_HOST<eprosima::fastrtps::rtps::ParticipantFilteringFlags::FILTER_DIFFERENT_HOST>`
-.. |FILTER_DIFFERENT_PROCESS| replace:: :cpp:enumerator:`FILTER_DIFFERENT_PROCESS<eprosima::fastrtps::rtps::ParticipantFilteringFlags::FILTER_DIFFERENT_PROCESS>`
-.. |FILTER_SAME_PROCESS| replace:: :cpp:enumerator:`FILTER_SAME_PROCESS<eprosima::fastrtps::rtps::ParticipantFilteringFlags::FILTER_SAME_PROCESS>`
+.. |ParticipantFilteringFlags-api| replace:: :cpp:enum:`ParticipantFilteringFlags<eprosima::fastdds::rtps::ParticipantFilteringFlags>`
+.. |NO_FILTER| replace:: :cpp:enumerator:`NO_FILTER<eprosima::fastdds::rtps::ParticipantFilteringFlags::NO_FILTER>`
+.. |FILTER_DIFFERENT_HOST| replace:: :cpp:enumerator:`FILTER_DIFFERENT_HOST<eprosima::fastdds::rtps::ParticipantFilteringFlags::FILTER_DIFFERENT_HOST>`
+.. |FILTER_DIFFERENT_PROCESS| replace:: :cpp:enumerator:`FILTER_DIFFERENT_PROCESS<eprosima::fastdds::rtps::ParticipantFilteringFlags::FILTER_DIFFERENT_PROCESS>`
+.. |FILTER_SAME_PROCESS| replace:: :cpp:enumerator:`FILTER_SAME_PROCESS<eprosima::fastdds::rtps::ParticipantFilteringFlags::FILTER_SAME_PROCESS>`
 
-.. |Guid_t-api| replace:: :cpp:struct:`Guid_t<eprosima::fastrtps::rtps::GUID_t>`
-.. |is_on_same_host_as-api| replace:: :cpp:func:`is_on_same_host_as()<eprosima::fastrtps::rtps::GUID_t::is_on_same_host_as>`
-.. |is_on_same_process_as-api| replace:: :cpp:func:`is_on_same_process_as()<eprosima::fastrtps::rtps::GUID_t::is_on_same_process_as>`
-.. |GuidPrefix_t-api| replace:: :cpp:struct:`GuidPrefix_t<eprosima::fastrtps::rtps::GuidPrefix_t>`
-.. |EntityId_t-api| replace:: :cpp:struct:`EntityId_t<eprosima::fastrtps::rtps::EntityId_t>`
-.. |InitialAnnouncementConfig-api| replace:: :cpp:struct:`InitialAnnouncementConfig<eprosima::fastrtps::rtps::InitialAnnouncementConfig>`
-.. |InitialAnnouncementConfig::period-api| replace:: :cpp:member:`period<eprosima::fastrtps::rtps::InitialAnnouncementConfig::period>`
-.. |RemoteServerAttributes-api| replace:: :cpp:class:`RemoteServerAttributes<eprosima::fastrtps::rtps::RemoteServerAttributes>`
-.. |RemoteServerAttributes::metatrafficUnicastLocatorList-api| replace:: :cpp:member:`metatrafficUnicastLocatorList<eprosima::fastrtps::rtps::RemoteServerAttributes::metatrafficUnicastLocatorList>`
-.. |RemoteServerAttributes::metatrafficMulticastLocatorList-api| replace:: :cpp:member:`metatrafficMulticastLocatorList<eprosima::fastrtps::rtps::RemoteServerAttributes::metatrafficMulticastLocatorList>`
-.. |RemoteServerAttributes::guidPrefix-api| replace:: :cpp:member:`guidPrefix<eprosima::fastrtps::rtps::RemoteServerAttributes::guidPrefix>`
-.. |BuiltinAttributes-api| replace:: :cpp:class:`BuiltinAttributes<eprosima::fastrtps::rtps::BuiltinAttributes>`
-.. |BuiltinAttributes::discovery_config-api| replace:: :cpp:member:`discovery_config<eprosima::fastrtps::rtps::BuiltinAttributes::discovery_config>`
-.. |BuiltinAttributes::metatrafficUnicastLocatorList-api| replace:: :cpp:member:`metatrafficUnicastLocatorList<eprosima::fastrtps::rtps::BuiltinAttributes::metatrafficUnicastLocatorList>`
-.. |BuiltinAttributes::metatrafficUnicastLocatorList-qos-api| replace:: :cpp:member:`builtin.metatrafficUnicastLocatorList<eprosima::fastrtps::rtps::BuiltinAttributes::metatrafficUnicastLocatorList>`
-.. |BuiltinAttributes::metatrafficMulticastLocatorList-api| replace:: :cpp:member:`metatrafficMulticastLocatorList<eprosima::fastrtps::rtps::BuiltinAttributes::metatrafficMulticastLocatorList>`
-.. |BuiltinAttributes::metatrafficMulticastLocatorList-qos-api| replace:: :cpp:member:`builtin.metatrafficMulticastLocatorList<eprosima::fastrtps::rtps::BuiltinAttributes::metatrafficMulticastLocatorList>`
-.. |BuiltinAttributes::metatraffic_external_unicast_locators-api| replace:: :cpp:member:`metatraffic_external_unicast_locators<eprosima::fastrtps::rtps::BuiltinAttributes::metatraffic_external_unicast_locators>`
-.. |BuiltinAttributes::metatraffic_external_unicast_locators-qos-api| replace:: :cpp:member:`builtin.metatraffic_external_unicast_locators<eprosima::fastrtps::rtps::BuiltinAttributes::metatraffic_external_unicast_locators>`
-.. |BuiltinAttributes::initialPeersList-api| replace:: :cpp:member:`initialPeersList<eprosima::fastrtps::rtps::BuiltinAttributes::initialPeersList>`
+.. |Guid_t-api| replace:: :cpp:struct:`Guid_t<eprosima::fastdds::rtps::GUID_t>`
+.. |is_on_same_host_as-api| replace:: :cpp:func:`is_on_same_host_as()<eprosima::fastdds::rtps::GUID_t::is_on_same_host_as>`
+.. |is_on_same_process_as-api| replace:: :cpp:func:`is_on_same_process_as()<eprosima::fastdds::rtps::GUID_t::is_on_same_process_as>`
+.. |GuidPrefix_t-api| replace:: :cpp:struct:`GuidPrefix_t<eprosima::fastdds::rtps::GuidPrefix_t>`
+.. |EntityId_t-api| replace:: :cpp:struct:`EntityId_t<eprosima::fastdds::rtps::EntityId_t>`
+.. |InitialAnnouncementConfig-api| replace:: :cpp:struct:`InitialAnnouncementConfig<eprosima::fastdds::rtps::InitialAnnouncementConfig>`
+.. |InitialAnnouncementConfig::period-api| replace:: :cpp:member:`period<eprosima::fastdds::rtps::InitialAnnouncementConfig::period>`
+.. |RemoteServerAttributes-api| replace:: :cpp:class:`RemoteServerAttributes<eprosima::fastdds::rtps::RemoteServerAttributes>`
+.. |RemoteServerAttributes::metatrafficUnicastLocatorList-api| replace:: :cpp:member:`metatrafficUnicastLocatorList<eprosima::fastdds::rtps::RemoteServerAttributes::metatrafficUnicastLocatorList>`
+.. |RemoteServerAttributes::metatrafficMulticastLocatorList-api| replace:: :cpp:member:`metatrafficMulticastLocatorList<eprosima::fastdds::rtps::RemoteServerAttributes::metatrafficMulticastLocatorList>`
+.. |RemoteServerAttributes::guidPrefix-api| replace:: :cpp:member:`guidPrefix<eprosima::fastdds::rtps::RemoteServerAttributes::guidPrefix>`
+.. |BuiltinAttributes-api| replace:: :cpp:class:`BuiltinAttributes<eprosima::fastdds::rtps::BuiltinAttributes>`
+.. |BuiltinAttributes::discovery_config-api| replace:: :cpp:member:`discovery_config<eprosima::fastdds::rtps::BuiltinAttributes::discovery_config>`
+.. |BuiltinAttributes::metatrafficUnicastLocatorList-api| replace:: :cpp:member:`metatrafficUnicastLocatorList<eprosima::fastdds::rtps::BuiltinAttributes::metatrafficUnicastLocatorList>`
+.. |BuiltinAttributes::metatrafficUnicastLocatorList-qos-api| replace:: :cpp:member:`builtin.metatrafficUnicastLocatorList<eprosima::fastdds::rtps::BuiltinAttributes::metatrafficUnicastLocatorList>`
+.. |BuiltinAttributes::metatrafficMulticastLocatorList-api| replace:: :cpp:member:`metatrafficMulticastLocatorList<eprosima::fastdds::rtps::BuiltinAttributes::metatrafficMulticastLocatorList>`
+.. |BuiltinAttributes::metatrafficMulticastLocatorList-qos-api| replace:: :cpp:member:`builtin.metatrafficMulticastLocatorList<eprosima::fastdds::rtps::BuiltinAttributes::metatrafficMulticastLocatorList>`
+.. |BuiltinAttributes::metatraffic_external_unicast_locators-api| replace:: :cpp:member:`metatraffic_external_unicast_locators<eprosima::fastdds::rtps::BuiltinAttributes::metatraffic_external_unicast_locators>`
+.. |BuiltinAttributes::metatraffic_external_unicast_locators-qos-api| replace:: :cpp:member:`builtin.metatraffic_external_unicast_locators<eprosima::fastdds::rtps::BuiltinAttributes::metatraffic_external_unicast_locators>`
+.. |BuiltinAttributes::initialPeersList-api| replace:: :cpp:member:`initialPeersList<eprosima::fastdds::rtps::BuiltinAttributes::initialPeersList>`
 
-.. |Property-api| replace:: :cpp:class:`Property<eprosima::fastrtps::rtps::Property>`
+.. |Property-api| replace:: :cpp:class:`Property<eprosima::fastdds::rtps::Property>`
 
 .. |Log-api| replace:: :cpp:class:`Log <eprosima::fastdds::dds::Log>`
 .. |LogConsumer-api| replace:: :cpp:class:`LogConsumer <eprosima::fastdds::dds::LogConsumer>`
@@ -951,7 +951,7 @@
 .. |HAVE_LOG_NO_ERROR| replace:: :cpp:type:`HAVE_LOG_NO_ERROR`
 .. |LOG_CONSUMER_DEFAULT| replace:: :cpp:type:`LOG_CONSUMER_DEFAULT`
 
-.. |EDPStatic| replace:: :cpp:class:`EDPStatic <eprosima::fastrtps::rtps::EDPStatic>`
+.. |EDPStatic| replace:: :cpp:class:`EDPStatic <eprosima::fastdds::rtps::EDPStatic>`
 
 .. {{{ X-Types API
 .. |AnnotationDescriptor-api| replace:: :cpp:class:`AnnotationDescriptor <eprosima::fastdds::dds::AnnotationDescriptor>`
@@ -1032,11 +1032,11 @@
 
 .. |MonitorServiceDataReaderQos-api| replace:: :cpp:class:`MonitorServiceDataReaderQos <eprosima::fastdds::statistics::dds::MonitorServiceDataReaderQos>`
 
-.. |MessageReceiver| replace:: :cpp:class:`MessageReceiver <eprosima::fastrtps::rtps::MessageReceiver>`
+.. |MessageReceiver| replace:: :cpp:class:`MessageReceiver <eprosima::fastdds::rtps::MessageReceiver>`
 
-.. |WriteParams-api| replace:: :cpp:class:`WriteParams <eprosima::fastrtps::rtps::WriteParams>`
-.. |WriteParams-sample_identity-api| replace:: :cpp:func:`sample_identity() <eprosima::fastrtps::rtps::WriteParams::sample_identity>`
-.. |WriteParams-related_sample_identity-api| replace:: :cpp:func:`related_sample_identity() <eprosima::fastrtps::rtps::WriteParams::related_sample_identity>`
+.. |WriteParams-api| replace:: :cpp:class:`WriteParams <eprosima::fastdds::rtps::WriteParams>`
+.. |WriteParams-sample_identity-api| replace:: :cpp:func:`sample_identity() <eprosima::fastdds::rtps::WriteParams::sample_identity>`
+.. |WriteParams-related_sample_identity-api| replace:: :cpp:func:`related_sample_identity() <eprosima::fastdds::rtps::WriteParams::related_sample_identity>`
 
 .. |ThreadSettings::scheduling_policy-api| replace:: :cpp:member:`scheduling_policy<eprosima::fastdds::rtps::ThreadSettings::scheduling_policy>`
 .. |ThreadSettings::priority-api| replace:: :cpp:member:`priority<eprosima::fastdds::rtps::ThreadSettings::priority>`

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -863,7 +863,6 @@
 
 .. |DiscoveryProtocol-api| replace:: :cpp:enum:`DiscoveryProtocol<eprosima::fastdds::rtps::DiscoveryProtocol>`
 .. |SIMPLE| replace:: :cpp:enumerator:`SIMPLE<eprosima::fastdds::rtps::DiscoveryProtocol::SIMPLE>`
-.. |STATIC| replace:: :cpp:enumerator:`STATIC<eprosima::fastdds::rtps::DiscoveryProtocol::STATIC>`
 .. |SERVER| replace:: :cpp:enumerator:`SERVER<eprosima::fastdds::rtps::DiscoveryProtocol::SERVER>`
 .. |CLIENT| replace:: :cpp:enumerator:`CLIENT<eprosima::fastdds::rtps::DiscoveryProtocol::CLIENT>`
 .. |CLIENTS| replace:: :cpp:enumerator:`CLIENTS<eprosima::fastdds::rtps::DiscoveryProtocol::CLIENT>`

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -856,7 +856,7 @@
 .. |DiscoverySettings-api| replace:: :cpp:class:`DiscoverySettings <eprosima::fastdds::rtps::DiscoverySettings>`
 .. |leaseDuration_announcementperiod| replace:: :cpp:member:`leaseDuration_announcementperiod <eprosima::fastdds::rtps::DiscoverySettings::leaseDuration_announcementperiod>`
 .. |DiscoveryProtocol| replace:: :cpp:member:`DiscoveryProtocol <eprosima::fastdds::rtps::DiscoverySettings::DiscoveryProtocol>`
-.. |ParticipantFilteringFlags_t| replace:: :cpp:member:`ParticipantFilteringFlags_t <eprosima::fastdds::rtps::DiscoverySettings::ParticipantFilteringFlags_t>`
+.. |ParticipantFilteringFlags| replace:: :cpp:member:`ParticipantFilteringFlags <eprosima::fastdds::rtps::DiscoverySettings::ParticipantFilteringFlags>`
 .. |discoveryProtocol| replace:: :cpp:member:`discoveryProtocol <eprosima::fastdds::rtps::DiscoverySettings::discoveryProtocol>`
 .. |m_DiscoveryServers| replace:: :cpp:member:`m_DiscoveryServers <eprosima::fastdds::rtps::DiscoverySettings::m_DiscoveryServers>`
 .. |discoveryServer_client_syncperiod| replace:: :cpp:member:`discoveryServer_client_syncperiod <eprosima::fastdds::rtps::DiscoverySettings::discoveryServer_client_syncperiod>`

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -855,7 +855,7 @@
 
 .. |DiscoverySettings-api| replace:: :cpp:class:`DiscoverySettings <eprosima::fastdds::rtps::DiscoverySettings>`
 .. |leaseDuration_announcementperiod| replace:: :cpp:member:`leaseDuration_announcementperiod <eprosima::fastdds::rtps::DiscoverySettings::leaseDuration_announcementperiod>`
-.. |DiscoveryProtocol_t| replace:: :cpp:member:`DiscoveryProtocol_t <eprosima::fastdds::rtps::DiscoverySettings::DiscoveryProtocol_t>`
+.. |DiscoveryProtocol| replace:: :cpp:member:`DiscoveryProtocol <eprosima::fastdds::rtps::DiscoverySettings::DiscoveryProtocol>`
 .. |ParticipantFilteringFlags_t| replace:: :cpp:member:`ParticipantFilteringFlags_t <eprosima::fastdds::rtps::DiscoverySettings::ParticipantFilteringFlags_t>`
 .. |discoveryProtocol| replace:: :cpp:member:`discoveryProtocol <eprosima::fastdds::rtps::DiscoverySettings::discoveryProtocol>`
 .. |m_DiscoveryServers| replace:: :cpp:member:`m_DiscoveryServers <eprosima::fastdds::rtps::DiscoverySettings::m_DiscoveryServers>`

--- a/docs/fastdds/api_reference/rtps/Endpoint.rst
+++ b/docs/fastdds/api_reference/rtps/Endpoint.rst
@@ -3,6 +3,6 @@
 Endpoint
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::Endpoint
+.. doxygenclass:: eprosima::fastdds::rtps::Endpoint
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/RTPSDomain.rst
+++ b/docs/fastdds/api_reference/rtps/RTPSDomain.rst
@@ -3,6 +3,6 @@
 RTPSDomain
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::RTPSDomain
+.. doxygenclass:: eprosima::fastdds::rtps::RTPSDomain
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/BuiltinAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/BuiltinAttributes.rst
@@ -3,6 +3,6 @@
 BuiltinAttributes
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::BuiltinAttributes
+.. doxygenclass:: eprosima::fastdds::rtps::BuiltinAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/DiscoveryProtocol.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/DiscoveryProtocol.rst
@@ -3,5 +3,5 @@
 DiscoveryProtocol
 ------------------------
 
-.. doxygenenum:: eprosima::fastrtps::rtps::DiscoveryProtocol
+.. doxygenenum:: eprosima::fastdds::rtps::DiscoveryProtocol
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/attributes/DiscoverySettings.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/DiscoverySettings.rst
@@ -3,6 +3,6 @@
 DiscoverySettings
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::DiscoverySettings
+.. doxygenclass:: eprosima::fastdds::rtps::DiscoverySettings
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/EndpointAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/EndpointAttributes.rst
@@ -3,6 +3,6 @@
 EndpointAttributes
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::EndpointAttributes
+.. doxygenclass:: eprosima::fastdds::rtps::EndpointAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/HistoryAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/HistoryAttributes.rst
@@ -3,6 +3,6 @@
 HistoryAttributes
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::HistoryAttributes
+.. doxygenclass:: eprosima::fastdds::rtps::HistoryAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/InitialAnnouncementConfig.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/InitialAnnouncementConfig.rst
@@ -3,6 +3,6 @@
 InitialAnnouncementConfig
 ------------------------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::InitialAnnouncementConfig
+.. doxygenstruct:: eprosima::fastdds::rtps::InitialAnnouncementConfig
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/ParticipantFilteringFlags.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/ParticipantFilteringFlags.rst
@@ -3,5 +3,5 @@
 ParticipantFilteringFlags
 -----------------------------
 
-.. doxygenenum:: eprosima::fastrtps::rtps::ParticipantFilteringFlags
+.. doxygenenum:: eprosima::fastdds::rtps::ParticipantFilteringFlags
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/attributes/PropertyPolicy.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/PropertyPolicy.rst
@@ -3,6 +3,6 @@
 PropertyPolicy
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::PropertyPolicy
+.. doxygenclass:: eprosima::fastdds::rtps::PropertyPolicy
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/PropertyPolicyHelper.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/PropertyPolicyHelper.rst
@@ -3,6 +3,6 @@
 PropertyPolicyHelper
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::PropertyPolicyHelper
+.. doxygenclass:: eprosima::fastdds::rtps::PropertyPolicyHelper
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/RTPSParticipantAllocationAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/RTPSParticipantAllocationAttributes.rst
@@ -3,6 +3,6 @@
 RTPSParticipantAllocationAttributes
 ------------------------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes
+.. doxygenstruct:: eprosima::fastdds::rtps::RTPSParticipantAllocationAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/RTPSParticipantAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/RTPSParticipantAttributes.rst
@@ -3,6 +3,6 @@
 RTPSParticipantAttributes
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::RTPSParticipantAttributes
+.. doxygenclass:: eprosima::fastdds::rtps::RTPSParticipantAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/RTPSWriterPublishMode.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/RTPSWriterPublishMode.rst
@@ -3,5 +3,5 @@
 RTPSWriterPublishMode
 ------------------------
 
-.. doxygenenum:: eprosima::fastrtps::rtps::RTPSWriterPublishMode
+.. doxygenenum:: eprosima::fastdds::rtps::RTPSWriterPublishMode
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/attributes/ReaderAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/ReaderAttributes.rst
@@ -3,6 +3,6 @@
 ReaderAttributes
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::ReaderAttributes
+.. doxygenclass:: eprosima::fastdds::rtps::ReaderAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/ReaderTimes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/ReaderTimes.rst
@@ -3,6 +3,6 @@
 ReaderTimes
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::ReaderTimes
+.. doxygenclass:: eprosima::fastdds::rtps::ReaderTimes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/RemoteLocatorsAllocationAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/RemoteLocatorsAllocationAttributes.rst
@@ -3,6 +3,6 @@
 RemoteLocatorsAllocationAttributes
 ------------------------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::RemoteLocatorsAllocationAttributes
+.. doxygenstruct:: eprosima::fastdds::rtps::RemoteLocatorsAllocationAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/SendBuffersAllocationAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/SendBuffersAllocationAttributes.rst
@@ -3,6 +3,6 @@
 SendBuffersAllocationAttributes
 ------------------------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::SendBuffersAllocationAttributes
+.. doxygenstruct:: eprosima::fastdds::rtps::SendBuffersAllocationAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/SimpleEDPAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/SimpleEDPAttributes.rst
@@ -3,6 +3,6 @@
 SimpleEDPAttributes
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::SimpleEDPAttributes
+.. doxygenclass:: eprosima::fastdds::rtps::SimpleEDPAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/VariableLengthDataLimits.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/VariableLengthDataLimits.rst
@@ -3,6 +3,6 @@
 VariableLengthDataLimits
 ------------------------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::VariableLengthDataLimits
+.. doxygenstruct:: eprosima::fastdds::rtps::VariableLengthDataLimits
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/WriterAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/WriterAttributes.rst
@@ -3,6 +3,6 @@
 WriterAttributes
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::WriterAttributes
+.. doxygenclass:: eprosima::fastdds::rtps::WriterAttributes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/WriterTimes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/WriterTimes.rst
@@ -3,6 +3,6 @@
 WriterTimes
 ------------------------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::WriterTimes
+.. doxygenstruct:: eprosima::fastdds::rtps::WriterTimes
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/attributes/c_default_RTPSParticipantAllocationAttributes.rst
+++ b/docs/fastdds/api_reference/rtps/attributes/c_default_RTPSParticipantAllocationAttributes.rst
@@ -3,5 +3,5 @@
 c_default_RTPSParticipantAllocationAttributes
 ----------------------------------------------------
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_default_RTPSParticipantAllocationAttributes
+.. doxygenvariable:: eprosima::fastdds::rtps::c_default_RTPSParticipantAllocationAttributes
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/BinaryProperty/BinaryProperty.rst
+++ b/docs/fastdds/api_reference/rtps/common/BinaryProperty/BinaryProperty.rst
@@ -3,6 +3,6 @@
 BinaryProperty
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::BinaryProperty
+.. doxygenclass:: eprosima::fastdds::rtps::BinaryProperty
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/BinaryProperty/BinaryPropertyHelper.rst
+++ b/docs/fastdds/api_reference/rtps/common/BinaryProperty/BinaryPropertyHelper.rst
@@ -3,6 +3,6 @@
 BinaryPropertyHelper
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::BinaryPropertyHelper
+.. doxygenclass:: eprosima::fastdds::rtps::BinaryPropertyHelper
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/BinaryProperty/BinaryPropertySeq.rst
+++ b/docs/fastdds/api_reference/rtps/common/BinaryProperty/BinaryPropertySeq.rst
@@ -3,5 +3,5 @@
 BinaryPropertySeq
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::BinaryPropertySeq
+.. doxygentypedef:: eprosima::fastdds::rtps::BinaryPropertySeq
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/CDRMessage_t/CDRMessage_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/CDRMessage_t/CDRMessage_t.rst
@@ -3,6 +3,6 @@
 CDRMessage_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::CDRMessage_t
+.. doxygenstruct:: eprosima::fastdds::rtps::CDRMessage_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/CacheChange/CacheChange_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/CacheChange/CacheChange_t.rst
@@ -3,6 +3,6 @@
 CacheChange_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::CacheChange_t
+.. doxygenstruct:: eprosima::fastdds::rtps::CacheChange_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/CacheChange/ChangeKind_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/CacheChange/ChangeKind_t.rst
@@ -3,5 +3,5 @@
 ChangeKind_t
 --------------------------------
 
-.. doxygenenum:: eprosima::fastrtps::rtps::ChangeKind_t
+.. doxygenenum:: eprosima::fastdds::rtps::ChangeKind_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/EntityId_t/EntityId_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/EntityId_t/EntityId_t.rst
@@ -3,6 +3,6 @@
 EntityId_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::EntityId_t
+.. doxygenstruct:: eprosima::fastdds::rtps::EntityId_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/EntityId_t/const_values.rst
+++ b/docs/fastdds/api_reference/rtps/common/EntityId_t/const_values.rst
@@ -3,75 +3,75 @@
 Const values
 --------------------------------
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_Unknown
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_Unknown
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_SPDPReader
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_SPDPReader
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_SPDPWriter
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_SPDPWriter
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_SEDPPubWriter
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_SEDPPubWriter
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_SEDPPubReader
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_SEDPPubReader
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_SEDPSubWriter
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_SEDPSubWriter
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_SEDPSubReader
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_SEDPSubReader
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_RTPSParticipant
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_RTPSParticipant
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_WriterLiveliness
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_WriterLiveliness
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_ReaderLiveliness
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_ReaderLiveliness
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::participant_stateless_message_writer_entity_id
+.. doxygenvariable:: eprosima::fastdds::rtps::participant_stateless_message_writer_entity_id
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::participant_stateless_message_reader_entity_id
+.. doxygenvariable:: eprosima::fastdds::rtps::participant_stateless_message_reader_entity_id
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_TypeLookup_request_writer
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_TypeLookup_request_writer
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_TypeLookup_request_reader
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_TypeLookup_request_reader
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_TypeLookup_reply_writer
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_TypeLookup_reply_writer
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_TypeLookup_reply_reader
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_TypeLookup_reply_reader
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::sedp_builtin_publications_secure_writer
+.. doxygenvariable:: eprosima::fastdds::rtps::sedp_builtin_publications_secure_writer
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::sedp_builtin_publications_secure_reader
+.. doxygenvariable:: eprosima::fastdds::rtps::sedp_builtin_publications_secure_reader
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::sedp_builtin_subscriptions_secure_writer
+.. doxygenvariable:: eprosima::fastdds::rtps::sedp_builtin_subscriptions_secure_writer
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::sedp_builtin_subscriptions_secure_reader
+.. doxygenvariable:: eprosima::fastdds::rtps::sedp_builtin_subscriptions_secure_reader
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::participant_volatile_message_secure_writer_entity_id
+.. doxygenvariable:: eprosima::fastdds::rtps::participant_volatile_message_secure_writer_entity_id
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::participant_volatile_message_secure_reader_entity_id
+.. doxygenvariable:: eprosima::fastdds::rtps::participant_volatile_message_secure_reader_entity_id
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_WriterLivelinessSecure
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_WriterLivelinessSecure
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_EntityId_ReaderLivelinessSecure
+.. doxygenvariable:: eprosima::fastdds::rtps::c_EntityId_ReaderLivelinessSecure
     :project: FastDDS
 

--- a/docs/fastdds/api_reference/rtps/common/EntityId_t/operators.rst
+++ b/docs/fastdds/api_reference/rtps/common/EntityId_t/operators.rst
@@ -3,18 +3,18 @@
 EntityId_t Operators
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator==(EntityId_t &id1, const uint32_t id2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator==(EntityId_t &id1, const uint32_t id2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator==(const EntityId_t &id1, const EntityId_t &id2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator==(const EntityId_t &id1, const EntityId_t &id2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator!=(const EntityId_t &id1, const EntityId_t &id2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator!=(const EntityId_t &id1, const EntityId_t &id2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const EntityId_t &enI)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const EntityId_t &enI)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator>>(std::istream &input, EntityId_t &enP)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator>>(std::istream &input, EntityId_t &enP)
     :project: FastDDS
 

--- a/docs/fastdds/api_reference/rtps/common/FragmentNumber/FragmentNumberSet_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/FragmentNumber/FragmentNumberSet_t.rst
@@ -3,5 +3,5 @@
 FragmentNumberSet_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::FragmentNumberSet_t
+.. doxygentypedef:: eprosima::fastdds::rtps::FragmentNumberSet_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/FragmentNumber/FragmentNumber_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/FragmentNumber/FragmentNumber_t.rst
@@ -3,8 +3,8 @@
 FragmentNumber_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::FragmentNumber_t
+.. doxygentypedef:: eprosima::fastdds::rtps::FragmentNumber_t
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const FragmentNumberSet_t &fns)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const FragmentNumberSet_t &fns)
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Guid/GUID_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Guid/GUID_t.rst
@@ -3,6 +3,6 @@
 GUID_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::GUID_t
+.. doxygenstruct:: eprosima::fastdds::rtps::GUID_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Guid/c_Guid_Unknown.rst
+++ b/docs/fastdds/api_reference/rtps/common/Guid/c_Guid_Unknown.rst
@@ -3,5 +3,5 @@
 c_Guid_Unknown
 --------------------------------
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_Guid_Unknown
+.. doxygenvariable:: eprosima::fastdds::rtps::c_Guid_Unknown
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Guid/operators.rst
+++ b/docs/fastdds/api_reference/rtps/common/Guid/operators.rst
@@ -3,18 +3,18 @@
 GUID_t Operators
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator==(const GUID_t &g1, const GUID_t &g2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator==(const GUID_t &g1, const GUID_t &g2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator!=(const GUID_t &g1, const GUID_t &g2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator!=(const GUID_t &g1, const GUID_t &g2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<(const GUID_t &g1, const GUID_t &g2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<(const GUID_t &g1, const GUID_t &g2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const GUID_t &guid)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const GUID_t &guid)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator>>(std::istream &input, GUID_t &guid)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator>>(std::istream &input, GUID_t &guid)
     :project: FastDDS
 

--- a/docs/fastdds/api_reference/rtps/common/GuidPrefix_t/GuidPrefix_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/GuidPrefix_t/GuidPrefix_t.rst
@@ -3,6 +3,6 @@
 GuidPrefix_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::GuidPrefix_t
+.. doxygenstruct:: eprosima::fastdds::rtps::GuidPrefix_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/GuidPrefix_t/c_GuidPrefix_Unknown.rst
+++ b/docs/fastdds/api_reference/rtps/common/GuidPrefix_t/c_GuidPrefix_Unknown.rst
@@ -3,5 +3,5 @@
 c_GuidPrefix_Unknown
 --------------------------------
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_GuidPrefix_Unknown
+.. doxygenvariable:: eprosima::fastdds::rtps::c_GuidPrefix_Unknown
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/GuidPrefix_t/operators.rst
+++ b/docs/fastdds/api_reference/rtps/common/GuidPrefix_t/operators.rst
@@ -3,8 +3,8 @@
 GuidPrefix_t Operators
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const GuidPrefix_t &guiP)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const GuidPrefix_t &guiP)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator>>(std::istream &input, GuidPrefix_t &guiP)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator>>(std::istream &input, GuidPrefix_t &guiP)
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/InstanceHandle/InstanceHandle_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/InstanceHandle/InstanceHandle_t.rst
@@ -3,6 +3,6 @@
 InstanceHandle_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::InstanceHandle_t
+.. doxygenstruct:: eprosima::fastdds::rtps::InstanceHandle_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/InstanceHandle/c_InstanceHandle_Unknown.rst
+++ b/docs/fastdds/api_reference/rtps/common/InstanceHandle/c_InstanceHandle_Unknown.rst
@@ -3,5 +3,5 @@
 c_InstanceHandle_Unknown
 --------------------------------
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_InstanceHandle_Unknown
+.. doxygenvariable:: eprosima::fastdds::rtps::c_InstanceHandle_Unknown
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/InstanceHandle/operators.rst
+++ b/docs/fastdds/api_reference/rtps/common/InstanceHandle/operators.rst
@@ -3,23 +3,23 @@
 InstanceHandle_t Operators
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator==(const InstanceHandle_t &ihandle1, const InstanceHandle_t &ihandle2) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator==(const InstanceHandle_t &ihandle1, const InstanceHandle_t &ihandle2) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator!=(const InstanceHandle_t &ihandle1, const InstanceHandle_t &ihandle2) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator!=(const InstanceHandle_t &ihandle1, const InstanceHandle_t &ihandle2) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<(const InstanceHandle_t &h1, const InstanceHandle_t &h2) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<(const InstanceHandle_t &h1, const InstanceHandle_t &h2) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const InstanceHandle_t &iHandle)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const InstanceHandle_t &iHandle)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator>>(std::istream &input, InstanceHandle_t &iHandle)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator>>(std::istream &input, InstanceHandle_t &iHandle)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::iHandle2GUID(GUID_t &guid, const InstanceHandle_t &ihandle) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::iHandle2GUID(GUID_t &guid, const InstanceHandle_t &ihandle) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::iHandle2GUID(const InstanceHandle_t &ihandle) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::iHandle2GUID(const InstanceHandle_t &ihandle) noexcept
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Locator/IsAddressDefined.rst
+++ b/docs/fastdds/api_reference/rtps/common/Locator/IsAddressDefined.rst
@@ -3,5 +3,5 @@
 IsAddressDefined
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::IsAddressDefined
+.. doxygenfunction:: eprosima::fastdds::rtps::IsAddressDefined
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Locator/IsLocatorValid.rst
+++ b/docs/fastdds/api_reference/rtps/common/Locator/IsLocatorValid.rst
@@ -3,5 +3,5 @@
 IsLocatorValid
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::IsLocatorValid
+.. doxygenfunction:: eprosima::fastdds::rtps::IsLocatorValid
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Locator/Locator_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Locator/Locator_t.rst
@@ -3,6 +3,6 @@
 Locator_t
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::Locator_t
+.. doxygenclass:: eprosima::fastdds::rtps::Locator_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Locator/operators.rst
+++ b/docs/fastdds/api_reference/rtps/common/Locator/operators.rst
@@ -3,19 +3,19 @@
 Locator Operators
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<(const Locator_t &loc1, const Locator_t &loc2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<(const Locator_t &loc1, const Locator_t &loc2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator==(const Locator_t &loc1, const Locator_t &loc2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator==(const Locator_t &loc1, const Locator_t &loc2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator!=(const Locator_t &loc1, const Locator_t &loc2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator!=(const Locator_t &loc1, const Locator_t &loc2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const Locator_t &loc)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const Locator_t &loc)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator>>(std::istream &input, Locator_t &loc)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator>>(std::istream &input, Locator_t &loc)
     :project: FastDDS
 
 .. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const LocatorList &locList)
@@ -24,5 +24,5 @@ Locator Operators
 .. doxygenfunction:: eprosima::fastdds::rtps::operator>>(std::istream &input, LocatorList &locList)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator==(const ResourceLimitedVector<Locator_t> &lhs, const ResourceLimitedVector<Locator_t> &rhs)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator==(const ResourceLimitedVector<Locator_t> &lhs, const ResourceLimitedVector<Locator_t> &rhs)
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/LocatorSelector/LocatorSelector.rst
+++ b/docs/fastdds/api_reference/rtps/common/LocatorSelector/LocatorSelector.rst
@@ -3,6 +3,6 @@
 LocatorSelector
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::LocatorSelector
+.. doxygenclass:: eprosima::fastdds::rtps::LocatorSelector
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/LocatorSelectorEntry/LocatorSelectorEntry.rst
+++ b/docs/fastdds/api_reference/rtps/common/LocatorSelectorEntry/LocatorSelectorEntry.rst
@@ -3,6 +3,6 @@
 LocatorSelectorEntry
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::LocatorSelectorEntry
+.. doxygenstruct:: eprosima::fastdds::rtps::LocatorSelectorEntry
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/MatchingInfo/MatchingInfo.rst
+++ b/docs/fastdds/api_reference/rtps/common/MatchingInfo/MatchingInfo.rst
@@ -3,6 +3,6 @@
 MatchingInfo
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::MatchingInfo
+.. doxygenclass:: eprosima::fastdds::rtps::MatchingInfo
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/MatchingInfo/MatchingStatus.rst
+++ b/docs/fastdds/api_reference/rtps/common/MatchingInfo/MatchingStatus.rst
@@ -3,5 +3,5 @@
 MatchingStatus
 --------------------------------
 
-.. doxygenenum:: eprosima::fastrtps::rtps::MatchingStatus
+.. doxygenenum:: eprosima::fastdds::rtps::MatchingStatus
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/PortParameters/PortParameters.rst
+++ b/docs/fastdds/api_reference/rtps/common/PortParameters/PortParameters.rst
@@ -3,6 +3,6 @@
 PortParameters
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::PortParameters
+.. doxygenclass:: eprosima::fastdds::rtps::PortParameters
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Property/Property.rst
+++ b/docs/fastdds/api_reference/rtps/common/Property/Property.rst
@@ -3,6 +3,6 @@
 Property
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::Property
+.. doxygenclass:: eprosima::fastdds::rtps::Property
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Property/PropertyHelper.rst
+++ b/docs/fastdds/api_reference/rtps/common/Property/PropertyHelper.rst
@@ -3,6 +3,6 @@
 PropertyHelper
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::PropertyHelper
+.. doxygenclass:: eprosima::fastdds::rtps::PropertyHelper
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Property/PropertySeq.rst
+++ b/docs/fastdds/api_reference/rtps/common/Property/PropertySeq.rst
@@ -3,5 +3,5 @@
 PropertySeq
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::PropertySeq
+.. doxygentypedef:: eprosima::fastdds::rtps::PropertySeq
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/RemoteLocators/RemoteLocatorList.rst
+++ b/docs/fastdds/api_reference/rtps/common/RemoteLocators/RemoteLocatorList.rst
@@ -3,6 +3,6 @@
 RemoteLocatorList
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::RemoteLocatorList
+.. doxygenstruct:: eprosima::fastdds::rtps::RemoteLocatorList
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/RemoteLocators/operators.rst
+++ b/docs/fastdds/api_reference/rtps/common/RemoteLocators/operators.rst
@@ -3,5 +3,5 @@
 RemoteLocators Operators
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const RemoteLocatorList &remote_locators)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const RemoteLocatorList &remote_locators)
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/SampleIdentity/SampleIdentity.rst
+++ b/docs/fastdds/api_reference/rtps/common/SampleIdentity/SampleIdentity.rst
@@ -3,6 +3,6 @@
 SampleIdentity
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::SampleIdentity
+.. doxygenclass:: eprosima::fastdds::rtps::SampleIdentity
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/SequenceNumber/SequenceNumberDiff.rst
+++ b/docs/fastdds/api_reference/rtps/common/SequenceNumber/SequenceNumberDiff.rst
@@ -3,6 +3,6 @@
 SequenceNumberDiff
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::SequenceNumberDiff
+.. doxygenstruct:: eprosima::fastdds::rtps::SequenceNumberDiff
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/SequenceNumber/SequenceNumberHash.rst
+++ b/docs/fastdds/api_reference/rtps/common/SequenceNumber/SequenceNumberHash.rst
@@ -3,6 +3,6 @@
 SequenceNumberHash
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::SequenceNumberHash
+.. doxygenstruct:: eprosima::fastdds::rtps::SequenceNumberHash
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/SequenceNumber/SequenceNumberSet_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/SequenceNumber/SequenceNumberSet_t.rst
@@ -3,5 +3,5 @@
 SequenceNumberSet_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::SequenceNumberSet_t
+.. doxygentypedef:: eprosima::fastdds::rtps::SequenceNumberSet_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/SequenceNumber/SequenceNumber_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/SequenceNumber/SequenceNumber_t.rst
@@ -3,6 +3,6 @@
 SequenceNumber_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::SequenceNumber_t
+.. doxygenstruct:: eprosima::fastdds::rtps::SequenceNumber_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/SequenceNumber/c_SequenceNumber_Unknown.rst
+++ b/docs/fastdds/api_reference/rtps/common/SequenceNumber/c_SequenceNumber_Unknown.rst
@@ -3,5 +3,5 @@
 c_SequenceNumber_Unknown
 --------------------------------
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_SequenceNumber_Unknown
+.. doxygenvariable:: eprosima::fastdds::rtps::c_SequenceNumber_Unknown
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/SequenceNumber/operators.rst
+++ b/docs/fastdds/api_reference/rtps/common/SequenceNumber/operators.rst
@@ -3,39 +3,39 @@
 SequenceNumber_t Operators
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator==(const SequenceNumber_t &sn1, const SequenceNumber_t &sn2) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator==(const SequenceNumber_t &sn1, const SequenceNumber_t &sn2) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator!=(const SequenceNumber_t &sn1, const SequenceNumber_t &sn2) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator!=(const SequenceNumber_t &sn1, const SequenceNumber_t &sn2) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator>(const SequenceNumber_t &seq1, const SequenceNumber_t &seq2) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator>(const SequenceNumber_t &seq1, const SequenceNumber_t &seq2) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<(const SequenceNumber_t &seq1, const SequenceNumber_t &seq2) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<(const SequenceNumber_t &seq1, const SequenceNumber_t &seq2) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator>=(const SequenceNumber_t &seq1, const SequenceNumber_t &seq2) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator>=(const SequenceNumber_t &seq1, const SequenceNumber_t &seq2) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<=(const SequenceNumber_t &seq1, const SequenceNumber_t &seq2) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<=(const SequenceNumber_t &seq1, const SequenceNumber_t &seq2) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator-(const SequenceNumber_t &seq, const uint32_t inc) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator-(const SequenceNumber_t &seq, const uint32_t inc) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator+(const SequenceNumber_t &seq, const uint32_t inc) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator+(const SequenceNumber_t &seq, const uint32_t inc) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator-(const SequenceNumber_t &minuend, const SequenceNumber_t &subtrahend) noexcept
+.. doxygenfunction:: eprosima::fastdds::rtps::operator-(const SequenceNumber_t &minuend, const SequenceNumber_t &subtrahend) noexcept
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const SequenceNumber_t &seqNum)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const SequenceNumber_t &seqNum)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const std::vector<SequenceNumber_t> &seqNumSet)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const std::vector<SequenceNumber_t> &seqNumSet)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const SequenceNumberSet_t &sns)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const SequenceNumberSet_t &sns)
     :project: FastDDS
 

--- a/docs/fastdds/api_reference/rtps/common/SequenceNumber/sort_seqNum.rst
+++ b/docs/fastdds/api_reference/rtps/common/SequenceNumber/sort_seqNum.rst
@@ -3,5 +3,5 @@
 sort_seqNum
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::sort_seqNum
+.. doxygenfunction:: eprosima::fastdds::rtps::sort_seqNum
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/SerializedPayload/SerializedPayload_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/SerializedPayload/SerializedPayload_t.rst
@@ -3,6 +3,6 @@
 SerializedPayload_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::SerializedPayload_t
+.. doxygenstruct:: eprosima::fastdds::rtps::SerializedPayload_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Time_t/Duration_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Time_t/Duration_t.rst
@@ -1,7 +1,7 @@
 .. rst-class:: api-ref
 
-eprosima::fastrtps::Duration_t
+eprosima::fastdds::Duration_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::Duration_t
+.. doxygentypedef:: eprosima::fastdds::Duration_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Time_t/Time_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Time_t/Time_t.rst
@@ -3,6 +3,6 @@
 Time_t
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::Time_t
+.. doxygenclass:: eprosima::fastdds::rtps::Time_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Time_t/const_values.rst
+++ b/docs/fastdds/api_reference/rtps/common/Time_t/const_values.rst
@@ -3,12 +3,12 @@
 Const values
 --------------------------------
 
-.. doxygenvariable:: eprosima::fastrtps::c_TimeInfinite
+.. doxygenvariable:: eprosima::fastdds::c_TimeInfinite
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::c_TimeZero
+.. doxygenvariable:: eprosima::fastdds::c_TimeZero
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::c_TimeInvalid
+.. doxygenvariable:: eprosima::fastdds::c_TimeInvalid
     :project: FastDDS
 

--- a/docs/fastdds/api_reference/rtps/common/Time_t/fastrtps_Time_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Time_t/fastrtps_Time_t.rst
@@ -1,8 +1,8 @@
 .. rst-class:: api-ref
 
-eprosima::fastrtps::Time_t
+eprosima::fastdds::Time_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::Time_t
+.. doxygenstruct:: eprosima::fastdds::Time_t
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Time_t/operators.rst
+++ b/docs/fastdds/api_reference/rtps/common/Time_t/operators.rst
@@ -3,56 +3,56 @@
 Time_t Operators
 --------------------------------
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator==(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator==(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator!=(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator!=(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator>(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator>(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<=(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<=(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator>=(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator>=(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const Time_t &t)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const Time_t &t)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator+(const Time_t &ta, const Time_t &tb)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator+(const Time_t &ta, const Time_t &tb)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator-(const Time_t &ta, const Time_t &tb)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator-(const Time_t &ta, const Time_t &tb)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::operator==(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::operator==(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::operator!=(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::operator!=(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::operator<(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::operator<(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::operator>(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::operator>(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::operator<=(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::operator<=(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::operator>=(const Time_t &t1, const Time_t &t2)
+.. doxygenfunction:: eprosima::fastdds::operator>=(const Time_t &t1, const Time_t &t2)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::operator<<(std::ostream &output, const Time_t &t)
+.. doxygenfunction:: eprosima::fastdds::operator<<(std::ostream &output, const Time_t &t)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::operator+(const Time_t &ta, const Time_t &tb)
+.. doxygenfunction:: eprosima::fastdds::operator+(const Time_t &ta, const Time_t &tb)
     :project: FastDDS
 
-.. doxygenfunction:: eprosima::fastrtps::operator-(const Time_t &ta, const Time_t &tb)
+.. doxygenfunction:: eprosima::fastdds::operator-(const Time_t &ta, const Time_t &tb)
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Token/AuthenticatedPeerCredentialToken.rst
+++ b/docs/fastdds/api_reference/rtps/common/Token/AuthenticatedPeerCredentialToken.rst
@@ -3,5 +3,5 @@
 AuthenticatedPeerCredentialToken
 -----------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::AuthenticatedPeerCredentialToken
+.. doxygentypedef:: eprosima::fastdds::rtps::AuthenticatedPeerCredentialToken
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Token/DataHolder.rst
+++ b/docs/fastdds/api_reference/rtps/common/Token/DataHolder.rst
@@ -3,6 +3,6 @@
 DataHolder
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::DataHolder
+.. doxygenclass:: eprosima::fastdds::rtps::DataHolder
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Token/DataHolderHelper.rst
+++ b/docs/fastdds/api_reference/rtps/common/Token/DataHolderHelper.rst
@@ -3,6 +3,6 @@
 DataHolderHelper
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::DataHolderHelper
+.. doxygenclass:: eprosima::fastdds::rtps::DataHolderHelper
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/common/Token/DataHolderSeq.rst
+++ b/docs/fastdds/api_reference/rtps/common/Token/DataHolderSeq.rst
@@ -3,5 +3,5 @@
 DataHolderSeq
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::DataHolderSeq
+.. doxygentypedef:: eprosima::fastdds::rtps::DataHolderSeq
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Token/IdentityStatusToken.rst
+++ b/docs/fastdds/api_reference/rtps/common/Token/IdentityStatusToken.rst
@@ -3,5 +3,5 @@
 IdentityStatusToken
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::IdentityStatusToken
+.. doxygentypedef:: eprosima::fastdds::rtps::IdentityStatusToken
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Token/IdentityToken.rst
+++ b/docs/fastdds/api_reference/rtps/common/Token/IdentityToken.rst
@@ -3,5 +3,5 @@
 IdentityToken
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::IdentityToken
+.. doxygentypedef:: eprosima::fastdds::rtps::IdentityToken
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Token/PermissionsCredentialToken.rst
+++ b/docs/fastdds/api_reference/rtps/common/Token/PermissionsCredentialToken.rst
@@ -3,5 +3,5 @@
 PermissionsCredentialToken
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::PermissionsCredentialToken
+.. doxygentypedef:: eprosima::fastdds::rtps::PermissionsCredentialToken
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Token/PermissionsToken.rst
+++ b/docs/fastdds/api_reference/rtps/common/Token/PermissionsToken.rst
@@ -3,5 +3,5 @@
 PermissionsToken
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::PermissionsToken
+.. doxygentypedef:: eprosima::fastdds::rtps::PermissionsToken
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Token/Token.rst
+++ b/docs/fastdds/api_reference/rtps/common/Token/Token.rst
@@ -3,5 +3,5 @@
 Token
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::Token
+.. doxygentypedef:: eprosima::fastdds::rtps::Token
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/BuiltinEndpointSet_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/BuiltinEndpointSet_t.rst
@@ -3,5 +3,5 @@
 BuiltinEndpointSet_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::BuiltinEndpointSet_t
+.. doxygentypedef:: eprosima::fastdds::rtps::BuiltinEndpointSet_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/Count_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/Count_t.rst
@@ -3,5 +3,5 @@
 Count_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::Count_t
+.. doxygentypedef:: eprosima::fastdds::rtps::Count_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/DurabilityKind_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/DurabilityKind_t.rst
@@ -3,5 +3,5 @@
 DurabilityKind_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::DurabilityKind_t
+.. doxygentypedef:: eprosima::fastdds::rtps::DurabilityKind_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/Endianness_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/Endianness_t.rst
@@ -3,5 +3,5 @@
 Endianness_t
 --------------------------------
 
-.. doxygenenum:: eprosima::fastrtps::rtps::Endianness_t
+.. doxygenenum:: eprosima::fastdds::rtps::Endianness_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/EndpointKind_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/EndpointKind_t.rst
@@ -3,5 +3,5 @@
 EndpointKind_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::EndpointKind_t
+.. doxygentypedef:: eprosima::fastdds::rtps::EndpointKind_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/ProtocolVersion_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/ProtocolVersion_t.rst
@@ -3,9 +3,9 @@
 ProtocolVersion_t
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::ProtocolVersion_t
+.. doxygenstruct:: eprosima::fastdds::rtps::ProtocolVersion_t
     :project: FastDDS
     :members:
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator<<(std::ostream &output, const ProtocolVersion_t &pv)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator<<(std::ostream &output, const ProtocolVersion_t &pv)
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/ReliabilityKind_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/ReliabilityKind_t.rst
@@ -3,5 +3,5 @@
 ReliabilityKind_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::ReliabilityKind_t
+.. doxygentypedef:: eprosima::fastdds::rtps::ReliabilityKind_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/SubmessageFlag.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/SubmessageFlag.rst
@@ -3,5 +3,5 @@
 SubmessageFlag
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::SubmessageFlag
+.. doxygentypedef:: eprosima::fastdds::rtps::SubmessageFlag
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/TopicKind_t.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/TopicKind_t.rst
@@ -3,5 +3,5 @@
 TopicKind_t
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::TopicKind_t
+.. doxygentypedef:: eprosima::fastdds::rtps::TopicKind_t
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/Types/const_values.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/const_values.rst
@@ -3,19 +3,19 @@
 Const values
 --------------------------------
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_ProtocolVersion_2_0
+.. doxygenvariable:: eprosima::fastdds::rtps::c_ProtocolVersion_2_0
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_ProtocolVersion_2_1
+.. doxygenvariable:: eprosima::fastdds::rtps::c_ProtocolVersion_2_1
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_ProtocolVersion_2_2
+.. doxygenvariable:: eprosima::fastdds::rtps::c_ProtocolVersion_2_2
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_ProtocolVersion_2_3
+.. doxygenvariable:: eprosima::fastdds::rtps::c_ProtocolVersion_2_3
     :project: FastDDS
 
-.. doxygenvariable:: eprosima::fastrtps::rtps::c_ProtocolVersion
+.. doxygenvariable:: eprosima::fastdds::rtps::c_ProtocolVersion
     :project: FastDDS
 
 .. doxygenvariable:: eprosima::fastdds::rtps::c_VendorId_Unknown

--- a/docs/fastdds/api_reference/rtps/common/Types/octet.rst
+++ b/docs/fastdds/api_reference/rtps/common/Types/octet.rst
@@ -3,5 +3,5 @@
 octet
 --------------------------------
 
-.. doxygentypedef:: eprosima::fastrtps::rtps::octet
+.. doxygentypedef:: eprosima::fastdds::rtps::octet
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/common/WriteParams/WriteParams.rst
+++ b/docs/fastdds/api_reference/rtps/common/WriteParams/WriteParams.rst
@@ -3,6 +3,6 @@
 WriteParams
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::WriteParams
+.. doxygenclass:: eprosima::fastdds::rtps::WriteParams
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/history/History_class.rst
+++ b/docs/fastdds/api_reference/rtps/history/History_class.rst
@@ -3,6 +3,6 @@
 History
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::History
+.. doxygenclass:: eprosima::fastdds::rtps::History
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/history/IChangePool.rst
+++ b/docs/fastdds/api_reference/rtps/history/IChangePool.rst
@@ -3,6 +3,6 @@
 IChangePool
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::IChangePool
+.. doxygenclass:: eprosima::fastdds::rtps::IChangePool
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/history/IPayloadPool.rst
+++ b/docs/fastdds/api_reference/rtps/history/IPayloadPool.rst
@@ -3,6 +3,6 @@
 IPayloadPool
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::IPayloadPool
+.. doxygenclass:: eprosima::fastdds::rtps::IPayloadPool
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/history/ReaderHistory.rst
+++ b/docs/fastdds/api_reference/rtps/history/ReaderHistory.rst
@@ -3,6 +3,6 @@
 ReaderHistory
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::ReaderHistory
+.. doxygenclass:: eprosima::fastdds::rtps::ReaderHistory
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/history/WriterHistory.rst
+++ b/docs/fastdds/api_reference/rtps/history/WriterHistory.rst
@@ -3,6 +3,6 @@
 WriterHistory
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::WriterHistory
+.. doxygenclass:: eprosima::fastdds::rtps::WriterHistory
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/participant/RTPSParticipant.rst
+++ b/docs/fastdds/api_reference/rtps/participant/RTPSParticipant.rst
@@ -3,6 +3,6 @@
 RTPSParticipant
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::RTPSParticipant
+.. doxygenclass:: eprosima::fastdds::rtps::RTPSParticipant
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/participant/RTPSParticipantListener.rst
+++ b/docs/fastdds/api_reference/rtps/participant/RTPSParticipantListener.rst
@@ -3,6 +3,6 @@
 RTPSParticipantListener
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::RTPSParticipantListener
+.. doxygenclass:: eprosima::fastdds::rtps::RTPSParticipantListener
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ParticipantAuthenticationInfo.rst
+++ b/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ParticipantAuthenticationInfo.rst
@@ -3,9 +3,9 @@
 ParticipantAuthenticationInfo
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::ParticipantAuthenticationInfo
+.. doxygenstruct:: eprosima::fastdds::rtps::ParticipantAuthenticationInfo
     :project: FastDDS
     :members:
 
-.. doxygenfunction:: eprosima::fastrtps::rtps::operator==(const ParticipantAuthenticationInfo &l, const ParticipantAuthenticationInfo &r)
+.. doxygenfunction:: eprosima::fastdds::rtps::operator==(const ParticipantAuthenticationInfo &l, const ParticipantAuthenticationInfo &r)
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ParticipantDiscoveryInfo_class.rst
+++ b/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ParticipantDiscoveryInfo_class.rst
@@ -3,6 +3,6 @@
 ParticipantDiscoveryInfo
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::ParticipantDiscoveryInfo
+.. doxygenstruct:: eprosima::fastdds::rtps::ParticipantDiscoveryInfo
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ParticipantProxyData.rst
+++ b/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ParticipantProxyData.rst
@@ -3,7 +3,7 @@
 ParticipantProxyData
 --------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::ParticipantProxyData
+.. doxygenclass:: eprosima::fastdds::rtps::ParticipantProxyData
     :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ReaderDiscoveryInfo.rst
+++ b/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ReaderDiscoveryInfo.rst
@@ -3,6 +3,6 @@
 ReaderDiscoveryInfo
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::ReaderDiscoveryInfo
+.. doxygenstruct:: eprosima::fastdds::rtps::ReaderDiscoveryInfo
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ReaderProxyData.rst
+++ b/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/ReaderProxyData.rst
@@ -3,6 +3,6 @@
 ReaderProxyData
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::ReaderProxyData
+.. doxygenclass:: eprosima::fastdds::rtps::ReaderProxyData
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/WriterDiscoveryInfo.rst
+++ b/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/WriterDiscoveryInfo.rst
@@ -3,6 +3,6 @@
 WriterDiscoveryInfo
 --------------------------------
 
-.. doxygenstruct:: eprosima::fastrtps::rtps::WriterDiscoveryInfo
+.. doxygenstruct:: eprosima::fastdds::rtps::WriterDiscoveryInfo
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/WriterProxyData.rst
+++ b/docs/fastdds/api_reference/rtps/participant/participantdiscoveryinfo/WriterProxyData.rst
@@ -3,6 +3,6 @@
 WriterProxyData
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::WriterProxyData
+.. doxygenclass:: eprosima::fastdds::rtps::WriterProxyData
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/reader/RTPSReader.rst
+++ b/docs/fastdds/api_reference/rtps/reader/RTPSReader.rst
@@ -3,6 +3,6 @@
 RTPSReader
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::RTPSReader
+.. doxygenclass:: eprosima::fastdds::rtps::RTPSReader
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/reader/ReaderListener.rst
+++ b/docs/fastdds/api_reference/rtps/reader/ReaderListener.rst
@@ -3,6 +3,6 @@
 ReaderListener
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::ReaderListener
+.. doxygenclass:: eprosima::fastdds::rtps::ReaderListener
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/resources/MemoryManagementPolicy.rst
+++ b/docs/fastdds/api_reference/rtps/resources/MemoryManagementPolicy.rst
@@ -3,5 +3,5 @@
 MemoryManagementPolicy
 ------------------------
 
-.. doxygenenum:: eprosima::fastrtps::rtps::MemoryManagementPolicy
+.. doxygenenum:: eprosima::fastdds::rtps::MemoryManagementPolicy
     :project: FastDDS

--- a/docs/fastdds/api_reference/rtps/writer/RTPSWriter.rst
+++ b/docs/fastdds/api_reference/rtps/writer/RTPSWriter.rst
@@ -3,6 +3,6 @@
 RTPSWriter
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::RTPSWriter
+.. doxygenclass:: eprosima::fastdds::rtps::RTPSWriter
     :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/rtps/writer/WriterListener.rst
+++ b/docs/fastdds/api_reference/rtps/writer/WriterListener.rst
@@ -3,6 +3,6 @@
 WriterListener
 --------------------------------
 
-.. doxygenclass:: eprosima::fastrtps::rtps::WriterListener
+.. doxygenclass:: eprosima::fastdds::rtps::WriterListener
     :project: FastDDS
     :members:

--- a/docs/fastdds/discovery/general_disc_settings.rst
+++ b/docs/fastdds/discovery/general_disc_settings.rst
@@ -48,8 +48,6 @@ The possible values are:
 | Simple              | |SIMPLE|            | Simple discovery protocol as specified in the                            |
 |                     |                     | `RTPS standard <https://www.omg.org/spec/DDSI-RTPS/2.2/PDF>`_.           |
 +---------------------+---------------------+--------------------------------------------------------------------------+
-| Static              | |STATIC|            | SPDP with manual EDP specified in XML files.                             |
-+---------------------+---------------------+--------------------------------------------------------------------------+
 | Discovery Server    | |SERVER|            | The DomainParticipant acts as a hub for discovery traffic, receiving     |
 |                     |                     | |br| and distributing discovery information.                             |
 |                     +---------------------+--------------------------------------------------------------------------+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR migrate fastrtps namespace to fastdds. It also rename one of the member of DiscoveryProtocol from `NONE` to `MANUAL`.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
