### PR TITLE
Fix README and standardQosPolicies

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,12 @@ building tools.
     ```bash
     sudo apt update
     sudo apt install -y \
-        # Build tools
         gcc \
         g++ \
         cmake \
-        # Fast DDS dependencies
         libasio-dev \
         libtinyxml2-dev \
         libssl-dev \
-        # Fast DDS-Docs dependencies
         python3-sphinx
     ```
 

--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -681,7 +681,7 @@ Compatibility Rule
 
 To maintain the compatibility between LivelinessQosPolicy in DataReaders and DataWriters, the DataWriter kind must be
 higher or equal to the DataReader kind.
-And the order between the different kinds is::
+And the order between the different kinds is:
 
 |AUTOMATIC_LIVELINESS_QOS-api| < |MANUAL_BY_PARTICIPANT_LIVELINESS_QOS-api| < |MANUAL_BY_TOPIC_LIVELINESS_QOS-api|
 
@@ -1150,7 +1150,7 @@ Compatibility Rule
 
 To maintain the compatibility between ReliabilityQosPolicy in DataReaders and DataWriters, the DataWriter kind
 must be higher or equal to the DataReader kind.
-And the order between the different kinds is::
+And the order between the different kinds is:
 
 |BEST_EFFORT_RELIABILITY_QOS-api| < |RELIABLE_RELIABILITY_QOS-api|
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Some minor fixes in README and standarQosPolicies.rst
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
-->
FIxed a minor error showing compatibility rules in standard Qos Policies
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
