### PR TITLE
[21908] Adjust XML snippets to meet QoS constraints

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4288,13 +4288,13 @@ void dds_qos_examples()
         // This example uses a DataWriter, but it can also be applied to DataReader and Topic entities
         DataWriterQos writer_qos;
         // The ResourceLimitsQosPolicy is constructed with max_samples = 5000 by default
-        // Change max_samples to 200
-        writer_qos.resource_limits().max_samples = 200;
+        // Change max_samples to 2000
+        writer_qos.resource_limits().max_samples = 2000;
         // The ResourceLimitsQosPolicy is constructed with max_instances = 10 by default
         // Change max_instances to 20
         writer_qos.resource_limits().max_instances = 20;
         // The ResourceLimitsQosPolicy is constructed with max_samples_per_instance = 400 by default
-        // Change max_samples_per_instance to 100 as it must be lower than max_samples
+        // Change max_samples_per_instance to 100
         writer_qos.resource_limits().max_samples_per_instance = 100;
         // The ResourceLimitsQosPolicy is constructed with allocated_samples = 100 by default
         // Change allocated_samples to 50

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -1978,9 +1978,9 @@
             <depth>20</depth>
         </historyQos>
         <resourceLimitsQos>
-            <max_samples>5</max_samples>
-            <max_instances>2</max_instances>
-            <max_samples_per_instance>1</max_samples_per_instance>
+            <max_samples>100</max_samples>
+            <max_instances>5</max_instances>
+            <max_samples_per_instance>20</max_samples_per_instance>
             <allocated_samples>20</allocated_samples>
             <extra_samples>10</extra_samples>
         </resourceLimitsQos>
@@ -1995,9 +1995,9 @@
         <depth>20</depth>
     </historyQos>
     <resourceLimitsQos>
-        <max_samples>5</max_samples>
-        <max_instances>2</max_instances>
-        <max_samples_per_instance>1</max_samples_per_instance>
+        <max_samples>100</max_samples>
+        <max_instances>5</max_instances>
+        <max_samples_per_instance>20</max_samples_per_instance>
         <allocated_samples>20</allocated_samples>
         <extra_samples>10</extra_samples>
     </resourceLimitsQos>
@@ -3621,7 +3621,7 @@
 <data_writer profile_name="writer_xml_conf_resource_limits_profile">
     <topic>
         <resourceLimitsQos>
-            <max_samples>200</max_samples>
+            <max_samples>2000</max_samples>
             <max_instances>20</max_instances>
             <max_samples_per_instance>100</max_samples_per_instance>
             <allocated_samples>50</allocated_samples>
@@ -3632,7 +3632,7 @@
 <data_reader profile_name="reader_xml_conf_resource_limits_profile">
     <topic>
         <resourceLimitsQos>
-            <max_samples>200</max_samples>
+            <max_samples>2000</max_samples>
             <max_instances>20</max_instances>
             <max_samples_per_instance>100</max_samples_per_instance>
             <allocated_samples>50</allocated_samples>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -1978,9 +1978,9 @@
             <depth>20</depth>
         </historyQos>
         <resourceLimitsQos>
-            <max_samples>100</max_samples>
-            <max_instances>5</max_instances>
-            <max_samples_per_instance>20</max_samples_per_instance>
+            <max_samples>5</max_samples>
+            <max_instances>2</max_instances>
+            <max_samples_per_instance>1</max_samples_per_instance>
             <allocated_samples>20</allocated_samples>
             <extra_samples>10</extra_samples>
         </resourceLimitsQos>
@@ -1995,9 +1995,9 @@
         <depth>20</depth>
     </historyQos>
     <resourceLimitsQos>
-        <max_samples>100</max_samples>
-        <max_instances>5</max_instances>
-        <max_samples_per_instance>20</max_samples_per_instance>
+        <max_samples>5</max_samples>
+        <max_instances>2</max_instances>
+        <max_samples_per_instance>1</max_samples_per_instance>
         <allocated_samples>20</allocated_samples>
         <extra_samples>10</extra_samples>
     </resourceLimitsQos>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR updates the XML snippets to meet the resource limits QoS constraints
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.0.x 2.14.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
