### PR TITLE
[21311] Add Fast DDS v2.14.3 release notes (#867)

### DIFF
--- a/docs/notes/notes.rst
+++ b/docs/notes/notes.rst
@@ -5,7 +5,7 @@
 Information about the release lifecycle can be found
 `here <https://github.com/eProsima/Fast-DDS/blob/master/RELEASE_SUPPORT.md>`_.
 
-.. include:: previous_versions/v2.14.2.rst
+.. include:: previous_versions/v2.14.3.rst
 
 .. seealso::
 

--- a/docs/notes/previous_versions/supported_versions.rst
+++ b/docs/notes/previous_versions/supported_versions.rst
@@ -4,6 +4,7 @@ Supported versions
 Version 2.14
 ------------
 
+.. include:: v2.14.3.rst
 .. include:: v2.14.2.rst
 .. include:: v2.14.1.rst
 .. include:: v2.14.0.rst

--- a/docs/notes/previous_versions/v2.14.2.rst
+++ b/docs/notes/previous_versions/v2.14.2.rst
@@ -1,5 +1,5 @@
-`Version 2.14.2 (latest) <https://fast-dds.docs.eprosima.com/en/v2.14.2/index.html>`_
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Version 2.14.2 <https://fast-dds.docs.eprosima.com/en/v2.14.2/index.html>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. important::
 

--- a/docs/notes/previous_versions/v2.14.3.rst
+++ b/docs/notes/previous_versions/v2.14.3.rst
@@ -1,0 +1,29 @@
+`Version 2.14.3 (latest) <https://fast-dds.docs.eprosima.com/en/v2.14.3/index.html>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. important::
+
+    Fast DDS v2.14 will be the last minor version of Fast DDS v2, the next major release will be Fast DDS
+    v3.0.0, stay tuned!
+
+This release includes the following **features** in an ABI compatible manner:
+
+#. Setting ``vendor_id`` on received ``CacheChange_t``
+
+This release includes the following **improvements**:
+
+#. Repository & CI improvements.
+#. Create InitialConnection for :ref:`transport_tcp_tcp` initial peers
+
+This release includes the following **fixes**:
+
+#. Fix topic interference on ``liveliness_changed`` status
+#. Remove doxygen warnings
+#. Adjust doxygen so Fast DDS Python pydoc makes RTD build
+#. Fix compilation in Ubuntu 24.04 platforms
+#. Fix Latency test destruction
+
+.. note::
+
+    When upgrading to version 2.14.3 it is **advisable** to regenerate generated source from IDL files
+    using `Fast DDS-Gen v3.3.0 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v3.3.0>`_.

--- a/docs/notes/versions.rst
+++ b/docs/notes/versions.rst
@@ -360,7 +360,7 @@ Fast DDS as the core middleware.
             * - `Fast DDS python <https://github.com/eProsima/Fast-DDS-python/>`__
               - `v1.4.2 <https://github.com/eProsima/Fast-DDS-python/releases/tag/v1.4.2>`__
             * - `Shapes Demo <https://github.com/eProsima/ShapesDemo/>`__
-              - `v2.14.1 <https://github.com/eProsima/ShapesDemo/releases/tag/v2.14.1>`__
+              - `v2.14.3 <https://github.com/eProsima/ShapesDemo/releases/tag/v2.14.3>`__
             * - `Discovery Server <https://github.com/eProsima/Discovery-Server/>`__
               - `v1.2.2 <https://github.com/eProsima/Discovery-Server/releases/tag/v1.2.2>`__
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the Fast DDS v2.14.3 release notes to master. It is a forward port of:

* #867

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_: Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
