### PR TITLE
[21184]  Adjust type in get_dynamic_type_builder_from_xml_by_name to return DynamicTypeBuilder

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -1879,11 +1879,11 @@ void dds_topic_examples()
         DomainParticipantFactory::get_instance()->load_XML_profiles_file("example_type.xml");
 
         // Retrieve the an instance of the desired type
-        DynamicType::_ref_type dyn_type;
-        DomainParticipantFactory::get_instance()->get_dynamic_type_builder_from_xml_by_name("DynamicType", dyn_type);
+        DynamicTypeBuilder::_ref_type dyn_type_builder;
+        DomainParticipantFactory::get_instance()->get_dynamic_type_builder_from_xml_by_name("DynamicType", dyn_type_builder);
 
         // Register dynamic type
-        TypeSupport dyn_type_support(new DynamicPubSubType(dyn_type));
+        TypeSupport dyn_type_support(new DynamicPubSubType(dyn_type_builder->build()));
         dyn_type_support.register_type(participant, nullptr);
 
         // Create a Topic with the registered type.
@@ -5667,7 +5667,7 @@ void xml_profiles_examples()
                 DomainParticipantFactory::get_instance()->load_XML_profiles_file("my_profiles.xml"))
         {
             // Retrieve instance of the desired type
-            DynamicType::_ref_type my_struct_type;
+            DynamicTypeBuilder::_ref_type my_struct_type;
             if (RETCODE_OK !=
                     DomainParticipantFactory::get_instance()->get_dynamic_type_builder_from_xml_by_name(
                         "MyStruct", my_struct_type))
@@ -5677,7 +5677,7 @@ void xml_profiles_examples()
             }
 
             // Register MyStruct type
-            TypeSupport my_struct_type_support(new DynamicPubSubType(my_struct_type));
+            TypeSupport my_struct_type_support(new DynamicPubSubType(my_struct_type->build()));
             my_struct_type_support.register_type(participant, nullptr);
         }
         else


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adjust the type of the method get_dynamic_type_builder_from_xml_by_name() to get DynamicTypeBuilder instead of DynamicType after the refactor of the corresponding implementation PR:
*  https://github.com/eProsima/Fast-DDS/pull/4970 
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- N/A Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
