### PR TITLE
[21313] Type propagation policy

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -954,6 +954,16 @@ void dds_domain_examples()
             "1200");
         //!--
     }
+
+    {
+        // TYPE_PROPAGATION_PROPERTY
+        DomainParticipantQos pqos;
+
+        pqos.properties().properties().emplace_back(
+            "fastdds.type_propagation",
+            "enabled");
+        //!--
+    }
 }
 
 //DOMAINPARTICIPANTLISTENER-DISCOVERY-CALLBACKS

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3248,6 +3248,30 @@
 </data_writer>
 <!--><-->
 
+<!-->TYPE_PROPAGATION_PROPERTY<-->
+<!--
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds xmlns="http://www.eprosima.com">
+    <profiles>
+-->
+        <participant profile_name="type_propagation_domainparticipant_xml_profile">
+            <rtps>
+                <propertiesPolicy>
+                    <properties>
+                        <property>
+                            <name>fastdds.type_propagation</name>
+                            <value>enable</value>
+                        </property>
+                    </properties>
+                </propertiesPolicy>
+            </rtps>
+        </participant>
+<!--
+    </profiles>
+</dds>
+-->
+<!--><-->
+
 <!-->FASTDDS_STATISTICS_MODULE<-->
 <participant profile_name="statistics_domainparticipant_conf_xml_profile">
     <rtps>

--- a/docs/fastdds/api_reference/spelling_wordlist.txt
+++ b/docs/fastdds/api_reference/spelling_wordlist.txt
@@ -4,8 +4,8 @@ addReaderLocator
 addReaderProxy
 addWriterProxy
 allowlist
-AppliedAnnotationPubSubType
 AppliedAnnotationParameterPubSubType
+AppliedAnnotationPubSubType
 AppliedBuiltinMemberAnnotationsPubSubType
 AppliedBuiltinTypeAnnotationsPubSubType
 AppliedVerbatimAnnotationPubSubType
@@ -78,6 +78,7 @@ datareader
 DataReader
 DataReaderListener
 DataReaderQos
+DataRepresentationId
 DataRepresentationQosPolicy
 DataSharingQosPolicy
 datawriter
@@ -124,8 +125,8 @@ Hashid
 heartbeat_period
 heartbeat_response_delay
 HistoryQosPolicy
-InconsistentTopicStatus
 Implementers
+InconsistentTopicStatus
 infos
 initial_acknack_delay
 initial_heartbeat_delay
@@ -258,9 +259,9 @@ Subclassed
 subclasses
 subentities
 subnetwork
-subsequence
 SubscriberListener
 SubscriptionMatchedStatus
+subsequence
 synchronism
 te
 TimeBasedFilterQosPolicy
@@ -301,8 +302,8 @@ untaken
 untyped
 url
 UserAllocatedSequence
-Utils
 utils
+Utils
 wakeup
 wdata
 WLPListener

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -398,7 +398,7 @@ Setting ``fastdds.max_message_size`` At Participant Level
             :language: c++
             :start-after: // MAX_MESSAGE_SIZE_PROPERTY_PARTICIPANT
             :end-before: //!--
-            :dedent: 6
+            :dedent: 8
 
     .. tab:: XML
 
@@ -421,7 +421,7 @@ Setting ``fastdds.max_message_size`` At Writer Level
             :language: c++
             :start-after: // MAX_MESSAGE_SIZE_PROPERTY_WRITER
             :end-before: //!--
-            :dedent: 6
+            :dedent: 8
 
     .. tab:: XML
 
@@ -430,3 +430,83 @@ Setting ``fastdds.max_message_size`` At Writer Level
             :start-after: <!-->MAX_MESSAGE_SIZE_PROPERTY_WRITER<-->
             :end-before: <!--><-->
             :lines: 2,4-14
+
+.. _property_type_propagation:
+
+Type Propagation
+^^^^^^^^^^^^^^^^
+
+By default, *Fast DDS* leverages :ref:`xtypes_discovery_matching` both to discover remote types and to propagate local
+ones.
+Type propagation entails both adding meta-information to the EDP messages (see :ref:`disc_phases`) and using a
+dedicated set of builtin endpoints to transmit type definitions between the different |DomainParticipants| in the
+network.
+
+Depending on the application design and deployment, it might be desirable to change the default type propagation
+behavior to save bandwidth and/or resources.
+For this reason, *Fast DDS* |DomainParticipants| can be configured with a property ``fastdds.type_propagation``
+that controls how type information is propagated.
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - PropertyPolicyQos name
+     - PropertyPolicyQos value
+     - Default value
+   * - ``"fastdds.type_propagation"``
+     - ``"disabled"`` |br|
+       ``"enabled"`` |br|
+       ``"minimal_bandwidth"`` |br|
+       ``"registration_only"``
+     - ``"enabled"``
+
+The different property values have the following effects on the local |DomainParticipant|:
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - Value
+     - ``TypeObject`` registration
+     - Send type information on EDP
+     - Receive type information on EDP
+     - Type lookup service replies
+   * - ``"disabled"``
+     - NO
+     - NO
+     - IGNORED
+     - DISABLED
+   * - ``"enabled"``
+     - COMPLETE and MINIMAL
+     - COMPLETE and MINIMAL
+     - PROCESSED
+     - ENABLED
+   * - ``"minimal_bandwidth"``
+     - MINIMAL only
+     - MINIMAL only
+     - Only MINIMAL PROCESSED
+     - ENABLED
+   * - ``"registration_only"``
+     - COMPLETE and MINIMAL
+     - COMPLETE and MINIMAL
+     - IGNORED
+     - DISABLED
+
+.. tabs::
+
+    .. tab:: C++
+
+        .. literalinclude:: /../code/DDSCodeTester.cpp
+            :language: c++
+            :start-after: // TYPE_PROPAGATION_PROPERTY
+            :end-before: //!--
+            :dedent: 8
+
+    .. tab:: XML
+
+        .. literalinclude:: /../code/XMLTester.xml
+            :language: xml
+            :start-after: <!-->TYPE_PROPAGATION_PROPERTY<-->
+            :end-before: <!--><-->
+            :lines: 2-4,6-16,18-19

--- a/docs/fastdds/xtypes/discovery_matching.rst
+++ b/docs/fastdds/xtypes/discovery_matching.rst
@@ -60,13 +60,6 @@ The remote data type discovery feature only works if some requisites are met:
      :code:`-no-typeobjectsupport` option disables the generation of these files and effectively disables the
      discovery of remote types.
 
-   .. note::
-
-     Currently there is no support to register the TypeObject when the data type is defined using the
-     :ref:`xtypes_language_binding`.
-     Consequently, local types defined using the dynamic language binding API, are not going to be discovered by remote
-     DomainParticipants.
-
 2. :code:`TypeInformation` should be received with the DomainParticipant's endpoint discovery information.
    A DomainParticipant that does not inform about its :code:`TypeInformation` would not trigger the remote data type
    discovery mechanism.

--- a/docs/fastdds/xtypes/discovery_matching.rst
+++ b/docs/fastdds/xtypes/discovery_matching.rst
@@ -67,6 +67,13 @@ The remote data type discovery feature only works if some requisites are met:
 If the prerequisites are not met, endpoint matching relies on type name and topic name in order to match the discovered
 endpoints.
 
+.. _xtypes_discovery_matching_config:
+
+Configuration
+-------------
+
+The level of propagation of local data types can be configured as specified in :ref:`property_type_propagation`.
+
 Remote types discovery example
 ------------------------------
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR is the Fast DDS Docs counterpart of

* eProsima/Fast-DDS#5081

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
