### PR TITLE
Fix default ros2 publication mode

### DIFF
--- a/docs/fastdds/ros2/ros2_configure.rst
+++ b/docs/fastdds/ros2/ros2_configure.rst
@@ -24,7 +24,7 @@ This section describes how to specify this extended configuration.
 Changing publication mode
 -------------------------
 
-*rmw_fastrtps* in ROS 2 uses asynchronous publication by default.
+*rmw_fastrtps* in ROS 2 uses synchronous publication by default.
 This can be easily changed setting the environment variable ``RMW_FASTRTPS_PUBLICATION_MODE``
 to one of the following allowed values:
 

--- a/docs/fastdds/ros2/ros2_configure.rst
+++ b/docs/fastdds/ros2/ros2_configure.rst
@@ -66,7 +66,7 @@ Said parameters, and their default values under ROS 2, are:
        in a queue that is managed in a different thread, |br|
        meaning that the user thread is available right |br|
        after the call to send data.
-     - |ASYNCHRONOUS_PUBLISH_MODE-api|
+     - |SYNCHRONOUS_PUBLISH_MODE-api|
 
 
 .. _ros2_configure_xml:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR address this issue: https://github.com/ros2/rmw_fastrtps/issues/804

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
