### PR TITLE
[21299] Fix code block not been colored after sphinx upgrade

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,15 +82,15 @@ def select_css(html_css_dir):
     :param html_css_dir: The directory to save the CSS stylesheet.
     :return: Returns a list of CSS files to be imported.
     """
-    ret = ['_static/tabs.css']
-    common_css = '_static/css/eprosima_rtd_theme.css'
-    local_css = '_static/css/fiware_readthedocs.css'
+    ret = ''
+    common_css = 'css/eprosima_rtd_theme.css'
+    local_css = 'css/fiware_readthedocs.css'
     if download_css(html_css_dir):
         print('Applying common CSS style file: {}'.format(common_css))
-        ret.append(common_css)
+        ret = common_css
     else:
         print('Applying local CSS style file: {}'.format(local_css))
-        ret.append(local_css)
+        ret = local_css
 
     return ret
 
@@ -515,10 +515,7 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-html_context = {
-        'css_files': select_css(script_path),
-        }
-
+html_style = select_css(script_path)
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description

This is caused because `pygment.css` is not included with new Sphinx version in the html. This PR fixes this.
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
