### PR TITLE
[21655] Mirror `2.6.9` with `2.6.x` ci job

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,22 +2,22 @@
 on:
   push:
     branches:
-      - 'master'
+      - '2.6.x'
 
 jobs:
   mirror_job:
-    name: Mirror master branch to latest minor branches
+    name: Mirror 2.6.9 branch to 2.6.x branch
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         dest_branch:
-          - '2.6.x'
+          - '2.6.9'
     steps:
     - name: Mirror action step
       id: mirror
       uses: google/mirror-branch-action@v1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        source: 'master'
+        source: '2.6.x'
         dest: ${{ matrix.dest_branch }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   mirror_job:
-    name: Mirror 2.6.9 branch to 2.6.x branch
+    name: Mirror 2.6.x branch to 2.6.9 branch
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR mirrors the latest release `2.6.9` with `2.6.x` for addressing little documentation fixes.

*Note: Its possible that the job should be placed into master instead of 2.6.x to make any effect*

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- **N/A** Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** CI passes without warnings or errors.
