### PR TITLE
[21538] Allow all `durability` configurations

### DIFF
--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -211,8 +211,8 @@ There are four possible values (see |DurabilityQosPolicyKind-api|):
 * |TRANSIENT_LOCAL_DURABILITY_QOS-api|: When a new DataReader joins, its History is filled with past samples.
 * |TRANSIENT_DURABILITY_QOS-api|: When a new DataReader joins, its History is filled with past samples, which are stored
   on persistent storage (see :ref:`persistence_service`).
-* |PERSISTENT_DURABILITY_QOS-api|: (`Not Implemented`, currently behaves as |TRANSIENT_DURABILITY_QOS-api|):
-  All the samples are stored on a permanent storage, so that they can outlive a system session.
+* |PERSISTENT_DURABILITY_QOS-api|: When a new DataReader joins, its History is filled with past samples,
+  which are stored on persistent storage (see :ref:`persistence_service`).
 
 .. _durability_compatibilityrule:
 

--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -211,8 +211,8 @@ There are four possible values (see |DurabilityQosPolicyKind-api|):
 * |TRANSIENT_LOCAL_DURABILITY_QOS-api|: When a new DataReader joins, its History is filled with past samples.
 * |TRANSIENT_DURABILITY_QOS-api|: When a new DataReader joins, its History is filled with past samples, which are stored
   on persistent storage (see :ref:`persistence_service`).
-* |PERSISTENT_DURABILITY_QOS-api|: (`Not Implemented`): All the samples are stored on a permanent storage, so that they
-  can outlive a system session.
+* |PERSISTENT_DURABILITY_QOS-api|: (`Not Implemented`, currently behaves as |TRANSIENT_DURABILITY_QOS-api|):
+  All the samples are stored on a permanent storage, so that they can outlive a system session.
 
 .. _durability_compatibilityrule:
 

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -40,7 +40,7 @@ The configuration of the persistence service is accomplished by setting of the a
 or DataReader) |PropertyPolicyQos|.
 
 * For the :ref:`persistence_service` to have any effect, the |DurabilityQosPolicyKind-api| needs to be set to
-  |TRANSIENT_DURABILITY_QOS-api|.
+  |TRANSIENT_DURABILITY_QOS-api| or |PERSISTENT_DURABILITY_QOS-api| (which behaves as |TRANSIENT_DURABILITY_QOS-api|).
 
 * A persistence identifier (|Guid_t-api|) must be set for the entity using the property ``dds.persistence.guid``.
   This identifier is used to load the appropriate data from the database, and also to synchronize DataWriter and
@@ -56,8 +56,15 @@ or DataReader) |PropertyPolicyQos|.
   For selecting an appropriate GUID for the DataReader and DataWriter, please refer to
   `RTPS standard <https://www.omg.org/spec/DDSI-RTPS/2.2/PDF>`_ (section *9.3.1 The Globally Unique Identifier (GUID)*).
 
+  If no ``dds.persistence.guid`` is specified, the durability will fallback to |TRANSIENT_LOCAL_DURABILITY_QOS-api|.
+
 * A persistence plugin must be configured for managing the database using property ``dds.persistence.plugin`` (see
   :ref:`persistence_sqlite3_builtin_plugin`):
+
+.. note::
+
+    If the |DurabilityQosPolicyKind-api| is set to |TRANSIENT_DURABILITY_QOS-api| or |PERSISTENT_DURABILITY_QOS-api|
+    and no ``dds.persistence.guid`` is specified, |TRANSIENT_LOCAL_DURABILITY_QOS-api| will be used.
 
 
 .. _persistence_sqlite3_builtin_plugin:

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -62,12 +62,6 @@ or DataReader) |PropertyPolicyQos|.
 * A persistence plugin must be configured for managing the database using property ``dds.persistence.plugin`` (see
   :ref:`persistence_sqlite3_builtin_plugin`):
 
-.. note::
-
-    If the |DurabilityQosPolicyKind-api| is set to |TRANSIENT_DURABILITY_QOS-api| or |PERSISTENT_DURABILITY_QOS-api|
-    and no ``dds.persistence.guid`` is specified, |TRANSIENT_LOCAL_DURABILITY_QOS-api| will be used.
-
-
 .. _persistence_sqlite3_builtin_plugin:
 
 PERSISTENCE:SQLITE3 built-in plugin

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -40,7 +40,7 @@ The configuration of the persistence service is accomplished by setting of the a
 or DataReader) |PropertyPolicyQos|.
 
 * For the :ref:`persistence_service` to have any effect, the |DurabilityQosPolicyKind-api| needs to be set to
-  |TRANSIENT_DURABILITY_QOS-api| or |PERSISTENT_DURABILITY_QOS-api| (which behaves as |TRANSIENT_DURABILITY_QOS-api|).
+  |TRANSIENT_DURABILITY_QOS-api| or |PERSISTENT_DURABILITY_QOS-api|.
 
 * A persistence identifier (|Guid_t-api|) must be set for the entity using the property ``dds.persistence.guid``.
   This identifier is used to load the appropriate data from the database, and also to synchronize DataWriter and
@@ -56,7 +56,8 @@ or DataReader) |PropertyPolicyQos|.
   For selecting an appropriate GUID for the DataReader and DataWriter, please refer to
   `RTPS standard <https://www.omg.org/spec/DDSI-RTPS/2.2/PDF>`_ (section *9.3.1 The Globally Unique Identifier (GUID)*).
 
-  If no ``dds.persistence.guid`` is specified, the durability will fallback to |TRANSIENT_LOCAL_DURABILITY_QOS-api|.
+  If no ``dds.persistence.guid`` is specified,
+  the durability behavior will fallback to |TRANSIENT_LOCAL_DURABILITY_QOS-api|.
 
 * A persistence plugin must be configured for managing the database using property ``dds.persistence.plugin`` (see
   :ref:`persistence_sqlite3_builtin_plugin`):


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR documents the new behavior included in the implementation PR:

* Allows the creation of a DataWriter/Reader with a PERSISTENT durability, but behaving as TRANSIENT (warning about it).
* When in TRANSIENT, if no persistence guid is given, it fallbacks to TRANSIENT_LOCAL.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#5224


## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
