### PR TITLE
[22427] Fast DDS EASY_MODE - Feature - XMLRPC Server

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Install Python dependencies
         uses: eProsima/eProsima-CI/multiplatform/install_python_packages@v0
         with:
-          packages: vcstool xmlschema
+          packages: vcstool xmlschema psutil
           upgrade: false
 
       - name: Install Fast DDS Docs required python packages

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -737,6 +737,7 @@
 .. |PortParameters::offsetd1-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd1<eprosima::fastdds::rtps::PortParameters::offsetd1>`
 .. |PortParameters::offsetd2-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd2<eprosima::fastdds::rtps::PortParameters::offsetd2>`
 .. |PortParameters::offsetd3-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd3<eprosima::fastdds::rtps::PortParameters::offsetd3>`
+.. |PortParameters::offsetd4-qos-api| replace:: :cpp:member:`wire_protocol().port.offsetd4<eprosima::fastdds::rtps::PortParameters::offsetd4>`
 
 .. |WriterResourceLimitsQos-api| replace:: :cpp:class:`WriterResourceLimitsQos<eprosima::fastdds::dds::WriterResourceLimitsQos>`
 .. |WriterResourceLimitsQos::matched_subscriber_allocation-api| replace:: :cpp:member:`matched_subscriber_allocation<eprosima::fastdds::dds::WriterResourceLimitsQos::matched_subscriber_allocation>`

--- a/docs/fastdds/discovery/discovery_server.rst
+++ b/docs/fastdds/discovery/discovery_server.rst
@@ -17,7 +17,7 @@ ease Discovery Server setup and testing.
 .. note::
 
   :ref:`DDS Domain <dds_layer_domain>` concept does not apply when enabling the default Discovery Server mechanism,
-  but it applies when using :ref:`EASY_MODE<env_vars_easy_mode>`.
+  but it applies when using :ref:`ROS2_EASY_MODE<env_vars_easy_mode>`.
 
 .. contents::
     :local:

--- a/docs/fastdds/discovery/discovery_server.rst
+++ b/docs/fastdds/discovery/discovery_server.rst
@@ -50,6 +50,7 @@ In this architecture there are several key concepts to understand:
     * A *server* also announces the existence of a new *server* to its known *servers*, and vice versa.
       In this way, a new server can connect to every other existing *server* in the network by just knowing the
       existence of one of them.
+      In this way, a mesh topology between servers is created with minimal configuration.
     * The discovery information that is redistributed might come from a **direct** *client* connected to the |SERVER|,
       or from another *server* that is redirecting the discovery data from **its** *clients*.
     * Known *servers* will receive all the information from the **direct** *clients* known by the *server* and the

--- a/docs/fastdds/discovery/discovery_server.rst
+++ b/docs/fastdds/discovery/discovery_server.rst
@@ -16,7 +16,8 @@ ease Discovery Server setup and testing.
 
 .. note::
 
-  :ref:`DDS Domain <dds_layer_domain>` concept does not apply when enabling the Discovery Server mechanism.
+  :ref:`DDS Domain <dds_layer_domain>` concept does not apply when enabling the default Discovery Server mechanism,
+  but it applies when using :ref:`EASY_MODE<env_vars_easy_mode>`.
 
 .. contents::
     :local:

--- a/docs/fastdds/env_vars/env_vars.rst
+++ b/docs/fastdds/env_vars/env_vars.rst
@@ -278,17 +278,17 @@ which will try to connect to another Discovery Server located in the host ``10.0
 
 .. code-block:: bash
 
-   $> export EASY_MODE=10.0.0.1
+    export EASY_MODE=10.0.0.1
 
 The port of the Discovery Server is calculated using the rules explained in the :ref:`listening_locators_defaultPorts`.
-The transports configured in this new mode include :ref:`TCP<transport_tcp_tcp>` for discovery and user data and
-:ref:`Shared Memory<transport_sharedMemory_sharedMemory>` for user data.
+The transports configured in this new mode include :ref:`UDP<transport_udp_udp>` unicast for discovery and
+:ref:`TCP<transport_tcp_tcp>` and :ref:`Shared Memory<transport_sharedMemory_sharedMemory>` for user data.
 
 A detailed tutorial can be found in the
 `Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__ documentation.
 
 .. warning::
-    Discovery Server ``EASY_MODE`` is not yet available for Windows.
+    Discovery Server ``EASY_MODE`` is not yet available for Windows platforms.
 
 .. _env_vars_ros_super_client:
 

--- a/docs/fastdds/env_vars/env_vars.rst
+++ b/docs/fastdds/env_vars/env_vars.rst
@@ -254,34 +254,38 @@ The following example shows how to set the address of two remote discovery serve
 
 .. _env_vars_easy_mode:
 
-``EASY_MODE`` (Beta)
---------------------
+``EASY_MODE``
+-------------
 
-.. warning::
-    Discovery Server ``EASY_MODE`` is a Beta feature. Its functionalities are still under development and they might contain bugs.
-    Its final version will be available soon. Any feedback is appreciated and can be provided at:
-
-Setting ``EASY_MODE`` to an IP value allows a participant to automatically enter the `Discovery Server EASY_MODE<https://docs.vulcanexus.org/en/latest/rst/enhancements/ds_auto_discovery/ds_auto_discovery.html>`__.
+Setting ``EASY_MODE`` to an IP value allows a participant to automatically enter the
+`Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__.
 This mode completely disables **multicast communication**, and relies on Discovery Servers for discovery purposes.
 
-In ``EASY_MODE`` a new Discovery Server will be automatically spawned locally in the given domain, pointing to another Discovery Server located in the specified IP.
+With ``EASY_MODE`` a new Discovery Server will be automatically spawned locally in the given
+:ref:`domain<dds_layer_domain>`, pointing to another Discovery Server located in the specified IP.
 If the specified IP belongs to the same host, it will only work in localhost, until another host connects to it.
-If there exists a Discovery Server for that domain, the spawn process will be skipped, relying on the existing server for discovery purposes.
+If there exists a Discovery Server for that domain, the spawn process will be skipped, relying on the existing server
+for discovery purposes.
 Therefore, only one Discovery Server per host will be present in the domain.
 
-In order for this variable to take effect, the participant must have its :ref:`discovery protocol<discovery_protocol>` set to |SIMPLE| (default), to automatically enter the `Discovery Server EASY_MODE<https://docs.vulcanexus.org/en/latest/rst/enhancements/ds_auto_discovery/ds_auto_discovery.html>`__.
+In order for this variable to take effect, the participant must have its
+:ref:`discovery protocol<discovery_protocol>` set to |SIMPLE| (default), to automatically enter the
+`Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__.
 If this happens, the participant will be configured as a |SUPER_CLIENT| pointing to the local server.
 
-The following example will configure participants as |SUPER_CLIENT| pointing to a local Discovery Server, which will try to connect to another Discovery Server located in the host ``10.0.0.1``.
+The following example will configure participants as |SUPER_CLIENT| pointing to a local Discovery Server,
+which will try to connect to another Discovery Server located in the host ``10.0.0.1``.
 
 .. code-block:: bash
 
    $> export EASY_MODE=10.0.0.1
 
 The port of the Discovery Server is calculated using the rules explained in the :ref:`listening_locators_defaultPorts`.
-The transports configured in this new mode include :ref:`TCP<transport_tcp_tcp>` for discovery and user data and :ref:`Shared Memory<transport_sharedMemory_sharedMemory>` for user data.
+The transports configured in this new mode include :ref:`TCP<transport_tcp_tcp>` for discovery and user data and
+:ref:`Shared Memory<transport_sharedMemory_sharedMemory>` for user data.
 
-A detailed tutorial can be found in the `Discovery Server EASY_MODE<https://docs.vulcanexus.org/en/latest/rst/enhancements/ds_auto_discovery/ds_auto_discovery.html>`__ documentation.
+A detailed tutorial can be found in the
+`Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__ documentation.
 
 .. warning::
     Discovery Server ``EASY_MODE`` is not yet available for Windows.

--- a/docs/fastdds/env_vars/env_vars.rst
+++ b/docs/fastdds/env_vars/env_vars.rst
@@ -254,14 +254,14 @@ The following example shows how to set the address of two remote discovery serve
 
 .. _env_vars_easy_mode:
 
-``EASY_MODE``
--------------
+``ROS2_EASY_MODE``
+------------------
 
-Setting ``EASY_MODE`` to an IP value allows a participant to automatically enter the
+Setting ``ROS2_EASY_MODE`` to an IP value allows a participant to automatically enter the
 `Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__.
 This mode completely disables **multicast communication**, and relies on Discovery Servers for discovery purposes.
 
-With ``EASY_MODE`` a new Discovery Server will be automatically spawned locally in the given
+With ``ROS2_EASY_MODE`` a new Discovery Server will be automatically spawned locally in the given
 :ref:`domain<dds_layer_domain>`, pointing to another Discovery Server located in the specified IP.
 If the specified IP belongs to the same host, it will only work in localhost, until another host connects to it.
 If there exists a Discovery Server for that domain, the spawn process will be skipped, relying on the existing server
@@ -278,7 +278,7 @@ which will try to connect to another Discovery Server located in the host ``10.0
 
 .. code-block:: bash
 
-    export EASY_MODE=10.0.0.1
+    export ROS2_EASY_MODE=10.0.0.1
 
 The port of the Discovery Server is calculated using the rules explained in the :ref:`listening_locators_defaultPorts`.
 The transports configured in this new mode include :ref:`UDP<transport_udp_udp>` unicast for discovery and
@@ -288,7 +288,7 @@ A detailed tutorial can be found in the
 `Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__ documentation.
 
 .. warning::
-    Discovery Server ``EASY_MODE`` is not yet available for Windows platforms.
+    Discovery Server ``ROS2_EASY_MODE`` is not yet available for Windows platforms.
 
 .. _env_vars_ros_super_client:
 

--- a/docs/fastdds/env_vars/env_vars.rst
+++ b/docs/fastdds/env_vars/env_vars.rst
@@ -285,7 +285,7 @@ The transports configured in this new mode include :ref:`UDP<transport_udp_udp>`
 :ref:`TCP<transport_tcp_tcp>` and :ref:`Shared Memory<transport_sharedMemory_sharedMemory>` for user data.
 
 A detailed tutorial can be found in the
-`Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__ documentation.
+`Vucanexus Easy Mode Tutorial <https://docs.vulcanexus.org/en/latest/rst/tutorials/core/wifi/easy_mode/easy_mode.html>`__ documentation.
 
 .. warning::
     Discovery Server ``ROS2_EASY_MODE`` is not yet available for Windows platforms.

--- a/docs/fastdds/env_vars/env_vars.rst
+++ b/docs/fastdds/env_vars/env_vars.rst
@@ -252,6 +252,40 @@ The following example shows how to set the address of two remote discovery serve
     (that has been initialized with this environment variable previously) if loaded from an environment file using
     :ref:`env_vars_fastdds_environment_file`.
 
+.. _env_vars_easy_mode:
+
+``EASY_MODE`` (Beta)
+--------------------
+
+.. warning::
+    Discovery Server ``EASY_MODE`` is a Beta feature. Its functionalities are still under development and they might contain bugs.
+    Its final version will be available soon. Any feedback is appreciated and can be provided at:
+
+Setting ``EASY_MODE`` to an IP value allows a participant to automatically enter the `Discovery Server EASY_MODE<https://docs.vulcanexus.org/en/latest/rst/enhancements/ds_auto_discovery/ds_auto_discovery.html>`__.
+This mode completely disables **multicast communication**, and relies on Discovery Servers for discovery purposes.
+
+In ``EASY_MODE`` a new Discovery Server will be automatically spawned locally in the given domain, pointing to another Discovery Server located in the specified IP.
+If the specified IP belongs to the same host, it will only work in localhost, until another host connects to it.
+If there exists a Discovery Server for that domain, the spawn process will be skipped, relying on the existing server for discovery purposes.
+Therefore, only one Discovery Server per host will be present in the domain.
+
+In order for this variable to take effect, the participant must have its :ref:`discovery protocol<discovery_protocol>` set to |SIMPLE| (default), to automatically enter the `Discovery Server EASY_MODE<https://docs.vulcanexus.org/en/latest/rst/enhancements/ds_auto_discovery/ds_auto_discovery.html>`__.
+If this happens, the participant will be configured as a |SUPER_CLIENT| pointing to the local server.
+
+The following example will configure participants as |SUPER_CLIENT| pointing to a local Discovery Server, which will try to connect to another Discovery Server located in the host ``10.0.0.1``.
+
+.. code-block:: bash
+
+   $> export EASY_MODE=10.0.0.1
+
+The port of the Discovery Server is calculated using the rules explained in the :ref:`listening_locators_defaultPorts`.
+The transports configured in this new mode include :ref:`TCP<transport_tcp_tcp>` for discovery and user data and :ref:`Shared Memory<transport_sharedMemory_sharedMemory>` for user data.
+
+A detailed tutorial can be found in the `Discovery Server EASY_MODE<https://docs.vulcanexus.org/en/latest/rst/enhancements/ds_auto_discovery/ds_auto_discovery.html>`__ documentation.
+
+.. warning::
+    Discovery Server ``EASY_MODE`` is not yet available for Windows.
+
 .. _env_vars_ros_super_client:
 
 ``ROS_SUPER_CLIENT``

--- a/docs/fastdds/transport/listening_locators.rst
+++ b/docs/fastdds/transport/listening_locators.rst
@@ -210,6 +210,8 @@ Well-known ports are calculated using the following predefined rules:
      - ``PB`` + ``DG`` * *domainId* + ``offsetd2``
    * - User unicast
      - ``PB`` + ``DG`` * *domainId* + ``offsetd3`` + ``PG`` * *participantId*
+   * - Discovery Server
+     - ``PB`` + ``DG`` * *domainId* + ``offsetd4``
 
 
 The values used in these rules are explained on the following table.
@@ -262,3 +264,7 @@ The default values can be modified using the |WireProtocolConfigQos::port-api| m
      - Additional offset
      - 11
      - |PortParameters::offsetd3-qos-api|
+   * - ``offsetd4``
+     - Additional offset
+     - 2
+     - |PortParameters::offsetd4-qos-api|

--- a/docs/fastdds/transport/listening_locators.rst
+++ b/docs/fastdds/transport/listening_locators.rst
@@ -210,7 +210,7 @@ Well-known ports are calculated using the following predefined rules:
      - ``PB`` + ``DG`` * *domainId* + ``offsetd2``
    * - User unicast
      - ``PB`` + ``DG`` * *domainId* + ``offsetd3`` + ``PG`` * *participantId*
-   * - Discovery Server
+   * - Discovery Server (Easy Mode)
      - ``PB`` + ``DG`` * *domainId* + ``offsetd4``
 
 

--- a/docs/fastddscli/cli/cli.rst
+++ b/docs/fastddscli/cli/cli.rst
@@ -134,7 +134,7 @@ The following table lists the available commands for the *Fast DDS* Discovery Se
       - Selects the domain of the server to target for this action.
         It defaults to 0 if |br| this argument is missing and no value is found in the ``ROS_DOMAIN_ID``
         environment variable.
-    * - "remote_server_list"
+    * - ``<remote_server_list>``
       - It is only accepted with the `start`, `add` and `set` commands.
         It is a list of |br| remote servers to connect to that follows this structure: "<IP:domain>;<IP:domain>;...".
 

--- a/docs/fastddscli/cli/cli.rst
+++ b/docs/fastddscli/cli/cli.rst
@@ -58,8 +58,8 @@ It encompasses two main functionalities:
   only parameter that the user must specify.
   If no Domain ID is provided, the default value is 0.
 
-  It is intended to be used along with the ``EASY_MODE`` environment variable, which will manage clients connections
-  automatically.
+  It is intended to be used along with the ``ROS2_EASY_MODE`` environment variable, which will manage clients
+  connections automatically.
   This CLI feature allows the user to dynamically manage servers from the network: launching, stopping, restarting
   and even modifying their remote servers connections.
   For further information about this mode refer to `Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__.
@@ -78,9 +78,9 @@ Discovery Server CLI Easy Mode
 
 This mode aims to simplify the deployment and configuration of *Fast DDS* Discovery Servers by automatically handling
 the server's connections.
-This mode of the CLI is meant to be used along with the ``EASY_MODE`` environment variable, which can be used to
+This mode of the CLI is meant to be used along with the ``ROS2_EASY_MODE`` environment variable, which can be used to
 remove to **multicast announcements** from DDS entities and interconnect different hosts by just using the environment
-variable ``EASY_MODE=<ip>``.
+variable ``ROS2_EASY_MODE=<ip>``.
 (Check `Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__
 to see a detailed explanation of this feature).
 
@@ -89,7 +89,7 @@ It can be used to manage running servers, modifying their remote connections, re
 *Fast DDS* Discovery servers are handled and monitored from a background daemon which is automatically spawned when
 required.
 
-Configuration of servers launched with ``EASY_MODE`` is available by using the following command:
+Configuration of servers launched with ``ROS2_EASY_MODE`` is available by using the following command:
 
 .. code-block:: bash
 
@@ -122,7 +122,7 @@ The following table lists the available commands for the *Fast DDS* Discovery Se
         This will replace |br| existing remote servers with the new connections. |br|
         Example to replace remote servers with a new one: set -d 5 "10.0.0.3:42".
     * - list
-      - List local active Discovery Servers created with the CLI Tool or the ``EASY_MODE=<ip>``.
+      - List local active Discovery Servers created with the CLI Tool or the ``ROS2_EASY_MODE=<ip>``.
 
 .. list-table::
     :header-rows: 1

--- a/docs/fastddscli/cli/cli.rst
+++ b/docs/fastddscli/cli/cli.rst
@@ -52,39 +52,44 @@ discovery
 This command provides a simple and direct way to launch a *Fast DDS* :ref:`Discovery Server <discovery_server>`.
 It encompasses two main functionalities:
 
-* **Discovery Server CLI with EASY_MODE (Beta)**: It launches a background daemon which will automatically handle the creation of servers.
-  The port of each server is calculated based on the Domain ID (``-d`` argument or ``ROS_DOMAIN_ID``), which is the only parameter that the user must specify.
+* **Discovery Server CLI Easy Mode**: It launches a background daemon which will automatically handle the
+  creation of servers.
+  The port of each server is calculated based on the Domain ID (``-d`` argument or ``ROS_DOMAIN_ID``), which is the
+  only parameter that the user must specify.
   If no Domain ID is provided, the default value is 0.
 
-  It is intended to be used along with the ``EASY_MODE`` environment variable, which will manage clients connections automatically.
-  This CLI feature allows the user to dynamically manage servers from the network: launching, stopping, restarting and even modifying their remote servers connections.
-  For further information about this mode and its status refer to `Discovery Server EASY_MODE <https://docs.vulcanexus.org/en/latest/rst/enhancements/ds_auto_discovery/ds_auto_discovery.html>`__.
+  It is intended to be used along with the ``EASY_MODE`` environment variable, which will manage clients connections
+  automatically.
+  This CLI feature allows the user to dynamically manage servers from the network: launching, stopping, restarting
+  and even modifying their remote servers connections.
+  For further information about this mode refer to `Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__.
 
 * **Discovery Server CLI Standard Mode**: It launches a server running in foreground with the specified parameters.
   Configurable parameters include IP address, port, transport protocol, XML profile, etc.
-  In this mode, *clients* must know how to reach the *server*, which is accomplished by specifying an IP address, a port and
-  a transport protocol like UDP or TCP.
+  In this mode, *clients* must know how to reach the *server*, which is accomplished by specifying an IP address,
+  a port and a transport protocol like UDP or TCP.
   *Servers* do not need any prior knowledge of their *clients*, but require the listening IP address and port
   where they may be reached.
 
-.. warning::
-    Discovery Server EASY_MODE is a Beta feature. Its functionalities are still under development and they might contain bugs.
-    Its final version will be available soon. Any feedback is appreciated and can be provided at:
-
-
 .. _cli_discovery_easy_mode:
 
-Discovery Server EASY_MODE (Beta)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Discovery Server Easy Mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This mode aims to simplify the deployment and configuration of *Fast DDS* Discovery Servers by automatically handling the server's connections.
-This mode of the CLI is meant to be used along with the ``EASY_MODE`` environment variable, which can be used to remove to **multicast announcements** from DDS entities and interconnect different hosts by just using the environment variable ``EASY_MODE=<ip>``. (Check `Discovery Server EASY_MODE<https://docs.vulcanexus.org/en/latest/rst/enhancements/ds_auto_discovery/ds_auto_discovery.html>`__ to see a detailed explanation of this feature).
+This mode aims to simplify the deployment and configuration of *Fast DDS* Discovery Servers by automatically handling
+the server's connections.
+This mode of the CLI is meant to be used along with the ``EASY_MODE`` environment variable, which can be used to
+remove to **multicast announcements** from DDS entities and interconnect different hosts by just using the environment
+variable ``EASY_MODE=<ip>``.
+(Check `Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__
+to see a detailed explanation of this feature).
 
 In this way, the CLI provides an auxiliary tool to obtain more advanced configuration for specific cases of use.
 It can be used to manage running servers, modifying their remote connections, restarting them or stopping them.
-*Fast DDS* Discovery servers are handled and monitored from a background daemon which is automatically spawned when required.
+*Fast DDS* Discovery servers are handled and monitored from a background daemon which is automatically spawned when
+required.
 
-Configuration of servers launched with EASY_MODE is available by using the following command:
+Configuration of servers launched with ``EASY_MODE`` is available by using the following command:
 
 .. code-block:: bash
 
@@ -99,13 +104,15 @@ The following table lists the available commands for the *Fast DDS* Discovery Se
     * - Command
       - Description
     * - auto
-      - Handle the daemon start-up automatically and creates a Discovery Server in the specified |br| domain (0 by default).
+      - Handle the daemon start-up automatically and creates a Discovery Server in the specified
+        |br| domain (0 by default).
     * - start
       - Start the Discovery Server daemon with the remote connections specified. |br|
         (Example: start -d 1 "127.0.0.1:2;10.0.0.3:42").
     * - stop
       - Stop the Discovery Server daemon if it is executed with no arguments.
-        If a domain is |br| specified with the ``-d`` argument it will only stop the corresponding server and the daemon |br| will remain alive.
+        If a domain is |br| specified with the ``-d`` argument it will only stop the corresponding server and the
+        daemon |br| will remain alive.
     * - add
       - Add new remote Discovery Servers to the local server.
         This will connect both servers and |br| their sub-networks without modifying existing remote servers. |br|
@@ -125,7 +132,8 @@ The following table lists the available commands for the *Fast DDS* Discovery Se
       - Description
     * - ``-d  --domain``
       - Selects the domain of the server to target for this action.
-        It defaults to 0 if |br| this argument is missing and no value is found in the ``ROS_DOMAIN_ID`` environment variable.
+        It defaults to 0 if |br| this argument is missing and no value is found in the ``ROS_DOMAIN_ID``
+        environment variable.
     * - "remote_server_list"
       - It is only accepted with the `start`, `add` and `set` commands.
         It is a list of |br| remote servers to connect to that follows this structure: "<IP:domain>;<IP:domain>;...".
@@ -137,7 +145,8 @@ Discovery Server CLI Mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This mode allows the user to deeply customize Discovery Servers initialization avoiding programming.
-However, it requires manual configuration for clients to reach the server, as they must know the server's IP address, port and protocol.
+However, it requires manual configuration for clients to reach the server, as they must know the server's
+IP address, port and protocol.
 For more information on the different *Fast DDS* discovery mechanisms and how to configure them, please refer to
 :ref:`discovery`.
 

--- a/docs/fastddscli/cli/cli.rst
+++ b/docs/fastddscli/cli/cli.rst
@@ -73,8 +73,8 @@ It encompasses two main functionalities:
 
 .. _cli_discovery_easy_mode:
 
-Discovery Server Easy Mode
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Discovery Server CLI Easy Mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This mode aims to simplify the deployment and configuration of *Fast DDS* Discovery Servers by automatically handling
 the server's connections.
@@ -138,11 +138,69 @@ The following table lists the available commands for the *Fast DDS* Discovery Se
       - It is only accepted with the `start`, `add` and `set` commands.
         It is a list of |br| remote servers to connect to that follows this structure: "<IP:domain>;<IP:domain>;...".
 
+.. _easy_mode_discovery_examples:
+
+Examples
+""""""""
+
+1.  Start a DS in the default domain 0:
+
+    .. code-block:: bash
+
+        fastdds discovery auto
+
+2.  Stop all running DS and shut down Fast DDS daemon:
+
+    .. code-block:: bash
+
+        fastdds discovery stop
+
+3.  Stop DS running in domain 0:
+
+    .. code-block:: bash
+
+        fastdds discovery stop -d 0
+
+4.  Start a DS in the domain 42:
+
+    .. code-block:: bash
+
+        fastdds discovery auto -d 42
+
+    OR
+
+    .. code-block:: bash
+
+        ROS_DOMAIN_ID=42 fastdds discovery auto
+
+5.  Start a DS in domain 4 pointing to remote DS in domain 4:
+
+    .. code-block:: bash
+
+        fastdds discovery start -d 4 10.0.0.7:4
+
+6.  Add a new remote server to DS running in domain 4 :
+
+    .. code-block:: bash
+
+        fastdds discovery add -d 4 10.0.0.7:4
+
+7.  List all servers running locally:
+
+    .. code-block:: bash
+
+        fastdds discovery list
+
+8.  Starts a DS in domain 3 pointing to local DS in domain 6:
+
+    .. code-block:: bash
+
+        fastdds discovery start -d 3 127.0.0.1:6
 
 .. _cli_discovery_cli:
 
-Discovery Server CLI Mode
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Discovery Server CLI Standard Mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This mode allows the user to deeply customize Discovery Servers initialization avoiding programming.
 However, it requires manual configuration for clients to reach the server, as they must know the server's
@@ -192,21 +250,19 @@ The output is:
 
 .. code-block:: bash
 
-    ### Server is running ###
-      Participant Type:   <SERVER|BACKUP>
-      Security:           <YES|NO>
-      Server GUID prefix: <Default>|44.53.<server-id-in-hex>.5f.45.50.52.4f.53.49.4d.41
-      Server Addresses:   UDPv4:[<ip-address>]:<port>
-                          UDPv6:[<ip-address>]:<port>
-                          TCPv4:[<ip-address>]:<physical-port>-<logical-port>
-                          TCPv6:[<ip-address>]:<physical-port>-<logical-port>
+    #### Server started ####
+      GUID prefix: <Default>|44.53.<server-id-in-hex>.5f.45.50.52.4f.53.49.4d.41
+      Running on:  UDPv4:[<ip-address>]:<port>
+                   UDPv6:[<ip-address>]:<port>
+                   TCPv4:[<ip-address>]:<physical-port>-<logical-port>
+                   TCPv6:[<ip-address>]:<physical-port>-<logical-port>
 
 Once the *server* is instantiated, the *clients* can be configured either programmatically or by XML (see
 :ref:`discovery_server`), or using environment variable ``ROS_DISCOVERY_SERVER`` (see
 :ref:`env_vars_ros_discovery_server`)
 
 .. important::
-    It is possible to interconnect *servers* (or *backup* servers) instantiated with ``fastdds discovery`` using
+    It is possible to interconnect *servers* (or *backup* servers) instantiated with :ref:`cli_discovery_cli` using
     environment variable ``ROS_DISCOVERY_SERVER`` (see :ref:`env_vars_ros_discovery_server`) or a XML configuration
     file.
 
@@ -217,7 +273,7 @@ Once the *server* is instantiated, the *clients* can be configured either progra
 .. _cli_discovery_examples:
 
 Examples
---------
+""""""""
 
 1.  Launch a **default server** listening on all available interfaces on UDP port '11811'.
     Only one server can use default values per machine.
@@ -230,11 +286,9 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type:   SERVER
-          Security:           NO
-          Server GUID prefix: <Default GUID>
-          Server Addresses:   UDPv4:[0.0.0.0]:11811
+        #### Server started ####
+          GUID prefix: <Default GUID>
+          Running on:  UDPv4:[0.0.0.0]:11811
 
 2.  Launch a default server listening on localhost with UDP port 14520.
     Only localhost clients can reach the server defining as `ROS_DISCOVERY_SERVER=127.0.0.1:14520`.
@@ -247,11 +301,9 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type:   SERVER
-          Security:           NO
-          Server GUID prefix: <Default GUID>
-          Server Addresses:   UDPv4:[127.0.0.1]:14520
+        #### Server started ####
+          GUID prefix: <Default GUID>
+          Running on:  UDPv4:[127.0.0.1]:14520
 
     This same output can be obtained loading the following XML configuration file ``DiscoveryServerCLI.xml``:
 
@@ -275,11 +327,9 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type:   SERVER
-          Security:           NO
-          Server GUID prefix: <Default GUID>
-          Server Addresses:   TCPv4:[0.0.0.0]:42100
+        #### Server started ####
+          GUID prefix: <Default GUID>
+          Running on:  TCPv4:[0.0.0.0]:42100
 
 .. _Deprecated_CLI: https://fast-dds.docs.eprosima.com/en/v2.14.0/fastddscli/cli/cli.html
 
@@ -294,11 +344,9 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type:   SERVER
-          Security:           NO
-          Server GUID prefix: 44.53.01.5f.45.50.52.4f.53.49.4d.41
-          Server Addresses:   UDPv6:[2a02:ec80:600:ed1a::3]:14520
+        #### Server started ####
+          GUID prefix: 44.53.01.5f.45.50.52.4f.53.49.4d.41
+          Running on:  UDPv6:[2a02:ec80:600:ed1a::3]:14520
 
 5.  Launch a default server listening on WiFi (192.168.36.34) and Ethernet (172.20.96.1)
     local interfaces with UDP ports 8783 and 51083 respectively
@@ -312,12 +360,10 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type    SERVER
-          Security:           NO
-          Server GUID prefix: <Default GUID>
-          Server Addresses:   UDPv4:[192.168.36.34]:8783
-                              UDPv4:[172.20.96.1]:51083
+        #### Server started ####
+          GUID prefix: <Default GUID>
+          Running on:  UDPv4:[192.168.36.34]:8783
+                       UDPv4:[172.20.96.1]:51083
 
     Using the same XML configuration file from the second example, the same
     output can be obtained loading a specific profile: `second_participant_profile_discovery_server_cli`.
@@ -337,11 +383,9 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type    BACKUP
-          Security:           NO
-          Server GUID prefix: <Default GUID>
-          Server Addresses:   UDPv4:[172.30.144.1]:12345
+        #### Backup Server started ####
+          GUID prefix: <Default GUID>
+          Running on:  UDPv4:[172.30.144.1]:12345
 
 7.  Launch a secure server listening on all available interfaces on UDP port '11811'.
 
@@ -353,11 +397,9 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type:   SERVER
-          Security:           YES
-          Server GUID prefix: <Default GUID>
-          Server Addresses:   UDPv4:[0.0.0.0]:11811
+        #### Server started ####
+          GUID prefix: <Default GUID>
+          Running on:  UDPv4:[0.0.0.0]:11811
 
 8.  Launch a server reading specific `profile_name` configuration from XML file.
 
@@ -369,11 +411,9 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type:   SERVER
-          Security:           NO
-          Server GUID prefix: <Default GUID>
-          Server Addresses:   UDPv4:[127.0.0.1]:56542
+        #### Server started ####
+          GUID prefix: <Default GUID>
+          Running on:  UDPv4:[127.0.0.1]:56542
 
 9.  Launch a server listening on localhost on default TCP port '42100'.
 
@@ -385,11 +425,9 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type:   SERVER
-          Security:           NO
-          Server GUID prefix: <Default GUID>
-          Server Addresses:   TCPv4:[127.0.0.1]:42100-42100
+        #### Server started ####
+          GUID prefix: <Default GUID>
+          Running on:  TCPv4:[127.0.0.1]:42100-42100
 
 10. Launch a server listening on localhost and WiFi (192.163.6.34). Two TCP ports need to be
     specified because transports cannot share ports.
@@ -402,12 +440,10 @@ Examples
 
     .. code-block:: bash
 
-        ### Server is running ###
-          Participant Type:   SERVER
-          Security:           NO
-          Server GUID prefix: <Default GUID>
-          Server Addresses:   TCPv4:[127.0.0.1]:42100-42100
-                              TCPv4:[192.163.6.34]:42101-42101
+        #### Server started ####
+          GUID prefix: <Default GUID>
+          Running on:  TCPv4:[127.0.0.1]:42100-42100
+                       TCPv4:[192.163.6.34]:42101-42101
 
 .. note::
      When using Discovery Server over TCP, the first port shown in the output

--- a/docs/notes/previous_versions/v2.6.0.rst
+++ b/docs/notes/previous_versions/v2.6.0.rst
@@ -18,7 +18,7 @@ This minor release includes the following **features**:
 4. Endpoint discovery RTPS API
 5. ``on_sample_lost`` RTPS API
 6. Transport layer API extension
-7. :ref:`XML support for Fast DDS CLI <cli_discovery_run>`
+7. :ref:`XML support for Fast DDS CLI <cli_discovery_cli>`
 8. :ref:`New exchange format to reduce bandwidth in Static Discovery <property_policies_edp_exchange_format>`
 
 It also includes the following **improvements**:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR updates documentation about the new Easy Mode feature.

Must merge after:

- https://github.com/eProsima/Fast-DDS/pull/5548
- https://github.com/eProsima/Fast-DDS/pull/5551#

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
