### PR TITLE
[22353] Document new `transmit_algorithms_as_legacy` on builtin security plugins

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -645,6 +645,9 @@ void dds_domain_examples()
         pqos.properties().properties().emplace_back(
             "dds.sec.auth.builtin.PKI-DH.preferred_key_agreement",
             "ECDH");
+        pqos.properties().properties().emplace_back(
+            "dds.sec.auth.builtin.PKI-DH.transmit_algorithms_as_legacy",
+            "true");
         //!--
     }
     {

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -683,6 +683,9 @@ void dds_domain_examples()
         pqos.properties().properties().emplace_back(
             "dds.sec.access.builtin.Access-Permissions.permissions",
             "file://certs/permissions.smime");
+        pqos.properties().properties().emplace_back(
+            "dds.sec.access.builtin.Access-Permissions.transmit_algorithms_as_legacy",
+            "true");
         //!--
     }
     {

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3054,6 +3054,10 @@
                     <name>dds.sec.auth.builtin.PKI-DH.preferred_key_agreement</name>
                     <value>ECDH</value>
                 </property>
+                <property>
+                    <name>dds.sec.auth.builtin.PKI-DH.transmit_algorithms_as_legacy</name>
+                    <value>true</value>
+                </property>
             </properties>
         </propertiesPolicy>
     </rtps>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3110,6 +3110,10 @@
                     <name>dds.sec.access.builtin.Access-Permissions.permissions</name>
                     <value>file://permissions.smime</value>
                 </property>
+                <property>
+                    <name>dds.sec.access.builtin.Access-Permissions.transmit_algorithms_as_legacy</name>
+                    <value>true</value>
+                </property>
             </properties>
         </propertiesPolicy>
     </rtps>

--- a/docs/fastdds/property_policies/security.rst
+++ b/docs/fastdds/property_policies/security.rst
@@ -49,6 +49,9 @@ The following table outlines the properties used for the :ref:`DDS\:Auth\:PKI-DH
        b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
        c) ``AUTO`` for selecting the key agreement based on the signature algorithm in the Identity CA's certificate. |br|
        Will default to ``AUTO`` if the property is not present.
+   * - ``transmit_algorithms_as_legacy`` *(optional)*
+     - Whether to transmit algorithm identifiers in non-standard legacy format. |br|
+       Will default to ``false`` if the property is not present.
 
 .. note::
   All properties listed above have the ``dds.sec.auth.builtin.PKI-DH."`` prefix.

--- a/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
+++ b/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
@@ -55,7 +55,7 @@ The following table outlines the properties used for the DDS\:Access\:Permission
    * - permissions
      - URI to the Participant permissions document signed by the |br| Permissions CA in S/MIME format. |br|
        Supported URI schemes: file.
-   * - ``transmit_algorithms_as_legacy`` *(optional)*
+   * - transmit_algorithms_as_legacy *(optional)*
      - Whether to transmit algorithm identifiers in non-standard legacy format. |br|
        Will default to ``false`` if the property is not present.
 

--- a/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
+++ b/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
@@ -55,6 +55,9 @@ The following table outlines the properties used for the DDS\:Access\:Permission
    * - permissions
      - URI to the Participant permissions document signed by the |br| Permissions CA in S/MIME format. |br|
        Supported URI schemes: file.
+   * - ``transmit_algorithms_as_legacy`` *(optional)*
+     - Whether to transmit algorithm identifiers in non-standard legacy format. |br|
+       Will default to ``false`` if the property is not present.
 
 .. note::
   All listed properties have "dds.sec.access.builtin.Access-Permissions." prefix.

--- a/docs/fastdds/security/auth_plugin/auth_plugin.rst
+++ b/docs/fastdds/security/auth_plugin/auth_plugin.rst
@@ -64,6 +64,9 @@ The following table outlines the properties used for the DDS:\Auth\:PKI-DH plugi
        b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
        c) ``AUTO`` for selecting the key agreement based on the signature algorithm in the Identity CA's certificate. |br|
        Will default to ``AUTO`` if the property is not present.
+   * - ``transmit_algorithms_as_legacy`` *(optional)*
+     - Whether to transmit algorithm identifiers in non-standard legacy format. |br|
+       Will default to ``false`` if the property is not present.
 
 .. note::
   All listed properties have "dds.sec.auth.builtin.PKI-DH." prefix.

--- a/docs/fastdds/security/auth_plugin/auth_plugin.rst
+++ b/docs/fastdds/security/auth_plugin/auth_plugin.rst
@@ -64,7 +64,7 @@ The following table outlines the properties used for the DDS:\Auth\:PKI-DH plugi
        b) ``ECDH``, ``ECDH+prime256v1-CEUM`` for Elliptic Curve Diffie-Hellman Ephemeral with the NIST P-256 curve. |br|
        c) ``AUTO`` for selecting the key agreement based on the signature algorithm in the Identity CA's certificate. |br|
        Will default to ``AUTO`` if the property is not present.
-   * - ``transmit_algorithms_as_legacy`` *(optional)*
+   * - transmit_algorithms_as_legacy *(optional)*
      - Whether to transmit algorithm identifiers in non-standard legacy format. |br|
        Will default to ``false`` if the property is not present.
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds documentation for the new properties added in https://github.com/eProsima/Fast-DDS/pull/5450

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
