### PR TITLE
Fixed various typos and unified some formats in documentation

### DIFF
--- a/docs/fastdds/dds_layer/core/status/status.rst
+++ b/docs/fastdds/dds_layer/core/status/status.rst
@@ -230,7 +230,7 @@ List of status data members:
 * |LivelinessChangedStatus::last_publication_handle-api|:
   Handle to the last DataWriter
   whose liveliness status was changed.
-  If no liveliness has ever changed, it will have value ``c_InstanceHandle_Unknown``.
+  If no liveliness has ever changed, it will have value |c_InstanceHandle_Unknown-api|.
 
 
 .. _dds_layer_core_status_requestedDeadlineMissedStatus:
@@ -268,7 +268,7 @@ List of status data members:
 
 * |DeadlineMissedStatus::last_instance_handle-api|:
   Handle to the last instance that missed the deadline.
-  If no deadline was ever missed, it will have value ``c_InstanceHandle_Unknown``.
+  If no deadline was ever missed, it will have value |c_InstanceHandle_Unknown-api|.
 
 .. _dds_layer_core_status_requestedIncompatibleQosStatus:
 
@@ -428,7 +428,7 @@ List of status data members:
 
 * |SampleRejectedStatus::last_instance_handle-api|:
   Handle to the last instance whose sample was rejected.
-  If no sample was ever rejected, it will have value ``c_InstanceHandle_Unknown``.
+  If no sample was ever rejected, it will have value |c_InstanceHandle_Unknown-api|.
 
 .. _dds_layer_core_status_sampleRejectedStatusKind:
 

--- a/docs/fastdds/dds_layer/domain/domainParticipant/createDomainParticipant.rst
+++ b/docs/fastdds/dds_layer/domain/domainParticipant/createDomainParticipant.rst
@@ -18,7 +18,7 @@ Mandatory arguments are:
  * The |DomainId-api| that identifies the domain where the DomainParticipant will be created.
 
  * The :ref:`dds_layer_domainParticipantQos` describing the behavior of the DomainParticipant.
-   If the provided value is :class:`TOPIC_QOS_DEFAULT`, the value of the DomainParticipantQos is used.
+   If the provided value is :class:`PARTICIPANT_QOS_DEFAULT`, the value of the DomainParticipantQos is used.
 
 Alternatively, instead of the two mandatory arguments above, you can use:
 

--- a/docs/fastdds/dds_layer/domain/domainParticipant/domainParticipant.rst
+++ b/docs/fastdds/dds_layer/domain/domainParticipant/domainParticipant.rst
@@ -117,7 +117,7 @@ Default DomainParticipantQos
 The default DomainParticipantQos refers to the value returned by the
 |DomainParticipantFactory::get_default_participant_qos-api| member function on the
 :ref:`dds_layer_domainParticipantFactory` singleton.
-The special value ``PARTICIPANT_QOS_DEFAULT`` can be used as QoS argument on
+The special value :code:`PARTICIPANT_QOS_DEFAULT` can be used as QoS argument on
 |DomainParticipantFactory::create_participant-api|
 or |DomainParticipant::set_qos-api| member functions to indicate that the current default
 DomainParticipantQos should be used.
@@ -137,7 +137,7 @@ DomainParticipant instances.
    :dedent: 8
 
 |DomainParticipantFactory::set_default_participant_qos-api|
-member function also accepts the value ``PARTICIPANT_QOS_DEFAULT``
+member function also accepts the value :code:`PUBLISHER_QOS_DEFAULT`
 as input argument.
 This will reset the current default DomainParticipantQos to the default constructed value
 |DomainParticipantQos::DomainParticipantQos-api|.
@@ -149,7 +149,7 @@ This will reset the current default DomainParticipantQos to the default construc
    :dedent: 8
 
 .. note::
-   The value ``PARTICIPANT_QOS_DEFAULT`` has different meaning depending on where it is used:
+   The value :code:`PUBLISHER_QOS_DEFAULT` has different meaning depending on where it is used:
 
    * On |DomainParticipantFactory::create_participant-api| and |DomainParticipant::set_qos-api| it refers to the
      default DomainParticipantQos as returned by |DomainParticipantFactory::get_default_participant_qos-api|.

--- a/docs/fastdds/dds_layer/domain/domainParticipant/domainParticipant.rst
+++ b/docs/fastdds/dds_layer/domain/domainParticipant/domainParticipant.rst
@@ -137,7 +137,7 @@ DomainParticipant instances.
    :dedent: 8
 
 |DomainParticipantFactory::set_default_participant_qos-api|
-member function also accepts the value :code:`PUBLISHER_QOS_DEFAULT`
+member function also accepts the value :code:`PARTICIPANT_QOS_DEFAULT`
 as input argument.
 This will reset the current default DomainParticipantQos to the default constructed value
 |DomainParticipantQos::DomainParticipantQos-api|.
@@ -149,7 +149,7 @@ This will reset the current default DomainParticipantQos to the default construc
    :dedent: 8
 
 .. note::
-   The value :code:`PUBLISHER_QOS_DEFAULT` has different meaning depending on where it is used:
+   The value :code:`PARTICIPANT_QOS_DEFAULT` has different meaning depending on where it is used:
 
    * On |DomainParticipantFactory::create_participant-api| and |DomainParticipant::set_qos-api| it refers to the
      default DomainParticipantQos as returned by |DomainParticipantFactory::get_default_participant_qos-api|.

--- a/docs/fastdds/dds_layer/publisher/dataWriter/createDataWriter.rst
+++ b/docs/fastdds/dds_layer/publisher/dataWriter/createDataWriter.rst
@@ -15,9 +15,9 @@ Mandatory arguments are:
  * A :ref:`dds_layer_topic_topic` bound to the data type that will be transmitted.
 
  * The :ref:`dds_layer_publisher_dataWriterQos` describing the behavior of the DataWriter.
-   If the provided value is :class:`DATAWRITER_QOS_DEFAULT`,
+   If the provided value is :code:`DATAWRITER_QOS_DEFAULT`,
    the value of the :ref:`dds_layer_defaultDataWriterQos` is used.
-   If the provided value is :class:`DATAWRITER_QOS_USE_TOPIC_QOS`,
+   If the provided value is :code:`DATAWRITER_QOS_USE_TOPIC_QOS`,
    the values of the default QoS and the provided TopicQoS are used, whereby any policy
    that is set on the TopicQoS overrides the corresponding policy on the default QoS.
 

--- a/docs/fastdds/dds_layer/publisher/dataWriter/dataWriter.rst
+++ b/docs/fastdds/dds_layer/publisher/dataWriter/dataWriter.rst
@@ -131,8 +131,8 @@ DataWriter instances.
    :end-before: //!
    :dedent: 8
 
-|Publisher::set_default_datawriter_qos-api| member function also accepts the special value :code:`DATAWRITER_QOS_DEFAULT`
-as input argument.
+|Publisher::set_default_datawriter_qos-api| member function also accepts the special value
+:code:`DATAWRITER_QOS_DEFAULT` as input argument.
 This will reset the current default DataWriterQos to default constructed
 value |DataWriterQos::DataWriterQos-api|.
 

--- a/docs/fastdds/dds_layer/publisher/dataWriter/dataWriter.rst
+++ b/docs/fastdds/dds_layer/publisher/dataWriter/dataWriter.rst
@@ -91,7 +91,7 @@ default values.
 .. note::
 
    Reliability kind (whether the publication is reliable or best effort) is not mutable.
-   However, the ``max_blocking_time`` data member of |ReliabilityQosPolicy| can be modified any time.
+   However, the :code:`max_blocking_time` data member of |ReliabilityQosPolicy| can be modified any time.
 .. note::
 
    Not all data members of RTPSReliableWriterQos are mutable, please refer to |RTPSReliableWriterQos|
@@ -114,7 +114,7 @@ Default DataWriterQos
 
 The default :ref:`dds_layer_publisher_dataWriterQos` refers to the value returned by the
 |Publisher::get_default_datawriter_qos-api| member function on the Publisher instance.
-The special value :class:`DATAWRITER_QOS_DEFAULT` can be used as QoS argument on |Publisher::create_datawriter-api|
+The special value :code:`DATAWRITER_QOS_DEFAULT` can be used as QoS argument on |Publisher::create_datawriter-api|
 or |DataWriter::set_qos-api| member functions to indicate that the current default
 DataWriterQos should be used.
 
@@ -131,7 +131,7 @@ DataWriter instances.
    :end-before: //!
    :dedent: 8
 
-|Publisher::set_default_datawriter_qos-api| member function also accepts the special value ``DATAWRITER_QOS_DEFAULT``
+|Publisher::set_default_datawriter_qos-api| member function also accepts the special value :code:`DATAWRITER_QOS_DEFAULT`
 as input argument.
 This will reset the current default DataWriterQos to default constructed
 value |DataWriterQos::DataWriterQos-api|.
@@ -143,7 +143,7 @@ value |DataWriterQos::DataWriterQos-api|.
    :dedent: 8
 
 .. note::
-   The value ``DATAWRITER_QOS_DEFAULT`` has different meaning depending on where it is used:
+   The value :code:`DATAWRITER_QOS_DEFAULT` has different meaning depending on where it is used:
 
    * On |Publisher::create_datawriter-api| and |DataWriter::set_qos-api| it refers to the default DataWriterQos
      as returned by |Publisher::get_default_datawriter_qos-api|.

--- a/docs/fastdds/dds_layer/publisher/publisher/createPublisher.rst
+++ b/docs/fastdds/dds_layer/publisher/publisher/createPublisher.rst
@@ -13,7 +13,7 @@ DomainParticipant instance, that acts as a factory for the Publisher.
 Mandatory arguments are:
 
  * The :ref:`dds_layer_publisher_publisherQos` describing the behavior of the Publisher.
-   If the provided value is :class:`PUBLISHER_QOS_DEFAULT`,
+   If the provided value is :code:`PUBLISHER_QOS_DEFAULT`,
    the value of the :ref:`dds_layer_defaultPublisherQos` is used.
 
 Optional arguments are:

--- a/docs/fastdds/dds_layer/publisher/publisher/publisher.rst
+++ b/docs/fastdds/dds_layer/publisher/publisher/publisher.rst
@@ -58,7 +58,7 @@ Default PublisherQos
 
 The default :ref:`dds_layer_publisher_publisherQos` refers to the value returned by the
 |DomainParticipant::get_default_publisher_qos-api| member function on the DomainParticipant instance.
-The special value :class:`PUBLISHER_QOS_DEFAULT` can be used as QoS argument on
+The special value :code:`PUBLISHER_QOS_DEFAULT` can be used as QoS argument on
 |DomainParticipant::create_publisher-api| or |Publisher::set_qos-api| member functions to indicate that the current
 default PublisherQos should be used.
 
@@ -76,7 +76,7 @@ Modifying the default PublisherQos will not affect already existing
    :dedent: 8
 
 |DomainParticipant::set_default_publisher_qos-api| member function also accepts the special value
-``PUBLISHER_QOS_DEFAULT`` as input argument.
+:code:`PUBLISHER_QOS_DEFAULT` as input argument.
 This will reset the current default PublisherQos to default constructed
 value |PublisherQos::PublisherQos-api|.
 
@@ -87,7 +87,7 @@ value |PublisherQos::PublisherQos-api|.
    :dedent: 8
 
 .. note::
-   The value ``PUBLISHER_QOS_DEFAULT`` has different meaning depending on where it is used:
+   The value :code:`PUBLISHER_QOS_DEFAULT` has different meaning depending on where it is used:
 
    * On |DomainParticipant::create_publisher-api| and |Publisher::set_qos-api| it refers to the default
      :ref:`dds_layer_publisher_publisherQos`.

--- a/docs/fastdds/dds_layer/subscriber/dataReader/createDataReader.rst
+++ b/docs/fastdds/dds_layer/subscriber/dataReader/createDataReader.rst
@@ -15,9 +15,9 @@ Mandatory arguments are:
  * A :ref:`dds_layer_topic_topic` bound to the data type that will be transmitted.
 
  * The :ref:`dds_layer_subscriber_dataReaderQos` describing the behavior of the DataReader.
-   If the provided value is :class:`DATAREADER_QOS_DEFAULT`,
+   If the provided value is :code:`DATAREADER_QOS_DEFAULT`,
    the value of the :ref:`dds_layer_defaultDataReaderQos` is used.
-   If the provided value is :class:`DATAREADER_QOS_USE_TOPIC_QOS`,
+   If the provided value is :code:`DATAREADER_QOS_USE_TOPIC_QOS`,
    the values of the default QoS and the provided TopicQoS are used, whereby any policy
    that is set on the TopicQoS overrides the corresponding policy on the default QoS.
 

--- a/docs/fastdds/dds_layer/subscriber/dataReader/dataReader.rst
+++ b/docs/fastdds/dds_layer/subscriber/dataReader/dataReader.rst
@@ -120,7 +120,7 @@ Default DataReaderQos
 The default DataReaderQos refers to the value returned by the
 |Subscriber::get_default_datareader_qos-api| member function on the
 :ref:`dds_layer_subscriber_subscriber` instance.
-The special value ``DATAREADER_QOS_DEFAULT`` can be used as QoS argument on
+The special value :code:`DATAREADER_QOS_DEFAULT` can be used as QoS argument on
 |Subscriber::create_datareader-api| or
 |DataReader::set_qos-api| member functions to indicate that the current default
 DataReaderQos should be used.
@@ -140,7 +140,7 @@ Modifying the default DataReaderQos will not affect already existing
    :dedent: 8
 
 |Subscriber::set_default_datareader_qos-api| member function also accepts
-the special value ``DATAREADER_QOS_DEFAULT`` as input argument.
+the special value :code:`DATAREADER_QOS_DEFAULT` as input argument.
 This will reset the current default DataReaderQos to default constructed
 value |DataReaderQos::DataReaderQos-api|.
 
@@ -151,7 +151,7 @@ value |DataReaderQos::DataReaderQos-api|.
    :dedent: 8
 
 .. note::
-   The value ``DATAREADER_QOS_DEFAULT`` has different meaning depending on where it is used:
+   The value :code:`DATAREADER_QOS_DEFAULT` has different meaning depending on where it is used:
 
    * On |Subscriber::create_datareader-api|
      and |DataReader::set_qos-api| it refers to the default

--- a/docs/fastdds/dds_layer/subscriber/sampleInfo/sampleInfo.rst
+++ b/docs/fastdds/dds_layer/subscriber/sampleInfo/sampleInfo.rst
@@ -8,7 +8,7 @@ SampleInfo
 
 When a sample is retrieved from the :ref:`dds_layer_subscriber_dataReader`, in addition to the sample data,
 a |SampleInfo-api| instance is returned.
-This object contains additional information that complements the returned data value and helps on it interpretation.
+This object contains additional information that complements the returned data value and helps on its interpretation.
 For example, if the :ref:`dds_layer_subscriber_sampleInfo_validdata` value is ``false``, the
 DataReader is not informing the application about a new value in the data instance,
 but a change on its status, and the returned data value must be discarded.

--- a/docs/fastdds/dds_layer/subscriber/subscriber/createSubscriber.rst
+++ b/docs/fastdds/dds_layer/subscriber/subscriber/createSubscriber.rst
@@ -13,7 +13,7 @@ DomainParticipant instance, that acts as a factory for the Subscriber.
 Mandatory arguments are:
 
  * The :ref:`dds_layer_subscriber_subscriberQos` describing the behavior of the Subscriber.
-   If the provided value is :class:`SUBSCRIBER_QOS_DEFAULT`,
+   If the provided value is :code:`SUBSCRIBER_QOS_DEFAULT`,
    the value of the :ref:`dds_layer_defaultSubscriberQos` is used.
 
 Optional arguments are:

--- a/docs/fastdds/dds_layer/subscriber/subscriber/subscriber.rst
+++ b/docs/fastdds/dds_layer/subscriber/subscriber/subscriber.rst
@@ -59,7 +59,7 @@ Default SubscriberQos
 The default :ref:`dds_layer_subscriber_subscriberQos` refers to the value returned by the
 |DomainParticipant::get_default_subscriber_qos-api| member function
 on the :ref:`dds_layer_domainParticipant` instance.
-The special value ``SUBSCRIBER_QOS_DEFAULT`` can be used as QoS argument on
+The special value :code:`SUBSCRIBER_QOS_DEFAULT` can be used as QoS argument on
 |DomainParticipant::create_subscriber-api| or |Subscriber::set_qos-api|
 member functions to indicate that the current default SubscriberQos
 should be used.
@@ -79,7 +79,7 @@ Subscriber instances.
    :dedent: 8
 
 |DomainParticipant::set_default_subscriber_qos-api| member function also accepts
-the special value ``SUBSCRIBER_QOS_DEFAULT`` as input argument.
+the special value :code:`SUBSCRIBER_QOS_DEFAULT` as input argument.
 This will reset the current default SubscriberQos to default constructed
 value |SubscriberQos::SubscriberQos-api|.
 
@@ -90,7 +90,7 @@ value |SubscriberQos::SubscriberQos-api|.
    :dedent: 8
 
 .. note::
-   The value ``SUBSCRIBER_QOS_DEFAULT`` has different meaning depending on where it is used:
+   The value :code:`SUBSCRIBER_QOS_DEFAULT` has different meaning depending on where it is used:
 
    * On |DomainParticipant::create_subscriber-api| and |Subscriber::set_qos-api| it refers to the default
      SubscriberQos as returned by |DomainParticipant::get_default_subscriber_qos-api|.

--- a/docs/fastdds/dds_layer/topic/topic/createTopic.rst
+++ b/docs/fastdds/dds_layer/topic/topic/createTopic.rst
@@ -17,7 +17,7 @@ Mandatory arguments are:
  * The name of the registered :ref:`data type<dds_layer_definition_data_types>` that will be transmitted.
 
  * The :ref:`dds_layer_topic_topicQos` describing the behavior of the Topic.
-   If the provided value is :class:`TOPIC_QOS_DEFAULT`,
+   If the provided value is :code:`TOPIC_QOS_DEFAULT`,
    the value of the :ref:`dds_layer_defaultTopicQos` is used.
 
 Optional arguments are:

--- a/docs/fastdds/dds_layer/topic/topic/topic.rst
+++ b/docs/fastdds/dds_layer/topic/topic/topic.rst
@@ -84,7 +84,7 @@ Default TopicQos
 
 The default :ref:`dds_layer_topic_topicQos` refers to the value returned by the
 |DomainParticipant::get_default_topic_qos-api| member function on the :ref:`dds_layer_domainParticipant` instance.
-The special value ``TOPIC_QOS_DEFAULT`` can be used as QoS argument on |DomainParticipant::create_topic-api|
+The special value :code:`TOPIC_QOS_DEFAULT` can be used as QoS argument on |DomainParticipant::create_topic-api|
 or |Topic::set_qos-api| member functions to indicate that the current default TopicQos
 should be used.
 
@@ -101,7 +101,7 @@ instances.
    :end-before: //!
    :dedent: 8
 
-|DomainParticipant::get_default_topic_qos-api| member function also accepts the value ``TOPIC_QOS_DEFAULT``
+|DomainParticipant::get_default_topic_qos-api| member function also accepts the value :code:`TOPIC_QOS_DEFAULT`
 as input argument.
 This will reset the current default TopicQos to default constructed
 value |TopicQos::TopicQos-api|.
@@ -113,7 +113,7 @@ value |TopicQos::TopicQos-api|.
    :dedent: 8
 
 .. note::
-   The value ``TOPIC_QOS_DEFAULT`` has different meaning depending on where it is used:
+   The value :code:`TOPIC_QOS_DEFAULT` has different meaning depending on where it is used:
 
    * On |DomainParticipant::create_topic-api| and |Topic::set_qos-api| it refers to the default TopicQos
      as returned by |DomainParticipant::get_default_topic_qos-api|.

--- a/docs/fastdds/discovery/discovery_server.rst
+++ b/docs/fastdds/discovery/discovery_server.rst
@@ -397,7 +397,7 @@ discovery.
 
 As in SDP, when using this feature, the Domain Governance Document of all *clients* and *servers* connecting to a
 *server* must match that of the *server*, which implies that all |DomainParticipants| belonging to the same Discovery
-Sever network must configure the discovery protection in the same manner.
+Server network must configure the discovery protection in the same manner.
 
 Although the *server* mediates the discovery process and creates connections between *clients*, the *clients* themselves
 still go through the PKI (Public Key Infrastructure) exchange in order to have a secure communication between them.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Fixed some typos found while reading the documentation, fixed some links to c-InstanceHandle_Unknown and unified the format for the references to the different QOS_DEFAULT options.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
