### PR TITLE
[22280] Add documentation for `preferred_key_agreement` property

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -642,6 +642,9 @@ void dds_domain_examples()
         pqos.properties().properties().emplace_back(
             "dds.sec.auth.builtin.PKI-DH.password",
             "domainParticipantPassword");
+        pqos.properties().properties().emplace_back(
+            "dds.sec.auth.builtin.PKI-DH.preferred_key_agreement",
+            "ECDH");
         //!--
     }
     {

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3050,6 +3050,10 @@
                     <name>dds.sec.auth.builtin.PKI-DH.password</name>
                     <value>domainParticipantPassword</value>
                 </property>
+                <property>
+                    <name>dds.sec.auth.builtin.PKI-DH.preferred_key_agreement</name>
+                    <value>ECDH</value>
+                </property>
             </properties>
         </propertiesPolicy>
     </rtps>

--- a/docs/fastdds/library_overview/includes/functionalities.rst
+++ b/docs/fastdds/library_overview/includes/functionalities.rst
@@ -40,7 +40,8 @@ Security
 * Authentication of remote DomainParticipants.
   The **DDS:Auth:PKI-DH** plugin provides authentication using a trusted Certificate
   Authority (CA) and ECDSA Digital Signature Algorithms to perform the mutual authentication.
-  It also establishes a shared secret using Elliptic Curve Diffie-Hellman (ECDH) Key Agreement protocol.
+  It also establishes a shared secret using either Elliptic Curve Diffie-Hellman (ECDH) or MODP-2048 Diffie-Hellman (DH)
+  as Key Agreement protocol.
 * Access control of entities.
   The **DDS:Access:Permissions** plugin provides access control to DomainParticipants at the DDS Domain and Topic level.
 * Encryption of data.

--- a/docs/fastdds/property_policies/security.rst
+++ b/docs/fastdds/property_policies/security.rst
@@ -42,6 +42,12 @@ The following table outlines the properties used for the :ref:`DDS\:Auth\:PKI-DH
        If the *password* property is not present, then the value supplied in the |br|
        *private_key* property must contain the decrypted private key. |br|
        The *password* property is ignored if the *private_key* is given in PKCS#11 scheme.
+   * - preferred_key_agreement *(optional)*
+     - The preferred algorithm to use for generating the session's shared secret |br|
+       at the end of the authentication phase. Supported values are: |br|
+         a) ``DH``, ``DH+MODP-2048-256`` for  Diffie-Hellman Ephemeral with 2048-bit MODP Group parameters. |br|
+         b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
+	   Will default to ``ECDH`` if the property is not present.
 
 .. note::
   All properties listed above have the ``dds.sec.auth.builtin.PKI-DH."`` prefix.

--- a/docs/fastdds/property_policies/security.rst
+++ b/docs/fastdds/property_policies/security.rst
@@ -42,12 +42,12 @@ The following table outlines the properties used for the :ref:`DDS\:Auth\:PKI-DH
        If the *password* property is not present, then the value supplied in the |br|
        *private_key* property must contain the decrypted private key. |br|
        The *password* property is ignored if the *private_key* is given in PKCS#11 scheme.
-   * - preferred_key_agreement *(optional)*
+   * - ``preferred_key_agreement`` *(optional)*
      - The preferred algorithm to use for generating the session's shared secret |br|
        at the end of the authentication phase. Supported values are: |br|
-         a) ``DH``, ``DH+MODP-2048-256`` for  Diffie-Hellman Ephemeral with 2048-bit MODP Group parameters. |br|
-         b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
-	   Will default to ``ECDH`` if the property is not present.
+       a) ``DH``, ``DH+MODP-2048-256`` for  Diffie-Hellman Ephemeral with 2048-bit MODP Group parameters. |br|
+       b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
+       Will default to ``ECDH`` if the property is not present.
 
 .. note::
   All properties listed above have the ``dds.sec.auth.builtin.PKI-DH."`` prefix.

--- a/docs/fastdds/property_policies/security.rst
+++ b/docs/fastdds/property_policies/security.rst
@@ -47,7 +47,8 @@ The following table outlines the properties used for the :ref:`DDS\:Auth\:PKI-DH
        at the end of the authentication phase. Supported values are: |br|
        a) ``DH``, ``DH+MODP-2048-256`` for  Diffie-Hellman Ephemeral with 2048-bit MODP Group parameters. |br|
        b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
-       Will default to ``ECDH`` if the property is not present.
+       c) ``AUTO`` for selecting the key agreement based on the signature algorithm in the Identity CA's certificate. |br|
+       Will default to ``AUTO`` if the property is not present.
 
 .. note::
   All properties listed above have the ``dds.sec.auth.builtin.PKI-DH."`` prefix.

--- a/docs/fastdds/security/auth_plugin/auth_plugin.rst
+++ b/docs/fastdds/security/auth_plugin/auth_plugin.rst
@@ -62,7 +62,8 @@ The following table outlines the properties used for the DDS:\Auth\:PKI-DH plugi
        at the end of the authentication phase. Supported values are: |br|
        a) ``DH``, ``DH+MODP-2048-256`` for  Diffie-Hellman Ephemeral with 2048-bit MODP Group parameters. |br|
        b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
-       Will default to ``ECDH`` if the property is not present.
+       c) ``AUTO`` for selecting the key agreement based on the signature algorithm in the Identity CA's certificate. |br|
+       Will default to ``AUTO`` if the property is not present.
 
 .. note::
   All listed properties have "dds.sec.auth.builtin.PKI-DH." prefix.

--- a/docs/fastdds/security/auth_plugin/auth_plugin.rst
+++ b/docs/fastdds/security/auth_plugin/auth_plugin.rst
@@ -56,6 +56,12 @@ The following table outlines the properties used for the DDS:\Auth\:PKI-DH plugi
        If the *password* property is not present, then the value supplied in the |br|
        *private_key* property must contain the decrypted private key. |br|
        The *password* property is ignored if the *private_key* is given in PKCS#11 scheme.
+   * - preferred_key_agreement *(optional)*
+     - The preferred algorithm to use for generating the session's shared secret |br|
+       at the end of the authentication phase. Supported values are: |br|
+         a) ``DH``, ``DH+MODP-2048-256`` for  Diffie-Hellman Ephemeral with 2048-bit MODP Group parameters. |br|
+         b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
+	   Will default to ``ECDH`` if the property is not present.
 
 .. note::
   All listed properties have "dds.sec.auth.builtin.PKI-DH." prefix.

--- a/docs/fastdds/security/auth_plugin/auth_plugin.rst
+++ b/docs/fastdds/security/auth_plugin/auth_plugin.rst
@@ -24,7 +24,8 @@ The authentication plugin implemented in Fast DDS is referred to as "DDS:\Auth\:
 `DDS Security <https://www.omg.org/spec/DDS-SECURITY/1.1/>`_ specification.
 The DDS:\Auth\:PKI-DH plugin uses a trusted *Certificate Authority* (CA) and the ECDSA
 Digital Signature Algorithms to perform the mutual authentication.
-It also establishes a shared secret using Elliptic Curve Diffie-Hellman (ECDH) Key Agreement Methods.
+It also establishes a shared secret using either Elliptic Curve Diffie-Hellman (ECDH) or MODP-2048 Diffie-Hellman (DH)
+as Key Agreement protocol.
 This shared secret can be used by other security plugins as :ref:`crypto-aes-gcm-gmac`.
 
 The DDS:\Auth\:PKI-DH authentication plugin, can be activated setting the |DomainParticipantQos|

--- a/docs/fastdds/security/auth_plugin/auth_plugin.rst
+++ b/docs/fastdds/security/auth_plugin/auth_plugin.rst
@@ -59,9 +59,9 @@ The following table outlines the properties used for the DDS:\Auth\:PKI-DH plugi
    * - preferred_key_agreement *(optional)*
      - The preferred algorithm to use for generating the session's shared secret |br|
        at the end of the authentication phase. Supported values are: |br|
-         a) ``DH``, ``DH+MODP-2048-256`` for  Diffie-Hellman Ephemeral with 2048-bit MODP Group parameters. |br|
-         b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
-	   Will default to ``ECDH`` if the property is not present.
+       a) ``DH``, ``DH+MODP-2048-256`` for  Diffie-Hellman Ephemeral with 2048-bit MODP Group parameters. |br|
+       b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
+       Will default to ``ECDH`` if the property is not present.
 
 .. note::
   All listed properties have "dds.sec.auth.builtin.PKI-DH." prefix.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This adds documentation for the new property allowing the selection of the preferred key agreement algorithm.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x

We will backport to 3.1.x, but leaving the default value of the new property to the old behavior.
We will then backport from there into 3.0.x 2.14.x 2.10.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#5413

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
