### PR TITLE
[22706] Warn about XTypes in Fast DDS v3

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -970,7 +970,7 @@ void dds_domain_examples()
 
         pqos.properties().properties().emplace_back(
             "fastdds.type_propagation",
-            "enabled");
+            "disabled");
         //!--
     }
 }

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3277,7 +3277,7 @@
                     <properties>
                         <property>
                             <name>fastdds.type_propagation</name>
-                            <value>enable</value>
+                            <value>disabled</value>
                         </property>
                     </properties>
                 </propertiesPolicy>

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -509,4 +509,4 @@ The different property values have the following effects on the local |DomainPar
             :language: xml
             :start-after: <!-->TYPE_PROPAGATION_PROPERTY<-->
             :end-before: <!--><-->
-            :lines: 2-4,6-16,18-19
+            :lines: 2-4,6-17,19-20

--- a/docs/fastdds/troubleshooting/troubleshooting.rst
+++ b/docs/fastdds/troubleshooting/troubleshooting.rst
@@ -44,3 +44,8 @@ issues.
 
 * If having problems with transmitting **large samples such as video or point clouds**, please refer to
   :ref:`use-case-largeData`.
+
+* Fast DDS v3 introduced the new feature :ref:`XTypes<dynamic-types>`, which allows to discover remote types.
+  In consequence, discovery traffic can be increased during start up.
+  If you are experiencing high load during discovery, try disabling the new feature.
+  Please refer to :ref:`disable type propagation<property_type_propagation>` to learn how to do it.

--- a/docs/notes/migration_guide.rst
+++ b/docs/notes/migration_guide.rst
@@ -10,6 +10,12 @@ Migration Guide to Fast DDS v3
 This document aims to help during the migration process from eProsima *Fast DDS version* 2 to *Fast DDS version* 3.
 For more information about all the updates, please refer to the :ref:`release notes <release_notes>`.
 
+.. warning::
+    Fast DDS v3 introduces a new feature :ref:`XTypes<dynamic-types>` that allows to discover remote types.
+    In consequence, discovery traffic can be increased during start up.
+    If you are experiencing high load during discovery, try disabling the new feature.
+    Please refer to :ref:`disable type propagation<property_type_propagation>` to learn how to do it.
+
 Migration Steps
 ---------------
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR warns about XTypes in the migration guide to Fast DDS v3.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* https://github.com/eProsima/Fast-DDS/pull/5601


## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
