### PR TITLE
Remove benchmark example from docker fastdds image docs

### DIFF
--- a/docs/docker/fastdds/fast_dds.rst
+++ b/docs/docker/fastdds/fast_dds.rst
@@ -72,25 +72,3 @@ or
     goToExamples
     cd dds/HelloWorldExample/bin
     ./DDSHelloWorldExample subscriber
-
-Benchmark Example
-^^^^^^^^^^^^^^^^^
-
-This example creates either a Publisher or a Subscriber and on a successful match starts sending samples.
-After a few seconds the process that launched the Publisher will show a report with the number of samples transmitted.
-
-On the subscriber side, run:
-
-.. code-block:: bash
-
-    goToExamples
-    cd dds/Benchmark/bin
-    ./DDSBenchmark subscriber udp
-
-On the publisher side, run:
-
-.. code-block:: bash
-
-    goToExamples
-    cd dds/Benchmark/bin
-    ./DDSBenchmark publisher udp


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
As the benchmark example was not refactored with Fast DDS v3, we are removing it from the documentation until we add it.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->
@Mergifyio backport 3.1.x 3.0.x
<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS-docs#961

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
