### PR TITLE
[21137] Adapt to RTPS WriterHistory refactor

### DIFF
--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -125,7 +125,7 @@ void rtps_api_example_create_entities()
         //RTPS_API_CONF_PARTICIPANT
         RTPSParticipantAttributes participant_attr;
         participant_attr.setName("my_participant");
-        //etc.
+        // etc.
         //!--
     }
 
@@ -151,11 +151,11 @@ void rtps_api_example_create_entities()
     }
 
     //RTPS_API_WRITE_SAMPLE
-    //Request a change from the history
+    // Request a change from the history
     CacheChange_t* change = history->create_change(255, ALIVE);
-    //Write serialized data into the change
+    // Write serialized data into the change
     change->serializedPayload.length = sprintf((char*) change->serializedPayload.data, "My example string %d", 2) + 1;
-    //Insert change into the history. The Writer takes care of the rest.
+    // Insert change into the history. The Writer takes care of the rest.
     history->add_change(change);
     //!--
 }
@@ -273,12 +273,12 @@ void rtps_api_example_conf()
     //!--
 
     //RTPS_API_HISTORY_CONF_PAYLOADMAXSIZE
-    history_attr.payloadMaxSize  = 250;//Defaults to 500 bytes
+    history_attr.payloadMaxSize  = 250; // Defaults to 500 bytes
     //!--
 
     //RTPS_API_HISTORY_CONF_RESOURCES
-    history_attr.initialReservedCaches = 250; //Defaults to 500
-    history_attr.maximumReservedCaches = 500; //Defaults to 0 = Unlimited Changes
+    history_attr.initialReservedCaches = 250; // Defaults to 500
+    history_attr.maximumReservedCaches = 500; // Defaults to 0 = Unlimited Changes
     //!--
 }
 

--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -151,11 +151,8 @@ void rtps_api_example_create_entities()
     }
 
     //RTPS_API_WRITE_SAMPLE
-    //Request a change from the writer
-    CacheChange_t* change = writer->new_change([]() -> uint32_t
-                    {
-                        return 255;
-                    }, ALIVE);
+    //Request a change from the history
+    CacheChange_t* change = history->create_change(255, ALIVE);
     //Write serialized data into the change
     change->serializedPayload.length = sprintf((char*) change->serializedPayload.data, "My example string %d", 2) + 1;
     //Insert change into the history. The Writer takes care of the rest.
@@ -242,9 +239,9 @@ void rtps_api_example_create_entities_with_custom_pool()
 
     // A writer using the custom payload pool
     HistoryAttributes writer_history_attr;
-    WriterHistory* writer_history = new WriterHistory(writer_history_attr);
+    WriterHistory* writer_history = new WriterHistory(writer_history_attr, payload_pool);
     WriterAttributes writer_attr;
-    RTPSWriter* writer = RTPSDomain::createRTPSWriter(participant, writer_attr, payload_pool, writer_history);
+    RTPSWriter* writer = RTPSDomain::createRTPSWriter(participant, writer_attr, writer_history);
 
     // A reader using the same instance of the custom payload pool
     HistoryAttributes reader_history_attr;
@@ -254,10 +251,7 @@ void rtps_api_example_create_entities_with_custom_pool()
 
     // Write and Read operations work as usual, but take the Payloads from the pool.
     // Requesting a change to the Writer will provide one with an empty Payload taken from the pool
-    CacheChange_t* change = writer->new_change([]() -> uint32_t
-                    {
-                        return 255;
-                    }, ALIVE);
+    CacheChange_t* change = writer_history->create_change(255, ALIVE);
 
     // Write serialized data into the change and add it to the history
     change->serializedPayload.length = sprintf((char*) change->serializedPayload.data, "My example string %d", 2) + 1;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adapts the RTPS example code for the refactor in `WriterHistory`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#4966

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
