### PR TITLE
[21841] Extended incompatible qos for monitor service documentation

### DIFF
--- a/docs/fastdds/statistics/monitor_service/monitor_service_topics.rst
+++ b/docs/fastdds/statistics/monitor_service/monitor_service_topics.rst
@@ -28,33 +28,36 @@ The possible values are described in the following table:
 
 .. _monitoring_statuses:
 
-+---------+-----------------------------+-----------------------------------------+
-|**Value**|          **Name**           | **Description**                         |
-+---------+-----------------------------+-----------------------------------------+
-|  0      |     ``ProxyInfo``           | Collection of Parameters describing the |
-|         |                             | ``Proxy Data`` of that entity           |
-+---------+-----------------------------+-----------------------------------------+
-|  1      |     ``ConnectionList``      | List of connections that this entity is |
-|         |                             | using with its matched remote entities. |
-+---------+-----------------------------+-----------------------------------------+
-|  2      |  ``IncompatibleQoSInfo``    | Status of the Incompatible QoS          |
-|         |                             | of that entity.                         |
-+---------+-----------------------------+-----------------------------------------+
-|  3      | ``InconsistentTopicInfo``   | Status of Inconsistent topics that the  |
-|         |                             | topic of that entity has.               |
-+---------+-----------------------------+-----------------------------------------+
-|  4      |   ``LivelinessLostInfo``    | Tracks the status of the number of times|
-|         |                             | a writer lost liveliness.               |
-+---------+-----------------------------+-----------------------------------------+
-|  5      |   ``LivelinessChangedInfo`` | Tracks the status of the number of times|
-|         |                             | the liveliness changed in a reader.     |
-+---------+-----------------------------+-----------------------------------------+
-|  6      |  ``DeadlineMissedInfo``     | The Status of the number of deadlines   |
-|         |                             | missed of a sample for that entity.     |
-+---------+-----------------------------+-----------------------------------------+
-|  7      |     ``SampleLostInfo``      | Tracks the status of the number of times|
-|         |                             | this entity lost samples.               |
-+---------+-----------------------------+-----------------------------------------+
++---------+-----------------------------+----------------------------------------------------+
+|**Value**|          **Name**           | **Description**                                    |
++---------+-----------------------------+----------------------------------------------------+
+|  0      |     ``ProxyInfo``           | Collection of Parameters describing the            |
+|         |                             | ``Proxy Data`` of that entity                      |
++---------+-----------------------------+----------------------------------------------------+
+|  1      |     ``ConnectionList``      | List of connections that this entity is            |
+|         |                             | using with its matched remote entities.            |
++---------+-----------------------------+----------------------------------------------------+
+|  2      |  ``IncompatibleQoSInfo``    | Status of the Incompatible QoS                     |
+|         |                             | of that entity.                                    |
++---------+-----------------------------+----------------------------------------------------+
+|  3      | ``InconsistentTopicInfo``   | Status of Inconsistent topics that the             |
+|         |                             | topic of that entity has.                          |
++---------+-----------------------------+----------------------------------------------------+
+|  4      |   ``LivelinessLostInfo``    | Tracks the status of the number of times           |
+|         |                             | a writer lost liveliness.                          |
++---------+-----------------------------+----------------------------------------------------+
+|  5      |   ``LivelinessChangedInfo`` | Tracks the status of the number of times           |
+|         |                             | the liveliness changed in a reader.                |
++---------+-----------------------------+----------------------------------------------------+
+|  6      |  ``DeadlineMissedInfo``     | The Status of the number of deadlines              |
+|         |                             | missed of a sample for that entity.                |
++---------+-----------------------------+----------------------------------------------------+
+|  7      |     ``SampleLostInfo``      | Tracks the status of the number of times           |
+|         |                             | this entity lost samples.                          |
++---------+-----------------------------+----------------------------------------------------+
+|  8      | ``ExtendedIncompatibleQoS`` | Stores the list of remote incompatible ``GUIDs``   |
+|         |                             | and QoS policies for each local entity guid.       |
++---------+-----------------------------+----------------------------------------------------+
 
 .. note::
 
@@ -124,32 +127,46 @@ The actual field names for the different values are described below:
 
 * *sample_lost_status:* The number of samples that entity lost.
 
+* *extended_incompatible_qos_status:* Details a list of remote GUIDs with incompatible QoS with
+  a local entity and the particular |QosPolicyId_t-api| of those incompatible policies.
+
+.. code-block:: bash
+
+    ExtendedIncompatibleQoSStatus_s
+      GUID remote_guid
+      sequence<unsigned long> current_incompatible_policies
+
+    ExtendedIncompatibleQoSStatusSeq = sequence<ExtendedIncompatibleQoSStatus>
+
 The following table depicts the relation between each of the ``StatusKind`` values and the ``Data`` field:
 
-+---------------------+---------------------------+---------------------------+---------------------------+
-|**StatusKind Value** |     **StatusKind Name**   | **Data field Name**       | **IDL Data field Type**   |
-+---------------------+---------------------------+---------------------------+---------------------------+
-|  0                  |     ``ProxyInfo``         | entity_proxy              | sequence<octet>           |
-|                     |                           |                           |                           |
-+---------------------+---------------------------+---------------------------+---------------------------+
-|  1                  |     ``ConnectionList``    | connection_list           | sequence<Connection>      |
-|                     |                           |                           |                           |
-+---------------------+---------------------------+---------------------------+---------------------------+
-|  2                  |  ``IncompatibleQoSInfo``  | incompatible_qos_status   | IncompatibleQoSStatus     |
-|                     |                           |                           |                           |
-+---------------------+---------------------------+---------------------------+---------------------------+
-|  3                  | ``InconsistentTopicInfo`` | inconsistent_topic_status | InconsistentTopicStatus   |
-|                     |                           |                           |                           |
-+---------------------+---------------------------+---------------------------+---------------------------+
-|  4                  |   ``LivelinessLostInfo``  | liveliness_lost_status    | LivelinessLostStatus      |
-|                     |                           |                           |                           |
-+---------------------+---------------------------+---------------------------+---------------------------+
-|  5                  |   ``LivelinessLostInfo``  | liveliness_changed_status | LivelinessChangedStatus   |
-|                     |                           |                           |                           |
-+---------------------+---------------------------+---------------------------+---------------------------+
-|  6                  |  ``DeadlineMissedInfo``   | deadline_missed_status    | DeadlineMissedStatus      |
-|                     |                           |                           |                           |
-+---------------------+---------------------------+---------------------------+---------------------------+
-|  7                  |     ``SampleLostInfo``    | sample_lost_status        | SampleLostStatus          |
-|                     |                           |                           |                           |
-+---------------------+---------------------------+---------------------------+---------------------------+
++--------------+---------------------------+----------------------------------+----------------------------------+
+|**StatusKind**|     **StatusKind Name**   | **Data field Name**              | **IDL Data field Type**          |
++--------------+---------------------------+----------------------------------+----------------------------------+
+|  0           |     ``ProxyInfo``         | entity_proxy                     | sequence<octet>                  |
+|              |                           |                                  |                                  |
++--------------+---------------------------+----------------------------------+----------------------------------+
+|  1           |     ``ConnectionList``    | connection_list                  | sequence<Connection>             |
+|              |                           |                                  |                                  |
++--------------+---------------------------+----------------------------------+----------------------------------+
+|  2           |  ``IncompatibleQoSInfo``  | incompatible_qos_status          | IncompatibleQoSStatus            |
+|              |                           |                                  |                                  |
++--------------+---------------------------+----------------------------------+----------------------------------+
+|  3           | ``InconsistentTopicInfo`` | inconsistent_topic_status        | InconsistentTopicStatus          |
+|              |                           |                                  |                                  |
++--------------+---------------------------+----------------------------------+----------------------------------+
+|  4           |   ``LivelinessLostInfo``  | liveliness_lost_status           | LivelinessLostStatus             |
+|              |                           |                                  |                                  |
++--------------+---------------------------+----------------------------------+----------------------------------+
+|  5           |   ``LivelinessLostInfo``  | liveliness_changed_status        | LivelinessChangedStatus          |
+|              |                           |                                  |                                  |
++--------------+---------------------------+----------------------------------+----------------------------------+
+|  6           |  ``DeadlineMissedInfo``   | deadline_missed_status           | DeadlineMissedStatus             |
+|              |                           |                                  |                                  |
++--------------+---------------------------+----------------------------------+----------------------------------+
+|  7           |     ``SampleLostInfo``    | sample_lost_status               | SampleLostStatus                 |
+|              |                           |                                  |                                  |
++--------------+---------------------------+----------------------------------+----------------------------------+
+|  8           |``ExtendedIncompatibleQoS``| extended_incompatible_qos_status | ExtendedIncompatibleQoSStatusSeq |
+|              |                           |                                  |                                  |
++--------------+---------------------------+----------------------------------+----------------------------------+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR brings the documentation for the `Extended Incompatible QoS` for monitor service.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#5345

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
