### PR TITLE
Add data-sharing with security incompatiblity warning

### DIFF
--- a/docs/fastdds/security/includes/intro.rst
+++ b/docs/fastdds/security/includes/intro.rst
@@ -44,4 +44,7 @@ and its value (:class:`std::string`).
   However, it is possible to configure basic system security settings, i.e. authentication, access control and
   encryption, to Fast DDS without this knowledge.
 
+.. warning::
+  The use of security plugins is incompatible with :ref:`Data-sharing delivery <datasharing-delivery>`.
+
 The following sections describe how to configure each of these properties to set up the Fast DDS security plugins.

--- a/docs/fastdds/transport/datasharing.rst
+++ b/docs/fastdds/transport/datasharing.rst
@@ -61,7 +61,7 @@ This feature is available only if the following requirements are met:
   i.e., its |TopicDataType::is_bounded-api| member function returns true.
 * The Topic :ref:`is not keyed<dds_layer_topic_keyed_data_types>`.
 * The DataWriter is configured with |PREALLOCATED_MEMORY_MODE-api| or |PREALLOCATED_WITH_REALLOC_MEMORY_MODE-api|.
-* No :ref:`security <security>` plugin is used.
+* No :ref:`security <security>` plugins are used.
 
 There is also a limitation with the DataReader's HistoryQos.
 Using Data-sharing mechanism, the DataWriter's history is shared with the DataReaders.

--- a/docs/fastdds/transport/datasharing.rst
+++ b/docs/fastdds/transport/datasharing.rst
@@ -61,6 +61,7 @@ This feature is available only if the following requirements are met:
   i.e., its |TopicDataType::is_bounded-api| member function returns true.
 * The Topic :ref:`is not keyed<dds_layer_topic_keyed_data_types>`.
 * The DataWriter is configured with |PREALLOCATED_MEMORY_MODE-api| or |PREALLOCATED_WITH_REALLOC_MEMORY_MODE-api|.
+* No :ref:`security <security>` plugin is used.
 
 There is also a limitation with the DataReader's HistoryQos.
 Using Data-sharing mechanism, the DataWriter's history is shared with the DataReaders.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Add missing data-sharing with security incompatiblity warning, both in security and data sharing sections.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
