### PR TITLE
[22721] Increase 'max_blocking_time' in Easy Mode

### DIFF
--- a/docs/fastdds/env_vars/env_vars.rst
+++ b/docs/fastdds/env_vars/env_vars.rst
@@ -287,6 +287,14 @@ The transports configured in this new mode include :ref:`UDP<transport_udp_udp>`
 A detailed tutorial can be found in the
 `Vucanexus Easy Mode Tutorial <https://docs.vulcanexus.org/en/latest/rst/tutorials/core/wifi/easy_mode/easy_mode.html>`__ documentation.
 
+.. note::
+    When ``ROS2_EASY_MODE`` is enabled, Fast DDS automatically loads a custom XML profile named ``service``.
+    This profile increases the server's response timeout for ROS2 services by modifying the
+    |ReliabilityQosPolicy::max_blocking_time-api|.
+    However, if the user provides an XML file that already contains a profile with the same name, Fast DDS will not
+    load any extra profile.
+    Instead, the |ReliabilityQosPolicy::max_blocking_time-api| value defined in the user's XML file will be used.
+
 .. warning::
     Discovery Server ``ROS2_EASY_MODE`` is not yet available for Windows platforms.
 

--- a/docs/fastdds/env_vars/env_vars.rst
+++ b/docs/fastdds/env_vars/env_vars.rst
@@ -289,7 +289,7 @@ A detailed tutorial can be found in the
 
 .. note::
     When ``ROS2_EASY_MODE`` is enabled, Fast DDS automatically loads a custom XML profile named ``service``.
-    This profile increases the server's response timeout for ROS2 services by modifying the
+    This profile increases the server's response timeout for ROS 2 services by modifying the
     |ReliabilityQosPolicy::max_blocking_time-api|.
     However, if the user provides an XML file that already contains a profile with the same name, Fast DDS will not
     load any extra profile.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR adds an explanatory note to detail the behavior of the `service` XML profile loaded automatically by Fast DDS (if `ROS2_EASY_MODE` is enabled) and how it will behave in case the user has its own XML profile defined.

Merge after:

- https://github.com/eProsima/Fast-DDS/pull/5617

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
