### PR TITLE
[21209] Add v2.14.2 release notes

### DIFF
--- a/docs/notes/notes.rst
+++ b/docs/notes/notes.rst
@@ -5,7 +5,7 @@
 Information about the release lifecycle can be found
 `here <https://github.com/eProsima/Fast-DDS/blob/master/RELEASE_SUPPORT.md>`_.
 
-.. include:: previous_versions/v2.14.1.rst
+.. include:: previous_versions/v2.14.2.rst
 
 .. seealso::
 

--- a/docs/notes/previous_versions/supported_versions.rst
+++ b/docs/notes/previous_versions/supported_versions.rst
@@ -4,6 +4,7 @@ Supported versions
 Version 2.14
 ------------
 
+.. include:: v2.14.2.rst
 .. include:: v2.14.1.rst
 .. include:: v2.14.0.rst
 

--- a/docs/notes/previous_versions/v2.14.0.rst
+++ b/docs/notes/previous_versions/v2.14.0.rst
@@ -1,5 +1,5 @@
-`Version 2.14.0 (latest) <https://fast-dds.docs.eprosima.com/en/v2.14.0/index.html>`_
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Version 2.14.0 <https://fast-dds.docs.eprosima.com/en/v2.14.0/index.html>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. important::
 

--- a/docs/notes/previous_versions/v2.14.1.rst
+++ b/docs/notes/previous_versions/v2.14.1.rst
@@ -1,5 +1,5 @@
-`Version 2.14.1 (latest) <https://fast-dds.docs.eprosima.com/en/v2.14.1/index.html>`_
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Version 2.14.1 <https://fast-dds.docs.eprosima.com/en/v2.14.1/index.html>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. important::
 

--- a/docs/notes/previous_versions/v2.14.2.rst
+++ b/docs/notes/previous_versions/v2.14.2.rst
@@ -15,8 +15,8 @@ This release includes the following **features** in an ABI compatible manner:
 This release includes the following **improvements**:
 
 #. Repository & CI improvements.
-#. Do not require `PYTHON_VERSION` to be defined. in .bat files.
-#. Use `%*` instead of loop in `.bat` scripts.
+#. Do not require ``PYTHON_VERSION`` to be defined. in .bat files.
+#. Use ``%*`` instead of loop in ``.bat`` scripts.
 #. Use absolute paths when loading XML files.
 #. Bump Fast CDR submodule to version 2.2.2.
 
@@ -29,8 +29,8 @@ This release includes the following **fixes**:
 #. Bugfix: correct :ref:`liveliness<livelinessqospolicy>` state in a multiple reader - one writer scenario.
 #. Only apply :ref:`content filter<dds_layer_topic_contentFilteredTopic>` to ALIVE changes.
 #. Properly delete builtin statistics writers upon :func:`delete_contained_entities`.
-#. Fix doxygen warning about undocumented `@param` in deleted functions.
-#. Correctly initialize `MatchingFailureMask` constants to be used with the `std::bitset` API.
+#. Fix doxygen warning about undocumented ``@param`` in deleted functions.
+#. Correctly initialize ``MatchingFailureMask`` constants to be used with the ``std::bitset`` API.
 #. Fix :ref:`Discovery Server<discovery_server>` not connecting due to ports logic.
 
 .. note::

--- a/docs/notes/previous_versions/v2.14.2.rst
+++ b/docs/notes/previous_versions/v2.14.2.rst
@@ -1,0 +1,39 @@
+`Version 2.14.2 (latest) <https://fast-dds.docs.eprosima.com/en/v2.14.2/index.html>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. important::
+
+    Fast DDS v2.14 will be the last minor version of Fast DDS v2, the next major release will be Fast DDS
+    v3.0.0, stay tuned!
+
+This release includes the following **features** in an ABI compatible manner:
+
+#. Set :ref:`DataSharing Qos policy<datasharingqospolicy>` in transmitted ``WriterProxyData`` and ``ReaderProxyData``.
+#. New :ref:`max_message_size<use-case-large-data-options>` property to limit the output datagrams size.
+#. Add XML configuration for :ref:`flow-controllers`.
+
+This release includes the following **improvements**:
+
+#. Repository & CI improvements.
+#. Do not require `PYTHON_VERSION` to be defined. in .bat files.
+#. Use `%*` instead of loop in `.bat` scripts.
+#. Use absolute paths when loading XML files.
+#. Bump Fast CDR submodule to version 2.2.2.
+
+This release includes the following **fixes**:
+
+#. Handle errors when setting socket buffer sizes.
+#. Do not require Fast CDR v2 in examples.
+#. Fix :ref:`transport_sharedMemory_sharedMemory` buffer recovery MacOS flaky test.
+#. Automatically unmatch remote participants on participant deletion.
+#. Bugfix: correct :ref:`liveliness<livelinessqospolicy>` state in a multiple reader - one writer scenario.
+#. Only apply :ref:`content filter<dds_layer_topic_contentFilteredTopic>` to ALIVE changes.
+#. Properly delete builtin statistics writers upon :func:`delete_contained_entities`.
+#. Fix doxygen warning about undocumented `@param` in deleted functions.
+#. Correctly initialize `MatchingFailureMask` constants to be used with the `std::bitset` API.
+#. Fix :ref:`Discovery Server<discovery_server>` not connecting due to ports logic.
+
+.. note::
+
+    When upgrading to version 2.14.2 it is **advisable** to regenerate generated source from IDL files
+    using `Fast DDS-Gen v3.3.0 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v3.3.0>`_.

--- a/docs/notes/versions.rst
+++ b/docs/notes/versions.rst
@@ -260,7 +260,7 @@ The following table shows the corresponding versions of the Fast DDS library dep
             * - Product
               - Related version
             * - `Fast CDR <https://github.com/eProsima/Fast-CDR/>`__
-              - `v2.2.1 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.1>`__
+              - `v2.2.2 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.2>`__
             * - `Foonathan Memory Vendor <https://github.com/eProsima/foonathan_memory_vendor/>`__
               - `v1.3.1 <https://github.com/eProsima/foonathan_memory_vendor/releases/tag/v1.3.1>`__
             * - `Asio <https://github.com/chriskohlhoff/asio>`__
@@ -346,7 +346,7 @@ Fast DDS as the core middleware.
             * - `Fast DDS Gen - IDL parser <https://github.com/eProsima/IDL-Parser/>`__
               - `v3.0.0 <https://github.com/eProsima/IDL-Parser/releases/tag/v3.0.0>`__
             * - `Fast DDS python <https://github.com/eProsima/Fast-DDS-python/>`__
-              - `v1.4.1 <https://github.com/eProsima/Fast-DDS-python/releases/tag/v1.4.1>`__
+              - `v1.4.2 <https://github.com/eProsima/Fast-DDS-python/releases/tag/v1.4.2>`__
             * - `Shapes Demo <https://github.com/eProsima/ShapesDemo/>`__
               - `v2.14.1 <https://github.com/eProsima/ShapesDemo/releases/tag/v2.14.1>`__
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -202,6 +202,7 @@ optionparser
 OSS
 ostream
 overcomplicated
+param
 parseLogConfig
 parseXMLBitsetDynamicType
 persistency


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the v2.14.2 release notes to Fast DDS Docs master

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_: Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
