### PR TITLE
[23008] Update CLI commands for Easy Mode

### DIFF
--- a/docs/fastddscli/cli/cli.rst
+++ b/docs/fastddscli/cli/cli.rst
@@ -98,24 +98,19 @@ The following table lists the available commands for the *Fast DDS* Discovery Se
 
     * - Command
       - Description
-    * - auto
-      - Handle the daemon start-up automatically and creates a Discovery Server in the specified
-        |br| domain (0 by default).
     * - start
       - Start the Discovery Server daemon with the remote connections specified. |br|
-        (Example: start -d 1 "127.0.0.1:2;10.0.0.3:42").
+        (Example: start -d 1 10.0.0.1:1).
     * - stop
       - Stop the Discovery Server daemon if it is executed with no arguments.
         If a domain is |br| specified with the ``-d`` argument it will only stop the corresponding server and the
         daemon |br| will remain alive.
     * - add
       - Add new remote Discovery Servers to the local server.
-        This will connect both servers and |br| their sub-networks without modifying existing remote servers. |br|
-        Example to add two new remote servers: add -d 7 "127.0.0.1:2;10.0.0.3:42".
+        This will connect both servers and |br| their sub-networks without modifying existing remote servers.
     * - set
       - Rewrite the remote Discovery Servers connected to the local server.
-        This will replace |br| existing remote servers with the new connections. |br|
-        Example to replace remote servers with a new one: set -d 5 "10.0.0.3:42".
+        This will replace |br| existing remote servers with the new connections.
     * - list
       - List local active Discovery Servers created with the CLI Tool or the ``ROS2_EASY_MODE=<ip>``.
 
@@ -127,11 +122,16 @@ The following table lists the available commands for the *Fast DDS* Discovery Se
       - Description
     * - ``-d  --domain``
       - Selects the domain of the server to target for this action.
-        It defaults to 0 if |br| this argument is missing and no value is found in the ``ROS_DOMAIN_ID``
-        environment variable.
+        It is mandatory for |br| commands ``start``, ``add`` and ``set``.
     * - ``<remote_server_list>``
-      - It is only accepted with the `start`, `add` and `set` commands.
-        It is a list of |br| remote servers to connect to that follows this structure: "<IP:domain>;<IP:domain>;...".
+      - It is a list of remote servers to connect to that follows this structure: |br|
+        ``<IP:domain>;<IP:domain>;...``.
+        It is mandatory with the `start`, `add` and `set` commands. |br|
+        Only valid IPv4 addresses are accepted.
+
+.. important::
+    The domain argument (``-d`` or ``--domain``) and an ``<IP>:<domain>`` pair are mandatory for commands ``start``,
+    ``add`` and ``set``.
 
 .. _easy_mode_discovery_examples:
 
@@ -142,7 +142,7 @@ Examples
 
     .. code-block:: bash
 
-        fastdds discovery auto
+        fastdds discovery start -d 0 127.0.0.1:0
 
 2.  Stop all running DS and shut down Fast DDS daemon:
 
@@ -156,19 +156,7 @@ Examples
 
         fastdds discovery stop -d 0
 
-4.  Start a DS in the domain 42:
-
-    .. code-block:: bash
-
-        fastdds discovery auto -d 42
-
-    OR
-
-    .. code-block:: bash
-
-        ROS_DOMAIN_ID=42 fastdds discovery auto
-
-5.  Start a DS in domain 4 pointing to remote DS in domain 4:
+5.  Start a DS in domain 4 pointing to remote DS in domain 4 and IP 10.0.0.7:
 
     .. code-block:: bash
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR updates documentation for changes on:

- https://github.com/eProsima/Fast-DDS/pull/5749

Hence, it needs to be merged after it.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
