### PR TITLE
[21443] Fix bug in initial peers documentation

### DIFF
--- a/docs/fastdds/discovery/simple.rst
+++ b/docs/fastdds/discovery/simple.rst
@@ -123,11 +123,11 @@ to a multicast address and another one linked to a unicast address.
 *Fast DDS* allows for the configuration of an initial peers list which contains one or more such IP-port address
 pairs corresponding to remote DomainParticipants PDP discovery listening resources, so that the local
 DomainParticipant will not only send its PDP traffic to the default multicast address-port specified by its domain,
-but also to all the IP-port address pairs specified in the initial peers list.
+or to all the IP-port address pairs specified in the initial peers list.
 
 A DomainParticipant's initial peers list contains the list of IP-port address pairs of all other DomainParticipants
 with which it will communicate.
-It is a list of addresses that a DomainParticipant will use in the unicast discovery mechanism, together or as an
+It is a list of addresses that a DomainParticipant will use in the unicast discovery mechanism, as an
 alternative to multicast discovery.
 Therefore, this approach also applies to those scenarios in which multicast functionality is not available.
 

--- a/docs/fastdds/discovery/simple.rst
+++ b/docs/fastdds/discovery/simple.rst
@@ -122,13 +122,13 @@ must listen for incoming Participant Discovery Protocol (PDP) discovery metatraf
 to a multicast address and another one linked to a unicast address.
 *Fast DDS* allows for the configuration of an initial peers list which contains one or more such IP-port address
 pairs corresponding to remote DomainParticipants PDP discovery listening resources, so that the local
-DomainParticipant will not only send its PDP traffic to the default multicast address-port specified by its domain,
-or to all the IP-port address pairs specified in the initial peers list.
+DomainParticipant will only send its PDP traffic to the IP-port address pairs specified in the initial peers list.
 
 A DomainParticipant's initial peers list contains the list of IP-port address pairs of all other DomainParticipants
 with which it will communicate.
-It is a list of addresses that a DomainParticipant will use in the unicast discovery mechanism, as an
-alternative to multicast discovery.
+It is a list of addresses that a DomainParticipant will use in the PDP discovery mechanism, and can hold both multicast
+and unicast addresses.
+The default multicast address will be used if the list is empty.
 Therefore, this approach also applies to those scenarios in which multicast functionality is not available.
 
 According to the `RTPS standard <https://www.omg.org/spec/DDSI-RTPS/2.2/PDF>`_ (Section 9.6.1.1), the RTPSParticipants'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR updates the inital peers documentation with the changes introduced in 

Note: spelling issue (unknown word `reachability`) is fixed in the [bump PR](https://github.com/eProsima/Fast-DDS-docs/pull/884/files#diff-94d41e6faf6c8f9c8faefc24c63640d92a798138e3eb709d528c4159e5b33d64)
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes eProsima/Fast-DDS/discussions/5153

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
