### PR TITLE
[22012] Update migration guide removing things not related to application developer

### DIFF
--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -146,6 +146,8 @@ Step 5: Migrate public headers
    Also, the ``fixed_size_string.hpp`` implementation has been migrated from ``fastrtps/utils/fixed_size_string.hpp``
    to ``fastcdr/cdr/fixed_size_string.hpp``.
 
+   .. TODO:: Fix this table, ``fastdds/rtps/DomainParticipantQos.hpp`` has wrong path and doesn't include the content.
+
 2. File extensions:
 
    Rename file extensions from `.h` to `.hpp`.
@@ -208,6 +210,8 @@ If your project previously included any of these headers, you will need to modif
 Since these headers are now private, you should replace their usage with public alternatives or refactor the
 related code to ensure it does not depend on private headers.
 
+.. TODO:: Add a note about which headers to use instead of the private ones.
+  
 .. _step-7-update-api-methods:
 
 Step 7: Update API methods
@@ -394,6 +398,9 @@ your code to reflect these changes:
 
 Step 9: Examples refactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. TODO:: What to do here? Write which examples in 2 turned into which examples in 3?
+   A lot of the info seems too much.
 
 All examples have been refactored to follow a consistent structure across the Fast DDS project.
 This includes renaming files, restructuring classes, and updating the overall format.

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -75,7 +75,7 @@ Step 4: Apply namespace changes
    * Update all ``eprosima::fastrtps::`` namespace references to ``eprosima::fastdds::``.
    * Move built-in topics ``SubscriptionBuiltinTopicData``, ``PublicationBuiltinTopicData``, and
      ``ParticipantBuiltinTopicData`` from ``fastdds::dds::builtin::`` to ``fastdds::dds::``.
-   * Move ``Duration_t`` and ``c_TimeInfinite`` references to ``dds::``.
+   * Move ``Duration_t`` and ``c_TimeInfinite`` references from ``eprosima::fastdds::`` to ``eprosima::fastdds::dds``.
    * Move ``Time_t.hpp`` references from ``eprosima::fastdds::`` to ``eprosima::fastdds::dds``.
 
    Ensure you update these namespace references across your code to avoid compilation errors.

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -27,20 +27,18 @@ The following steps describe the possible changes that your project may require 
 
 .. _step-1-update-the-package-name-and-cmake-configuration:
 
-Step 1: Update the package name and CMake configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Step 1: Update the package name and CMake and Colcon configurations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1. CMake project name: Rename the CMake project from ``fastrtps`` to ``fastdds``.
-2. Environment variables:
+1. CMake project name: Rename all instances in the CMake project from ``fastrtps`` to ``fastdds``. For example, 
+   update ``target_link_libraries(fastrtps)`` to ``target_link_libraries(fastdds)``, and ``if(NOT fastrtps_FOUND)`` to
+   ``if(NOT fastdds_FOUND)``.
+2. If using Colcon, update the package name in ``colcon.pkg`` from ``fastrtps`` to ``fastdds``.
+3. Environment variables:
 
    * Rename ``FASTRTPS_DEFAULT_PROFILES_FILE`` to ``FASTDDS_DEFAULT_PROFILES_FILE``.
-   * The configuration file for loading profiles is now ``DEFAULT_FASTDDS_PROFILES.xml``.
-
-3. Update CMake file names on Windows:
-
-   * Rename ``fastrtps.manifest.in`` to ``fastdds.manifest.in``.
-   * Rename ``fastrtps-config.cmake`` to ``fastdds-config.cmake``.
-   * Rename ``fastrtps.rc`` to ``fastdds.rc``.
+   * The configuration file for loading profiles has been renamed from ``DEFAULT_FASTRTPS_PROFILES.xml`` to 
+     ``DEFAULT_FASTDDS_PROFILES.xml``.
 
 .. _step-2-update-dependencies:
 

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -30,7 +30,7 @@ The following steps describe the possible changes that your project may require 
 Step 1: Update the package name and CMake configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1. CMake project name: Rename all instances in the CMake project from ``fastrtps`` to ``fastdds``. For example, 
+1. CMake project name: Rename all instances in the CMake project from ``fastrtps`` to ``fastdds``. For example,
    update ``target_link_libraries(fastrtps)`` to ``target_link_libraries(fastdds)``, and ``if(NOT fastrtps_FOUND)`` to
    ``if(NOT fastdds_FOUND)``.
 2. Environment variables:

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -204,11 +204,6 @@ Since they are no longer public, it is not possible to include them in external 
 * TypeLookupService.hpp
 
 If your project previously included any of these headers, you will need to modify your implementation.
-Since these headers are now private, you should replace their usage with public alternatives or refactor the
-related code to ensure it does not depend on private headers.
-
-.. TODO:: Add a note about which headers to use instead of the private ones, since we mention that they should 
-  be replaced with public alternatives.
   
 .. _step-7-update-api-methods:
 

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -143,7 +143,8 @@ Step 5: Migrate public headers
       * - ``fastdds/rtps/common/Time_t.hpp in namespace{fastdds}``
         - ``fastdds/dds/core/Time_t.hpp in namespace{fastdds::dds}``
 
-   Also, the ``fixed_size_string.hpp`` implementation has been migrated from Fast DDS package to Fast CDR.
+   Also, the ``fixed_size_string.hpp`` implementation has been migrated from ``fastrtps/utils/fixed_size_string.hpp``
+   to ``fastcdr/cdr/fixed_size_string.hpp``.
 
 2. File extensions:
 
@@ -407,6 +408,8 @@ All the examples have been refactored to follow the same structure:
 * Detailed and well-formed README.md with example explanation.
 * Example structured in applications, stopped by ``SIGTERM`` signal.
 
+Please refactor the examples in your project to match the new format.
+
 `Hello World <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/hello_world>`_
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
@@ -414,8 +417,7 @@ Refactor the HelloWorld example with the current new example format.
 In this hello world example, the key changes are:
 
 * The XML profile is loaded from the environment (if defined), and the `--env` CLI option has been removed.
-* Add a subscriber implementing the waitsets mechanism.
-* Provide XML profiles examples targeting several scenarios (e.g., SampleConfig_Controller, Events, Multimedia).
+* Added a subscriber implementing the waitsets mechanism.
 
 `X-Types Examples <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/xtypes>`_
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -27,14 +27,13 @@ The following steps describe the possible changes that your project may require 
 
 .. _step-1-update-the-package-name-and-cmake-configuration:
 
-Step 1: Update the package name and CMake and Colcon configurations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Step 1: Update the package name and CMake configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1. CMake project name: Rename all instances in the CMake project from ``fastrtps`` to ``fastdds``. For example, 
    update ``target_link_libraries(fastrtps)`` to ``target_link_libraries(fastdds)``, and ``if(NOT fastrtps_FOUND)`` to
    ``if(NOT fastdds_FOUND)``.
-2. If using Colcon, update the package name in ``colcon.pkg`` from ``fastrtps`` to ``fastdds``.
-3. Environment variables:
+2. Environment variables:
 
    * Rename ``FASTRTPS_DEFAULT_PROFILES_FILE`` to ``FASTDDS_DEFAULT_PROFILES_FILE``.
    * The configuration file for loading profiles has been renamed from ``DEFAULT_FASTRTPS_PROFILES.xml`` to 
@@ -208,7 +207,8 @@ If your project previously included any of these headers, you will need to modif
 Since these headers are now private, you should replace their usage with public alternatives or refactor the
 related code to ensure it does not depend on private headers.
 
-.. TODO:: Add a note about which headers to use instead of the private ones.
+.. TODO:: Add a note about which headers to use instead of the private ones, since we mention that they should 
+  be replaced with public alternatives.
   
 .. _step-7-update-api-methods:
 
@@ -397,121 +397,8 @@ your code to reflect these changes:
 Step 9: Examples refactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. TODO:: What to do here? Write which examples in 2 turned into which examples in 3?
-   A lot of the info seems too much.
-
-All examples have been refactored to follow a consistent structure across the Fast DDS project.
-This includes renaming files, restructuring classes, and updating the overall format.
-Additionally, it is important to note that some examples have been removed, renamed, or had significant changes
-to their options and configurations.
-If you have integrated any of these examples into your own implementation, carefully review the updated examples
-to ensure compatibility with your project.
-
-All the examples have been refactored to follow the same structure:
-
-* File names, guards, and classes follow new format.
-* Detailed and well-formed README.md with example explanation.
-* Example structured in applications, stopped by ``SIGTERM`` signal.
-
-Please refactor the examples in your project to match the new format.
-
-`Hello World <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/hello_world>`_
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Refactor the HelloWorld example with the current new example format.
-In this hello world example, the key changes are:
-
-* The XML profile is loaded from the environment (if defined), and the `--env` CLI option has been removed.
-* Added a subscriber implementing the waitsets mechanism.
-
-`X-Types Examples <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/xtypes>`_
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-In this X-Types example, a type is defined at runtime on the publisher side using the Dynamic Types API.
-The subscriber discovers the type, creates a reader for it, and prints the received data.
-This example is type compatible with the Hello World example.
-
-`Configuration <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/configuration>`_
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-In the configuration example, the key changes are:
-
-* Included LargeData as an option (builtin transport argument).
-* Included all previous QoS examples:
-
-  - Deadline
-  - Disable positive ACKs
-  - Lifespan
-  - Liveliness
-  - Ownership (strength)
-  - Partitions
-
-`Content Filter <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/content_filter>`_
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Refactor the ContentFilteresTopicExample example with the current new example format.
-In this content filter example, the main changes are:
-
-* Added option to select filter type: Default, Custom, or None.
-* Customizable lower-bound and upper-bound options of the filter as arguments.
-
-  - For the Custom filter, they represent the maximum and minimum values of the message indexes that are filtered out
-    through the filter.
-  - For the Default filter, they represent the maximum and minimum value message indexes that are read.
-
-`Custom Payload Pool <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/custom_payload_pool>`_
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Refactor the CustomPayloadPoolExample example with the current new example format.
-
-`Delivery Mechanism <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/delivery_mechanisms>`_
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-In this delivery mechanisms example, the key changes are:
-
-* Loans and data-sharing compatible: bounded types, final extensibility.
-* Loans mechanism for data management.
-* Option to select all delivery mechanisms.
-
-`Discovery Server <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/discovery_server>`_
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Refactor the DiscoveryServerExample example with the current new example format.
-
-`Flow Controller <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/flow_control>`_
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Refactor the FlowControlExample example with the current new example format.
-In this Flow Controller example, the key changes are:
-
-* Publishers continuously send samples. The user can set the number of samples to send.
-* User can set the following QoS and properties for the Flow Controller:
-
-  - Scheduler policy used by the flow controller.
-  - Maximum number of bytes to be sent to the network per period.
-  - Period of time in milliseconds during which the flow controller is allowed to send the maximum number of bytes
-    per period.
-  - Property `fastdds.sfc.priority`.
-  - Property `fastdds.sfc.bandwidth_reservation`.
-
-`Request-Reply <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/request_reply>`_
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Refactor the Request-Reply example with the current new example format.
-
-`Static EDP Discovery <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/static_edp_discovery>`_
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Refactor the Static EDP Discovery example with the new example format.
-
-`Security <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/security>`_
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Refactor the SecureHelloWorld example with the current new example format.
-
-`RTPS Entities <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/rtps>`_
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Refactor the rtps/Registered example with the current new example format.
-This RTPS example demonstrates a basic RTPS deployment.
-The main change is that serialization and deserialization are done with overload methods from fastcdr.
+All examples in the Fast DDS project have been refactored to follow a consistent structure, having renamed files,
+restructured classes, and updated the overall format. Additionally, some examples have been removed, renamed, combined
+or had significant changes to their options and configurations. If you have integrated any example into your
+own implementation, carefully review the updated examples to ensure compatibility with your project. As reference,
+consider the example `Configuration <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/configuration>`.

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -36,7 +36,7 @@ Step 1: Update the package name and CMake configuration
 2. Environment variables:
 
    * Rename ``FASTRTPS_DEFAULT_PROFILES_FILE`` to ``FASTDDS_DEFAULT_PROFILES_FILE``.
-   * The configuration file for loading profiles has been renamed from ``DEFAULT_FASTRTPS_PROFILES.xml`` to 
+   * The configuration file for loading profiles has been renamed from ``DEFAULT_FASTRTPS_PROFILES.xml`` to
      ``DEFAULT_FASTDDS_PROFILES.xml``.
 
 .. _step-2-update-dependencies:
@@ -204,7 +204,7 @@ Since they are no longer public, it is not possible to include them in external 
 * TypeLookupService.hpp
 
 If your project previously included any of these headers, you will need to modify your implementation.
-  
+
 .. _step-7-update-api-methods:
 
 Step 7: Update API methods

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -70,9 +70,9 @@ Step 4: Apply namespace changes
 
 1. Namespace migration:
 
-   * Update all ``eprosima::fastrtps::`` namespace references to ``eprosima::fastdds::``.
+   * First, update all ``eprosima::fastrtps::`` namespace references to ``eprosima::fastdds::``.
    * Move built-in topics ``SubscriptionBuiltinTopicData``, ``PublicationBuiltinTopicData``, and
-     ``ParticipantBuiltinTopicData`` from ``fastdds::dds::builtin::`` to ``fastdds::dds::``.
+     ``ParticipantBuiltinTopicData`` from ``eprosima::fastdds::dds::builtin::`` to ``eprosima::fastdds::rtps::``.
    * Move ``Duration_t`` and ``c_TimeInfinite`` references from ``eprosima::fastdds::`` to ``eprosima::fastdds::dds``.
    * Move ``Time_t.hpp`` references from ``eprosima::fastdds::`` to ``eprosima::fastdds::dds``.
 

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -401,4 +401,4 @@ All examples in the Fast DDS project have been refactored to follow a consistent
 restructured classes, and updated the overall format. Additionally, some examples have been removed, renamed, combined
 or had significant changes to their options and configurations. If you have integrated any example into your
 own implementation, carefully review the updated examples to ensure compatibility with your project. As reference,
-consider the example `Configuration <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/configuration>`.
+consider the example `Configuration <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/configuration>`_.

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -393,7 +393,6 @@ Step 9: Examples refactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All examples in the Fast DDS project have been refactored to follow a consistent structure, having renamed files,
-restructured classes, and updated the overall format. Additionally, some examples have been removed, renamed, combined
-or had significant changes to their options and configurations. If you have integrated any example into your
+restructured classes, and updated the overall format. If you have integrated any example into your
 own implementation, carefully review the updated examples to ensure compatibility with your project. As reference,
 consider the example `Configuration <https://github.com/eProsima/Fast-DDS/tree/master/examples/cpp/configuration>`_.

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -107,7 +107,7 @@ Step 5: Migrate public headers
       * - ``fastrtps/eProsima_auto_link.h``
         - ``fastdds/fastdds_auto_link.hpp``
       * - ``fastrtps/attributes/ParticipantAttributes.h``
-        - ``fastdds/rtps/DomainParticipantQos.hpp``
+        - ``fastdds/dds/domain/qos/DomainParticipantExtendedQos.hpp``
       * - ``fastrtps/Domain.h``
         - ``fastdds/dds/domain/DomainParticipantFactory.hpp``
       * - ``fastrtps/log/Log.h``
@@ -145,8 +145,6 @@ Step 5: Migrate public headers
 
    Also, the ``fixed_size_string.hpp`` implementation has been migrated from ``fastrtps/utils/fixed_size_string.hpp``
    to ``fastcdr/cdr/fixed_size_string.hpp``.
-
-   .. TODO:: Fix this table, ``fastdds/rtps/DomainParticipantQos.hpp`` has wrong path and doesn't include the content.
 
 2. File extensions:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Modified the migration guide from Fast 2 to Fast 3. Eliminated some lines that referred to private files or internal tasks, and clarified a few points. Gave some change instructions a more clear "from ...  to ..." format. Almost completely deleted step 9 as for the users the examples' fate should matter little.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
-  _N/A_ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
