### PR TITLE
[21309] Change back Ubuntu versions for CI and RTD

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install apt dependencies
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
-          packages: libasio-dev libtinyxml2-dev libssl-dev swig4.1 doxygen imagemagick plantuml
+          packages: libasio-dev libtinyxml2-dev libssl-dev swig doxygen imagemagick plantuml
           update: false
           upgrade: false
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -299,7 +299,7 @@ if read_the_docs_build:
         sys.exit(doxygen_ret)
 
     # Generate SWIG code.
-    swig_ret = subprocess.call('swig4.1 -python -doxygen -I{}/include \
+    swig_ret = subprocess.call('swig -python -doxygen -I{}/include \
             -outdir {}/fastdds_python/src/swig -c++ -interface \
             _fastdds_python -o \
             {}/fastdds_python/src/swig/fastddsPYTHON_wrap.cxx \

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -6,12 +6,12 @@
 version: 2
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-20.04
   tools:
     python: "3.11"
   apt_packages:
     - plantuml
-    - swig4.1
+    - swig
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

#837 Moved both the CI and RTD generation to Ubuntu 24.04. Although it is a change we want to make, right now both Fast DDS and Fast DDS Python and having warnings and build errors on that platform which are uncovered by:

* #856

Until those are fixed, this PR sets the Ubuntu versions back to 22.04 for CI and 20.04.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_: Code snippets related to the added documentation have been provided.
- _N/A_: Documentation tests pass locally.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
