### PR TITLE
[21861] Enable Datasharing segments clean from CLI

### DIFF
--- a/docs/fastddscli/cli/cli.rst
+++ b/docs/fastddscli/cli/cli.rst
@@ -343,6 +343,10 @@ Zombie files are memory blocks that were reserved by shared memory and are no lo
 memory resources.
 This tool finds and frees those memory allocations.
 
+It is also possible to clean :ref:`Data Sharing<datasharing-delivery>` segments when the ``--force`` option is used.
+However, this option should be used with caution, as it will remove all Data Sharing segments, including the ones
+that are being used by active applications.
+
 .. code-block:: bash
 
     fastdds shm [<shm-command>]
@@ -356,8 +360,15 @@ This tool finds and frees those memory allocations.
 +--------------------------+-------------------------------------------------------------------------------------------+
 | Option                   | Description                                                                               |
 +==========================+===========================================================================================+
-| ``-h  -help``            | Produce help message.                                                                     |
+| ``-h  --help``           | Produce help message.                                                                     |
 +--------------------------+-------------------------------------------------------------------------------------------+
+| ``-f  --force``          | Force the deletion of data sharing segments.                                              |
++--------------------------+-------------------------------------------------------------------------------------------+
+
+.. warning::
+     Running this command with the ``--force`` option will remove all Data Sharing segments, including the ones that
+     are being used by active applications. Use this option only when there are no running Fast DDS applications,
+     as it might raise errors if the segments are still in use.
 
 .. _cli_xml:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR updates CLI documentation regarding the `shm` command with the new option to delete data sharing segments.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* https://github.com/eProsima/Fast-DDS/pull/5549


## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
