### PR TITLE
[21256] Fix nightly job and move 2.6.x to weekly CI

### DIFF
--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -61,17 +61,3 @@ jobs:
       run-build: true
       run-tests: true
       use-ccache: false
-
-  nightly-ubuntu-ci-2_6_x:
-    uses: eProsima/Fast-DDS-docs/.github/workflows/reusable-ubuntu-ci.yml@2.6.x
-    with:
-      # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
-      # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-version: 'ubuntu-20.04'
-      label: '-nightly-ubuntu-ci-2.6.x'
-      fastdds-docs-branch: '2.6.x'
-      fastdds-branch: '2.6.x'
-      fastdds-python-branch: '1.0.x'
-      run-build: true
-      run-tests: true
-      use-ccache: false

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: 'nightly-ubuntu-ci-master'
       fastdds-docs-branch: 'master'
       fastdds-branch: 'master'
@@ -25,7 +25,7 @@ jobs:
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: '-nightly-ubuntu-ci-2.14.x'
       fastdds-docs-branch: '2.14.x'
       fastdds-branch: '2.14.x'
@@ -39,7 +39,7 @@ jobs:
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: '-nightly-ubuntu-ci-2.13.x'
       fastdds-docs-branch: '2.13.x'
       fastdds-branch: '2.13.x'
@@ -53,7 +53,7 @@ jobs:
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: '-nightly-ubuntu-ci-2.10.x'
       fastdds-docs-branch: '2.10.x'
       fastdds-branch: '2.10.x'
@@ -67,7 +67,7 @@ jobs:
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-image: 'ubuntu-20.04'
+      os-version: 'ubuntu-20.04'
       label: '-nightly-ubuntu-ci-2.6.x'
       fastdds-docs-branch: '2.6.x'
       fastdds-branch: '2.6.x'

--- a/.github/workflows/weekly-ubuntu-ci.yml
+++ b/.github/workflows/weekly-ubuntu-ci.yml
@@ -1,0 +1,21 @@
+name: Fast DDS Docs Ubuntu CI (weekly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * 1' # Run at minute 0 on Monday
+
+jobs:
+  weekly-ubuntu-ci-2_6_x:
+    uses: eProsima/Fast-DDS-docs/.github/workflows/reusable-ubuntu-ci.yml@2.6.x
+    with:
+      # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
+      # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
+      os-version: 'ubuntu-20.04'
+      label: '-weekly-ubuntu-ci-2.6.x'
+      fastdds-docs-branch: '2.6.x'
+      fastdds-branch: '2.6.x'
+      fastdds-python-branch: '1.0.x'
+      run-build: true
+      run-tests: true
+      use-ccache: false


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Nightly job was failing due to `os-image`-`os-version` name mismatched. 
This PR fixes it and moves `2.6.x` related jobs to weekly CI
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- **N/A** Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- **N/A** Check contributor checklist is correct.
- **N/A** CI passes without warnings or errors.
