### PR TITLE
[21684] Update Foxy reference in ROS 2 section

### DIFF
--- a/docs/fastdds/ros2/ros2.rst
+++ b/docs/fastdds/ros2/ros2.rst
@@ -24,8 +24,8 @@ DDS* as middleware layer: ``rmw_fastrtps_cpp`` and ``rmw_fastrtps_dynamic_cpp``.
 The main difference between the two is that ``rmw_fastrtps_dynamic_cpp`` uses introspection type support at run time to
 decide on the serialization/deserialization mechanism, while ``rmw_fastrtps_cpp`` uses its own type support, which
 generates the mapping for each message type at build time.
-The default ROS 2 RMW implementation until *Foxy* is ``rmw_fastrtps_cpp``.
-For *Galactic* the environment variable ``RMW_IMPLEMENTATION`` has to be set to select ``rmw_fastrtps_cpp`` in order to
+The default ROS 2 RMW implementation until *Jazzy* is ``rmw_fastrtps_cpp``.
+For *EOL Galactic* the environment variable ``RMW_IMPLEMENTATION`` has to be set to select ``rmw_fastrtps_cpp`` in order to
 use *Fast DDS* as the middleware layer.
 This environment variable can also be used to select the ``rmw_fastrtps_dynamic_cpp`` implementation:
 
@@ -55,7 +55,7 @@ This environment variable can also be used to select the ``rmw_fastrtps_dynamic_
 
 .. note::
 
-   Since *Galactic* you may have to install the ``rmw_fastrtps_cpp`` package:
+   Since *EOL Galactic* you may have to install the ``rmw_fastrtps_cpp`` package:
 
    .. code-block:: bash
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR updates the ROS 2 section to refer to Jazzy as latest version, and highlights Galactic as EOL.
Are backports needed?
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
