### PR TITLE
[21590] Add warning about idls extensibility for Vulcanexus jazzy

### DIFF
--- a/docs/fastdds/use_cases/rosbag_capture/rosbag_capture.rst
+++ b/docs/fastdds/use_cases/rosbag_capture/rosbag_capture.rst
@@ -153,7 +153,7 @@ the TypeSupport and the example source files.
 
     If using Fast DDS *v3.0.0* or newer and generating the type with Fast DDS-Gen *v4.0.0*, the extensibility
     must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
-    Starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it defaults to ``@extensibility(FINAL)``.
+    Starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it defaults to ``@final``.
     Please, refer to :ref:`Fast DDS data types extensibility <extensibility>` for further information about type
     extensibility.
 

--- a/docs/fastdds/use_cases/rosbag_capture/rosbag_capture.rst
+++ b/docs/fastdds/use_cases/rosbag_capture/rosbag_capture.rst
@@ -151,9 +151,11 @@ the TypeSupport and the example source files.
 
 .. important::
 
-    If using Fast DDS *v3.0.0* or newer and generating the type with ``Fast DDS-Gen v4.0.0``, the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
-    Starting from ``Fast DDS-Gen v4.0.1``, it can be left unspecified, as it defaults to ``@final``.
-    Please, refer to :ref:`Fast DDS data types extensibility <extensibility>` for further information about type extensibility.
+    If using Fast DDS *v3.0.0* or newer and generating the type with Fast DDS-Gen *v4.0.0*, the extensibility
+    must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
+    Starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it defaults to ``@extensibility(FINAL)``.
+    Please, refer to :ref:`Fast DDS data types extensibility <extensibility>` for further information about type
+    extensibility.
 
 .. note::
 

--- a/docs/fastdds/use_cases/rosbag_capture/rosbag_capture.rst
+++ b/docs/fastdds/use_cases/rosbag_capture/rosbag_capture.rst
@@ -149,6 +149,12 @@ Create a new workspace different from the ROS 2 one used previously.
 Copy inside the same IDL file and run Fast DDS-Gen to generate
 the TypeSupport and the example source files.
 
+.. important::
+
+    If using Fast DDS *v3.0.0* or newer and generating the type with ``Fast DDS-Gen v4.0.0``, the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
+    Starting from ``Fast DDS-Gen v4.0.1``, it can be left unspecified, as it defaults to ``@final``.
+    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`_ for further information about type extensibility.
+
 .. note::
 
     Fast DDS-Gen :code:`-no-typeobjectsupport` option is advisable to be enabled as this feature does not ensure vendor

--- a/docs/fastdds/use_cases/rosbag_capture/rosbag_capture.rst
+++ b/docs/fastdds/use_cases/rosbag_capture/rosbag_capture.rst
@@ -153,7 +153,7 @@ the TypeSupport and the example source files.
 
     If using Fast DDS *v3.0.0* or newer and generating the type with ``Fast DDS-Gen v4.0.0``, the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
     Starting from ``Fast DDS-Gen v4.0.1``, it can be left unspecified, as it defaults to ``@final``.
-    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`_ for further information about type extensibility.
+    Please, refer to :ref:`Fast DDS data types extensibility <extensibility>` for further information about type extensibility.
 
 .. note::
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
