### PR TITLE
[22972] Support sequences in IDL Parser

### DIFF
--- a/docs/fastdds/xtypes/idl_parsing.rst
+++ b/docs/fastdds/xtypes/idl_parsing.rst
@@ -27,6 +27,7 @@ For further information about the supported |DynamicTypes|, please, refer to :re
 * :ref:`xtypes_supportedtypes_structure`
 * :ref:`xtypes_supportedtypes_alias`
 * :ref:`xtypes_supportedtypes_array`
+* :ref:`xtypes_supportedtypes_sequence`
 * :ref:`xtypes_supportedtypes_union`
 * :ref:`xtypes_supportedtypes_enumeration`
 * :ref:`xtypes_annotations`
@@ -36,7 +37,6 @@ For further information about the supported |DynamicTypes|, please, refer to :re
 The following types are currently not supported by the IDL parsing feature:
 
 * :ref:`xtypes_supportedtypes_bitmask`
-* :ref:`xtypes_supportedtypes_sequence`
 * :ref:`xtypes_supportedtypes_map`
 * :ref:`xtypes_supportedtypes_bitset`
 * :ref:`xtypes_builtin_annotations`


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR updates the list of supported types in IDL Parser. Documentation PR for:
- https://github.com/eProsima/Fast-DDS/pull/5763
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- __N/A__ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- __N/A__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
