### PR TITLE
[21646] Fix typo in statistics troubleshooting XML snippet

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3369,7 +3369,7 @@
         </participant>
 
         <!-- Generic profile for a specific statistics DataWriters -->
-        <data_writer profile_name="HISTORY_LATENCY_WRITER">
+        <data_writer profile_name="HISTORY_LATENCY_TOPIC">
             <!-- Configure History QoS as KEEP_LAST 20 -->
             <!-- History depth depends on the user application constraints (publication rate for instance) -->
             <topic>

--- a/docs/fastdds/statistics/dds_layer/troubleshooting.rst
+++ b/docs/fastdds/statistics/dds_layer/troubleshooting.rst
@@ -49,6 +49,12 @@ buffer to answer to requests:
             :end-before: <!--><-->
             :lines: 2-4, 6-53, 55-56
 
+        .. warning::
+
+            Mind that the specific profile only targets to the DataWriter which profile name matches with the alias of
+            the corresponding statistics topic.
+            Check the complete list of topics and their aliases in the :ref:`statistics_topic_names` section.
+
 .. note::
     Increasing the History Depth of the statistics DataWriters has an impact on memory usage, as sufficient space is
     pre-allocated for each of the DataWriter's histories to hold that number of samples per topic instance.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
The XML snippet for statistics troubleshooting does not display the proper profile name for statistics writers.
This PR updates the snippet with the correct name and includes a warning box to inform about the profile name behavior.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
