### PR TITLE
[22872] Configure ROS 2 Easy Mode via C++ and XML

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4697,6 +4697,8 @@ void dds_qos_examples()
         participant_qos.wire_protocol().default_external_unicast_locators[1][0].push_back(external_locator);
         // Drop non matching locators
         participant_qos.wire_protocol().ignore_non_matching_locators = true;
+        // Configure the ROS 2 Easy Mode master Discovery Server IP
+        participant_qos.wire_protocol().easy_mode("127.0.0.1");
         // Increase mutation tries
         participant_qos.wire_protocol().builtin.mutation_tries = 300u;
         // Use modified QoS in the creation of the DomainParticipant entity

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3811,6 +3811,7 @@
     <rtps>
         <prefix>72.61.73.70.66.61.72.6d.74.65.73.74</prefix>
         <participantID>11</participantID>
+        <easy_mode_ip>127.0.0.1</easy_mode_ip>
         <builtin>
             <discovery_config>
                 <discoveryProtocol>SERVER</discoveryProtocol>

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -728,6 +728,7 @@
 .. |WireProtocolConfigQos::default_multicast_locator_list-api| replace:: :cpp:member:`default_multicast_locator_list<eprosima::fastdds::dds::WireProtocolConfigQos::default_multicast_locator_list>`
 .. |WireProtocolConfigQos::default_external_unicast_locators-api| replace:: :cpp:member:`default_external_unicast_locators<eprosima::fastdds::dds::WireProtocolConfigQos::default_external_unicast_locators>`
 .. |WireProtocolConfigQos::ignore_non_matching_locators-api| replace:: :cpp:member:`ignore_non_matching_locators<eprosima::fastdds::dds::WireProtocolConfigQos::ignore_non_matching_locators>`
+.. |WireProtocolConfigQos::easy_mode-api| replace:: :cpp:func:`easy_mode()<eprosima::fastdds::dds::WireProtocolConfigQos::easy_mode>`
 
 .. |PortParameters-api| replace:: :cpp:class:`PortParameters<eprosima::fastdds::rtps::PortParameters>`
 .. |PortParameters::domainIDGain-qos-api| replace:: :cpp:member:`wire_protocol().port.domainIDGain<eprosima::fastdds::rtps::PortParameters::domainIDGain>`

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1153,6 +1153,25 @@ List of QoS Policy data members:
       - ``bool``
       - false
 
+List of QoS Policy methods:
+
+.. list-table::
+    :header-rows: 1
+    :align: left
+
+    * - Method name
+      - Input parameters
+      - Return type
+      - Description
+    * - |WireProtocolConfigQos::easy_mode-api|
+      - ``std::string ip``
+      - ``void``
+      - Setter for ``easy_mode_ip_`` private member.
+    * - |WireProtocolConfigQos::easy_mode-api|
+      - Empty
+      - ``std::string``
+      - Getter for ``easy_mode_ip_`` private member.
+
 * |WireProtocolConfigQos::prefix-api|:
   This data member allows the user to set manually the GUID prefix.
 * |WireProtocolConfigQos::participant_id-api|:
@@ -1176,6 +1195,13 @@ List of QoS Policy data members:
 * |WireProtocolConfigQos::ignore_non_matching_locators-api|:
   Defines whether to ignore locators received on announcements from other DDS participants when they don't match with
   any of the locators announced by this DDS participant.
+* |WireProtocolConfigQos::easy_mode-api|:
+  This method allows the user to set or get the ``easy_mode_ip_`` private member, which stores the IP address to be used
+  in the `Discovery Server Easy Mode
+  <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__ configuration.
+  When |WireProtocolConfigQos::easy_mode-api| setter is called, the input string parameter is validated to make sure
+  it is a valid IPv4 address.
+  If not, ``easy_mode_ip_`` will be set to an empty string, indicating that ROS 2 Easy Mode is disabled.
 
 .. note::
      This QoS Policy applies to |DomainParticipant| entities.

--- a/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
+++ b/docs/fastdds/dds_layer/core/policy/eprosimaExtensions.rst
@@ -1165,7 +1165,7 @@ List of QoS Policy methods:
       - Description
     * - |WireProtocolConfigQos::easy_mode-api|
       - ``std::string ip``
-      - ``void``
+      - ``ReturnCode_t``
       - Setter for ``easy_mode_ip_`` private member.
     * - |WireProtocolConfigQos::easy_mode-api|
       - Empty

--- a/docs/fastdds/xml_configuration/domainparticipant.rst
+++ b/docs/fastdds/xml_configuration/domainparticipant.rst
@@ -146,6 +146,12 @@ These elements allow the user to define the DomainParticipant configuration.
        |DomainParticipantFactory|.
      - ``int32_t``
      - 0
+   * - ``<easy_mode_ip>``
+     - IP address of the remote discovery server |br|
+       to connect to using
+       `Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__.
+     - ``string``
+     - Empty
    * - ``<userTransports>``
      - Transport descriptors to be used by the |br|
        DomainParticipant. See |br|

--- a/docs/fastddscli/cli/cli.rst
+++ b/docs/fastddscli/cli/cli.rst
@@ -74,7 +74,7 @@ Discovery Server CLI Easy Mode
 This mode aims to simplify the deployment and configuration of *Fast DDS* Discovery Servers by automatically handling
 the server's connections.
 This mode of the CLI is meant to be used along with the ``ROS2_EASY_MODE`` environment variable, which can be used to
-remove to **multicast announcements** from DDS entities and interconnect different hosts by just using the environment
+remove **multicast announcements** from DDS entities and interconnect different hosts by just using the environment
 variable ``ROS2_EASY_MODE=<ip>``.
 (Check `Discovery Server Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__
 to see a detailed explanation of this feature).


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
Merge after:

- https://github.com/eProsima/Fast-DDS/pull/5689

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
