### PR TITLE
[21319] Add python optional step in binary installation sections

### DIFF
--- a/docs/installation/binaries/binaries_linux.rst
+++ b/docs/installation/binaries/binaries_linux.rst
@@ -32,8 +32,6 @@ the :code:`install.sh` script with administrative privileges:
     By default, *eProsima Fast DDS* does not compile tests. To activate them, please refer to the :ref:`linux_sources`
     page.
 
-    To use the :ref:`cli_xml` validation tool, please refer to the :ref:`linux_sources` page.
-
 .. _contents_bl:
 
 Contents
@@ -96,6 +94,24 @@ For example in order to build the examples dynamically linked to **Fast-DDS** do
 
     $ cmake -Bbuildexample -DBUILD_SHARED_LIBS=ON .
     $ cmake --build buildexample --target install
+
+.. _cli_bl:
+
+Fast DDS CLI (optional)
+-----------------------
+
+The :ref:`Fast DDS CLI<ffastddscli_cli>` (Command Line Interface) is a tool that provides a set commands and
+sub-commands to perform, Fast DDS related, maintenance and configuration tasks.
+As an optional tool, its dependencies are not installed by default, but they can be installed by running the
+following command:
+
+.. code-block:: bash
+
+    sudo apt-get install python3 python3-pip
+    pip3 install xmlschema
+
+Python3 is required to run the CLI tool, and the `xmlschema <https://pypi.org/project/xmlschema/>`_ dependency is
+needed to use the :ref:`XML validation command<cli_xml>`.
 
 .. _uninstall_bl:
 

--- a/docs/installation/binaries/binaries_windows.rst
+++ b/docs/installation/binaries/binaries_windows.rst
@@ -129,3 +129,22 @@ For example in order to build the examples dynamically linked to **Fast-DDS** do
 
     > cmake -Bbuildexample -DBUILD_SHARED_LIBS=ON .
     > cmake --build buildexample --target install
+
+
+.. _cli_bw:
+
+Fast DDS CLI (optional)
+-----------------------
+
+The :ref:`Fast DDS CLI<ffastddscli_cli>` (Command Line Interface) is a tool that provides a set commands and
+sub-commands to perform, Fast DDS related, maintenance and configuration tasks.
+As an optional tool, its dependencies are not installed by default, but they can be installed by running the
+following command:
+
+.. code-block:: bash
+
+    choco install python
+    python -m pip install --upgrade pywin32 xmlschema
+
+Python3 is required to run the CLI tool, and the `xmlschema <https://pypi.org/project/xmlschema/>`_ dependency is
+needed to use the :ref:`XML validation command<cli_xml>`.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
There were missing instructions regarding Fast DDS CLI in binary installation sections.
This PR adds that section in both Linux and Windows.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
