### PR TITLE
[21137] Account for changes on RTPS writer refactor

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4275,18 +4275,18 @@ void dds_qos_examples()
         //DDS_CHANGE_RTPS_RELIABLE_WRITER_QOS
         // This example only applies to DataWriter entities
         DataWriterQos writer_qos;
-        // The RTPSReliableWriterQos is constructed with initialHeartbeatDelay = 12 ms by default
-        // Change the initialHeartbeatDelay to 20 nanoseconds
-        writer_qos.reliable_writer_qos().times.initialHeartbeatDelay = {0, 20};
-        // The RTPSReliableWriterQos is constructed with heartbeatPeriod = 3 s by default
-        // Change the heartbeatPeriod to 5 seconds
-        writer_qos.reliable_writer_qos().times.heartbeatPeriod = {5, 0};
-        // The RTPSReliableWriterQos is constructed with nackResponseDelay = 5 ms by default
-        // Change the nackResponseDelay to 10 nanoseconds
-        writer_qos.reliable_writer_qos().times.nackResponseDelay = {0, 10};
-        // The RTPSReliableWriterQos is constructed with nackSupressionDuration = 0 s by default
-        // Change the nackSupressionDuration to 20 nanoseconds
-        writer_qos.reliable_writer_qos().times.nackSupressionDuration = {0, 20};
+        // The RTPSReliableWriterQos is constructed with initial_heartbeat_delay = 12 ms by default
+        // Change the initial_heartbeat_delay to 20 nanoseconds
+        writer_qos.reliable_writer_qos().times.initial_heartbeat_delay = {0, 20};
+        // The RTPSReliableWriterQos is constructed with heartbeat_period = 3 s by default
+        // Change the heartbeat_period to 5 seconds
+        writer_qos.reliable_writer_qos().times.heartbeat_period = {5, 0};
+        // The RTPSReliableWriterQos is constructed with nack_response_delay = 5 ms by default
+        // Change the nack_response_delay to 10 nanoseconds
+        writer_qos.reliable_writer_qos().times.nack_response_delay = {0, 10};
+        // The RTPSReliableWriterQos is constructed with nack_supression_duration = 0 s by default
+        // Change the nack_supression_duration to 20 nanoseconds
+        writer_qos.reliable_writer_qos().times.nack_supression_duration = {0, 20};
         // You can also change the DisablePositiveACKsQosPolicy. For further details see DisablePositiveACKsQosPolicy section.
         writer_qos.reliable_writer_qos().disable_positive_acks.enabled = true;
         // The RTPSReliableWriterQos is constructed with disable_heartbeat_piggyback = false by default
@@ -6530,8 +6530,8 @@ void dds_usecase_examples()
     {
         //CONF_QOS_TUNING_RELIABLE_WRITER
         DataWriterQos qos;
-        qos.reliable_writer_qos().times.heartbeatPeriod.seconds = 0;
-        qos.reliable_writer_qos().times.heartbeatPeriod.nanosec = 500000000;     //500 ms
+        qos.reliable_writer_qos().times.heartbeat_period.seconds = 0;
+        qos.reliable_writer_qos().times.heartbeat_period.nanosec = 500000000;     //500 ms
         //!--
     }
 

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -1710,21 +1710,21 @@
             </qos>
 
             <times> <!-- writerTimesType -->
-                <initialHeartbeatDelay>
+                <initial_heartbeat_delay>
                     <nanosec>12</nanosec>
-                </initialHeartbeatDelay>
+                </initial_heartbeat_delay>
 
-                <heartbeatPeriod>
+                <heartbeat_period>
                     <sec>3</sec>
-                </heartbeatPeriod>
+                </heartbeat_period>
 
-                <nackResponseDelay>
+                <nack_response_delay>
                     <nanosec>5</nanosec>
-                </nackResponseDelay>
+                </nack_response_delay>
 
-                <nackSupressionDuration>
+                <nack_supression_duration>
                     <sec>0</sec>
-                </nackSupressionDuration>
+                </nack_supression_duration>
             </times>
 
             <unicastLocatorList>
@@ -3727,18 +3727,18 @@
 <!-->XML_RTPS_RELIABLE_WRITER_QOS<-->
 <data_writer profile_name="pub_profile_name">
     <times> <!-- writerTimesType -->
-        <initialHeartbeatDelay> <!-- DURATION -->
+        <initial_heartbeat_delay> <!-- DURATION -->
             <nanosec>20</nanosec>
-        </initialHeartbeatDelay>
-        <heartbeatPeriod> <!-- DURATION -->
+        </initial_heartbeat_delay>
+        <heartbeat_period> <!-- DURATION -->
             <sec>5</sec>
-        </heartbeatPeriod>
-        <nackResponseDelay> <!-- DURATION -->
+        </heartbeat_period>
+        <nack_response_delay> <!-- DURATION -->
             <nanosec>10</nanosec>
-        </nackResponseDelay>
-        <nackSupressionDuration> <!-- DURATION -->
+        </nack_response_delay>
+        <nack_supression_duration> <!-- DURATION -->
             <nanosec>20</nanosec>
-        </nackSupressionDuration>
+        </nack_supression_duration>
     </times>
 
     <!--You can also change the values of DisablePositiveACKsQosPolicy.-->

--- a/code/XMLTesterExample.xml
+++ b/code/XMLTesterExample.xml
@@ -591,22 +591,22 @@
             </qos>
 
             <times>
-                <initialHeartbeatDelay>
+                <initial_heartbeat_delay>
                     <sec>1</sec>
                     <nanosec>856000</nanosec>
-                </initialHeartbeatDelay>
-                <heartbeatPeriod>
+                </initial_heartbeat_delay>
+                <heartbeat_period>
                     <sec>1</sec>
                     <nanosec>856000</nanosec>
-                </heartbeatPeriod>
-                <nackResponseDelay>
+                </heartbeat_period>
+                <nack_response_delay>
                     <sec>1</sec>
                     <nanosec>856000</nanosec>
-                </nackResponseDelay>
-                <nackSupressionDuration>
+                </nack_response_delay>
+                <nack_supression_duration>
                     <sec>1</sec>
                     <nanosec>856000</nanosec>
-                </nackSupressionDuration>
+                </nack_supression_duration>
             </times>
 
             <unicastLocatorList>

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -580,10 +580,10 @@
 .. |RTPSEndpointQos::history_memory_policy-api| replace:: :cpp:member:`history_memory_policy<eprosima::fastdds::dds::RTPSEndpointQos::history_memory_policy>`
 
 .. |WriterTimes-api| replace:: :cpp:struct:`WriterTimes<eprosima::fastdds::rtps::WriterTimes>`
-.. |WriterTimes::initialHeartbeatDelay-api| replace:: :cpp:member:`initialHeartbeatDelay<eprosima::fastdds::rtps::WriterTimes::initialHeartbeatDelay>`
-.. |WriterTimes::heartbeatPeriod-api| replace:: :cpp:member:`heartbeatPeriod<eprosima::fastdds::rtps::WriterTimes::heartbeatPeriod>`
-.. |WriterTimes::nackResponseDelay-api| replace:: :cpp:member:`nackResponseDelay<eprosima::fastdds::rtps::WriterTimes::nackResponseDelay>`
-.. |WriterTimes::nackSupressionDuration-api| replace:: :cpp:member:`nackSupressionDuration<eprosima::fastdds::rtps::WriterTimes::nackSupressionDuration>`
+.. |WriterTimes::initial_heartbeat_delay-api| replace:: :cpp:member:`initial_heartbeat_delay<eprosima::fastdds::rtps::WriterTimes::initial_heartbeat_delay>`
+.. |WriterTimes::heartbeat_period-api| replace:: :cpp:member:`heartbeat_period<eprosima::fastdds::rtps::WriterTimes::heartbeat_period>`
+.. |WriterTimes::nack_response_delay-api| replace:: :cpp:member:`nack_response_delay<eprosima::fastdds::rtps::WriterTimes::nack_response_delay>`
+.. |WriterTimes::nack_supression_duration-api| replace:: :cpp:member:`nack_supression_duration<eprosima::fastdds::rtps::WriterTimes::nack_supression_duration>`
 
 .. |TransportConfigQos-api| replace:: :cpp:class:`TransportConfigQos<eprosima::fastdds::dds::TransportConfigQos>`
 .. |TransportConfigQos::user_transports-api| replace:: :cpp:member:`user_transports<eprosima::fastdds::dds::TransportConfigQos::user_transports>`

--- a/docs/fastdds/api_reference/spelling_wordlist.txt
+++ b/docs/fastdds/api_reference/spelling_wordlist.txt
@@ -121,14 +121,14 @@ guid
 GuidPrefix
 hashid
 Hashid
-heartbeatPeriod
+heartbeat_period
 heartbeat_response_delay
 HistoryQosPolicy
 InconsistentTopicStatus
 Implementers
 infos
 initial_acknack_delay
-initialHeartbeatDelay
+initial_heartbeat_delay
 inlined
 instanceHandle
 InstanceHandle
@@ -185,8 +185,8 @@ msg
 mutex
 mutexes
 myFilterFactory
-nackResponseDelay
-nackSupressionDuration
+nack_response_delay
+nack_supression_duration
 netmask
 Netmask
 NonConstEnabler

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -349,22 +349,22 @@ List of structure members:
 +-----------------------------------------------------------------------------------+------------------+---------------+
 | Member Name                                                                       | Type             | Default Value |
 +===================================================================================+==================+===============+
-| |WriterTimes::initialHeartbeatDelay-api|                                          | |Duration_t-api| | 12ms          |
+| |WriterTimes::initial_heartbeat_delay-api|                                        | |Duration_t-api| | 12ms          |
 +-----------------------------------------------------------------------------------+------------------+---------------+
-| |WriterTimes::heartbeatPeriod-api|                                                | |Duration_t-api| | 3s            |
+| |WriterTimes::heartbeat_period-api|                                               | |Duration_t-api| | 3s            |
 +-----------------------------------------------------------------------------------+------------------+---------------+
-| |WriterTimes::nackResponseDelay-api|                                              | |Duration_t-api| | 5ms           |
+| |WriterTimes::nack_response_delay-api|                                            | |Duration_t-api| | 5ms           |
 +-----------------------------------------------------------------------------------+------------------+---------------+
-| |WriterTimes::nackSupressionDuration-api|                                         | |Duration_t-api| | 0s            |
+| |WriterTimes::nack_supression_duration-api|                                       | |Duration_t-api| | 0s            |
 +-----------------------------------------------------------------------------------+------------------+---------------+
 
-* |WriterTimes::initialHeartbeatDelay-api|:
+* |WriterTimes::initial_heartbeat_delay-api|:
   Defines duration of the initial heartbeat delay.
-* |WriterTimes::heartbeatPeriod-api|:
+* |WriterTimes::heartbeat_period-api|:
   Specifies the interval between periodic heartbeats.
-* |WriterTimes::nackResponseDelay-api|:
+* |WriterTimes::nack_response_delay-api|:
   Establishes the duration of the delay applied to the response of an ACKNACK message.
-* |WriterTimes::nackSupressionDuration-api|:
+* |WriterTimes::nack_supression_duration-api|:
   The RTPSWriter ignores the nack messages received after sending the data until the
   duration time elapses.
 
@@ -373,7 +373,7 @@ List of structure members:
 DisableHeartbeatPiggyback
 """""""""""""""""""""""""
 
-Besides sending heartbeats periodically using the |WriterTimes::heartbeatPeriod-api| (see :ref:`writertimes`), reliable
+Besides sending heartbeats periodically using the |WriterTimes::heartbeat_period-api| (see :ref:`writertimes`), reliable
 DataWriters also use a mechanism to append a heartbeat submessage in the same message where data is being delivered to
 the DataReaders.
 This mechanism acts in specific situations where the reliable communication state must be up to date to maintain

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -70,7 +70,7 @@ See :ref:`tuning-heartbeat-period` for more details.
 .. warning::
     * It is inconsistent to enable the ``pull mode`` and also set the |ReliabilityQosPolicyKind-api| to
       |BEST_EFFORT_RELIABILITY_QOS-api|.
-    * It is inconsistent to enable the ``pull mode`` and also set the |WriterTimes::heartbeatPeriod-api| to
+    * It is inconsistent to enable the ``pull mode`` and also set the |WriterTimes::heartbeat_period-api| to
       |c_TimeInfinite-api|.
 
 

--- a/docs/fastdds/xml_configuration/datawriter.rst
+++ b/docs/fastdds/xml_configuration/datawriter.rst
@@ -132,16 +132,29 @@ WriterTimes
 
 These parameters are included within :ref:`rtpsreliablewriterqos` in the :ref:`writertimes` structure.
 
-+------------------------------+-------------------------------------------------------+---------------------+---------+
-| Name                         | Description                                           | Values              | Default |
-+==============================+=======================================================+=====================+=========+
-| ``<initial_heartbeat_delay>``  | Initial heartbeat delay.                              | :ref:`DurationType` | 12 ms   |
-+------------------------------+-------------------------------------------------------+---------------------+---------+
-| ``<heartbeat_period>``        | Periodic heartbeat period.                            | :ref:`DurationType` | 3 s     |
-+------------------------------+-------------------------------------------------------+---------------------+---------+
-| ``<nack_response_delay>``      | Delay to apply to the response of an ACKNACK message. | :ref:`DurationType` | 5 ms    |
-+------------------------------+-------------------------------------------------------+---------------------+---------+
-| ``<nack_supression_duration>`` | This time allows the DataWriter to ignore NACK |br|   | :ref:`DurationType` | 0 ms    |
-|                              | messages for a given period of time right after |br|  |                     |         |
-|                              | the data has been sent.                               |                     |         |
-+------------------------------+-------------------------------------------------------+---------------------+---------+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - Name
+     - Description
+     - Values
+     - Default
+   * - ``<initial_heartbeat_delay>``
+     - Initial heartbeat delay.
+     - :ref:`DurationType`
+     - 12 ms
+   * - ``<heartbeat_period>``
+     - Periodic heartbeat period.
+     - :ref:`DurationType`
+     - 3 s
+   * - ``<nack_response_delay>``
+     - Delay to apply to the response of an ACKNACK message.
+     - :ref:`DurationType`
+     - 5 ms
+   * - ``<nack_supression_duration>``
+     - This time allows the DataWriter to ignore NACK |br|
+       messages for a given period of time right after |br|
+       the data has been sent.
+     - :ref:`DurationType`
+     - 0 ms

--- a/docs/fastdds/xml_configuration/datawriter.rst
+++ b/docs/fastdds/xml_configuration/datawriter.rst
@@ -135,13 +135,13 @@ These parameters are included within :ref:`rtpsreliablewriterqos` in the :ref:`w
 +------------------------------+-------------------------------------------------------+---------------------+---------+
 | Name                         | Description                                           | Values              | Default |
 +==============================+=======================================================+=====================+=========+
-| ``<initialHeartbeatDelay>``  | Initial heartbeat delay.                              | :ref:`DurationType` | 12 ms   |
+| ``<initial_heartbeat_delay>``  | Initial heartbeat delay.                              | :ref:`DurationType` | 12 ms   |
 +------------------------------+-------------------------------------------------------+---------------------+---------+
-| ``<heartbeatPeriod>``        | Periodic heartbeat period.                            | :ref:`DurationType` | 3 s     |
+| ``<heartbeat_period>``        | Periodic heartbeat period.                            | :ref:`DurationType` | 3 s     |
 +------------------------------+-------------------------------------------------------+---------------------+---------+
-| ``<nackResponseDelay>``      | Delay to apply to the response of an ACKNACK message. | :ref:`DurationType` | 5 ms    |
+| ``<nack_response_delay>``      | Delay to apply to the response of an ACKNACK message. | :ref:`DurationType` | 5 ms    |
 +------------------------------+-------------------------------------------------------+---------------------+---------+
-| ``<nackSupressionDuration>`` | This time allows the DataWriter to ignore NACK |br|   | :ref:`DurationType` | 0 ms    |
+| ``<nack_supression_duration>`` | This time allows the DataWriter to ignore NACK |br|   | :ref:`DurationType` | 0 ms    |
 |                              | messages for a given period of time right after |br|  |                     |         |
 |                              | the data has been sent.                               |                     |         |
 +------------------------------+-------------------------------------------------------+---------------------+---------+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adapts the code to the RTPS writer APIs refactor. In particular, the rename of members in `WriterTimes`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#5028

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
