### PR TITLE
[21750] Add support @value annotation on fastddsgen

### DIFF
--- a/code/FastDDSGenCodeTester.cpp
+++ b/code/FastDDSGenCodeTester.cpp
@@ -163,7 +163,7 @@ enum Enumeration : int32_t
 {
     RED,
     GREEN,
-    BLUE
+    BLUE = 3
 };
 //!
 

--- a/docs/fastdds/xml_configuration/dynamic_types.rst
+++ b/docs/fastdds/xml_configuration/dynamic_types.rst
@@ -150,8 +150,7 @@ Optionally, unsigned integer attribute :code:`value` might be added to set a spe
 
 .. note::
 
-    :code:`value` attribute is equivalent to :code:`@value` builtin annotation which is not still supported in neither
-    the plain (IDL) nor |DynamicTypes|.
+    :code:`value` attribute is equivalent to :code:`@value` builtin annotation.
 
 Please, refer to :ref:`xtypes_supportedtypes_enumeration` for more information on enumeration types.
 

--- a/docs/fastdds/xtypes/language_binding.rst
+++ b/docs/fastdds/xtypes/language_binding.rst
@@ -298,10 +298,6 @@ For the enumeration type to be consistent, the remaining enumeration literals mu
 Additionally, the enumeration literal value might be set using |MemberDescriptor-api| :code:`default_value` property.
 The behavior is the same as setting the :code:`@value` :ref:`builtin annotation<builtin_annotations>`.
 
-.. note::
-
-  Currently, Fast DDS-Gen does not support :code:`@value` builtin annotation.
-
 As the enumeration type is basically a signed integer type which might take only some specific values defined with the
 enumeration literals, the corresponding DynamicData getters and setters are the ones corresponding to the underlying
 signed integer type (and any other method promotable to that specific primitive type).

--- a/docs/fastddsgen/dataTypes/dataTypes.rst
+++ b/docs/fastddsgen/dataTypes/dataTypes.rst
@@ -362,6 +362,7 @@ The following IDL enumeration:
     {
         RED,
         GREEN,
+        @value(3)
         BLUE
     };
 
@@ -572,7 +573,7 @@ annotations might be applied without the need of defining them).
       - ❌
     * - :code:`@value`
       - Set constant value to `enumerations`_ literal.
-      - ❌
+      - ✅
     * - :code:`@verbatim`
       - Add comment or text to the element.
       - ❌


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR updates the documentation according with eprosima/fast-dds-gen#379 which adds support to `@value` annotation. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.

