### PR TITLE
[21256] Fix issue with Fast DDS and Fast DDS python deduced branches

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -126,18 +126,17 @@ jobs:
           remote_repository: eProsima/Fast-DDS
           fallback_branch: ${{ inputs.fastdds-branch }}
 
-      - name: Obtain Fast DDS dependencies
-        uses: eProsima/eProsima-CI/multiplatform/get_file_from_repo@v0
+      - name: Obtain deduced Fast DDS repository content
+        uses: eProsima/eProsima-CI/external/checkout@v0
         with:
-          source_repository_branch: ${{ steps.get_fastdds_branch.outputs.deduced_branch }}
-          source_repository: eProsima/Fast-DDS
-          file_name: fastdds.repos
-          file_result: ${{ github.workspace }}/fastdds.repos
+          repository: eProsima/Fast-DDS
+          ref: ${{ steps.get_fastdds_branch.outputs.deduced_branch }}
+          path: ${{ github.workspace }}/src/fastdds
 
       - name: Fetch Fast DDS dependencies
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
         with:
-          vcs_repos_file: ${{ github.workspace }}/fastdds.repos
+          vcs_repos_file: ${{ github.workspace }}/src/fastdds/fastdds.repos
           destination_workspace: src
           skip_existing: 'true'
 
@@ -148,20 +147,12 @@ jobs:
           remote_repository: eProsima/Fast-DDS-python
           fallback_branch: ${{ inputs.fastdds-python-branch }}
 
-      - name: Obtain Fast DDS Python dependencies
-        uses: eProsima/eProsima-CI/multiplatform/get_file_from_repo@v0
+      - name: Obtain deduced Fast DDS Python repository content
+        uses: eProsima/eProsima-CI/external/checkout@v0
         with:
-          source_repository_branch: ${{ steps.get_fastdds_python_branch.outputs.deduced_branch }}
-          source_repository: eProsima/Fast-DDS-python
-          file_name: fastdds_python.repos
-          file_result: ${{ github.workspace }}/fastdds_python.repos
-
-      - name: Fetch Fast DDS Python dependencies
-        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
-        with:
-          vcs_repos_file: ${{ github.workspace }}/fastdds_python.repos
-          destination_workspace: src
-          skip_existing: 'true'
+          repository: eProsima/Fast-DDS-python
+          ref: ${{ steps.get_fastdds_python_branch.outputs.deduced_branch }}
+          path: ${{ github.workspace }}/src/fastdds_python
 
       - name: Fetch Fast DDS Docs CI dependencies
         if: ${{ inputs.run-tests == true }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
In the previous PR 
- #831 

The Fast DDS and Fast DDS python related branches were not used as expected:
Instead of using the provided branch, it was downloading the .repos file from that branch (so the base reference was used instead of the desired branch).
This hotfix PR performs a checkout before downloading the repos included in the .repos file, so the actual branch used is the desired one.
In the case of the Fast DDS Python, its dependencies are already downloaded, so there is no need to download them. It has been changed to just cloning that repo and checking out to the desired branch.

**Important**: when fixing the conflicts in the backports, please ensure:
- Change `fastdds.repos` to `fastrtps.repos`
- change `src/fastdds` to `src/fastrtps`
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- **N/A** Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
