### PR TITLE
[23078] Send only non-default QoS & Use 'serialize_optional_qos' for optional QoS in EDP messages

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -981,6 +981,16 @@ void dds_domain_examples()
             "disabled");
         //!--
     }
+
+    {
+        // SERIALIZE_OPTIONAL_QOS_PROPERTY
+        DomainParticipantQos pqos;
+
+        pqos.properties().properties().emplace_back(
+            "fastdds.serialize_optional_qos",
+            "True");
+        //!--
+    }
 }
 
 //DOMAINPARTICIPANTLISTENER-DISCOVERY-CALLBACKS
@@ -2062,7 +2072,7 @@ void dds_topic_examples()
         include_paths.push_back("<path/to/folder/containing/included/idl/files>");
 
         // Retrieve the instance of the desired type
-        DynamicTypeBuilder::_ref_type dyn_type_builder = 
+        DynamicTypeBuilder::_ref_type dyn_type_builder =
                 DynamicTypeBuilderFactory::get_instance()->create_type_w_uri(idl_file, type_name, include_paths);
 
         // Register dynamic type
@@ -7937,7 +7947,7 @@ void rpcdds_internal_api_examples()
             // Error
             return;
         }
- 
+
         // Wait for some time until a Reply sample is received
         requester->get_requester_reader()->wait_for_unread_message(Duration_t{3,0});
 
@@ -7948,12 +7958,12 @@ void rpcdds_internal_api_examples()
             // Error
             return;
         }
-    
+
         if (expected_request_info.related_sample_identity == received_request_info.related_sample_identity)
         {
           // Received Reply sample is associated to the sent Request sample
         }
-    
+
         // Delete created Requester
         ret = participant->delete_service_requester(requester->get_service_name(), requester);
         if (RETCODE_OK != ret)

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3293,6 +3293,30 @@
 -->
 <!--><-->
 
+<!-->SERIALIZE_OPTIONAL_QOS_PROPERTY<-->
+<!--
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds xmlns="http://www.eprosima.com">
+    <profiles>
+-->
+        <participant profile_name="serialize_optional_qos_domainparticipant_xml_profile">
+            <rtps>
+                <propertiesPolicy>
+                    <properties>
+                        <property>
+                            <name>fastdds.serialize_optional_qos</name>
+                            <value>True</value>
+                        </property>
+                    </properties>
+                </propertiesPolicy>
+            </rtps>
+        </participant>
+<!--
+    </profiles>
+</dds>
+-->
+<!--><-->
+
 <!-->FASTDDS_STATISTICS_MODULE<-->
 <participant profile_name="statistics_domainparticipant_conf_xml_profile">
     <rtps>

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -474,3 +474,65 @@ The different property values have the following effects on the local |DomainPar
         :start-after: <!-->TYPE_PROPAGATION_PROPERTY<-->
         :end-before: <!--><-->
         :lines: 2-4,6-17,19-20
+
+.. _property_serialize_optional_qos:
+
+Add optional QoS to EDP messages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+During the Endpoint Discovery Phase (EDP), |DataWriters-api| and |DataReaders-api| acknowledge each other.
+To do that, the DomainParticipants share information about their DataWriters and DataReaders with each other,
+using the communication channels established during the PDP.
+This information contains all data required to match the endpoints, such as the |Topic-api|, data type, and
+certain :ref:`QoS Policies <dds_layer_core_policy>` that might matching.
+Specific compatibility rules can be found in each QoS section of :ref:`QoS Policies <dds_layer_core_policy>`.
+
+However, there are some QoS that are not mandatory for matching, but can be useful to have in the EDP messages.
+Property ``fastdds.serialize_optional_qos`` allows the user to include these optional QoS in the EDP messages.
+Optional QoS, like any other QoS, will only be serialized if they have non-default values.
+Not receiving information about a QoS in the EDP message means that it has a default value.
+Optional QoS will be serialized if the value of the property is set to ``TRUE``, ``True``, ``true`` or ``1``, any
+other value will be considered as not set or ``FALSE``.
+
+The following table lists all the optional QoS that can be serialized in the EDP messages:
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - PropertyPolicyQos
+     - Applies to:
+   * - |ResourceLimitsQosPolicy-api|
+     - |DataWriter-api| and |DataReaders-api|.
+   * - |TransportPriorityQosPolicy-api|
+     - |DataWriter-api|.
+   * - |WriterDataLifecycleQosPolicy-api|
+     - |DataWriter-api|.
+   * - |ReaderDataLifecycleQosPolicy-api|
+     - |DataReaders-api|.
+   * - |PublishModeQosPolicy-api|
+     - |DataWriter-api|.
+   * - |RTPSReliableWriterQos-api|
+     - |DataWriter-api|.
+   * - |RTPSReliableReaderQos-api|
+     - |DataReaders-api|.
+   * - |RTPSEndpointQos-api|
+     - |DataWriter-api| and |DataReaders-api|.
+   * - |WriterResourceLimitsQos-api|
+     - |DataWriter-api|.
+   * - |ReaderResourceLimitsQos-api|
+     - |DataReaders-api|.
+
+.. tab-set-code::
+
+    .. literalinclude:: /../code/DDSCodeTester.cpp
+        :language: c++
+        :start-after: // SERIALIZE_OPTIONAL_QOS_PROPERTY
+        :end-before: //!--
+        :dedent: 8
+
+    .. literalinclude:: /../code/XMLTester.xml
+        :language: xml
+        :start-after: <!-->SERIALIZE_OPTIONAL_QOS_PROPERTY<-->
+        :end-before: <!--><-->
+        :lines: 2-4,6-17,19-20

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -477,18 +477,21 @@ The different property values have the following effects on the local |DomainPar
 
 .. _property_serialize_optional_qos:
 
-Add optional QoS to EDP messages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding optional QoS to Discovery data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 During the Endpoint Discovery Phase (EDP), |DataWriters-api| and |DataReaders-api| acknowledge each other.
 To do that, the DomainParticipants share information about their DataWriters and DataReaders with each other,
 using the communication channels established during the PDP.
 This information contains all data required to match the endpoints, such as the |Topic-api|, data type, and
-certain :ref:`QoS Policies <dds_layer_core_policy>` that might matching.
+certain :ref:`QoS Policies <dds_layer_core_policy>` that might affect matching.
 Specific compatibility rules can be found in each QoS section of :ref:`QoS Policies <dds_layer_core_policy>`.
 
 However, there are some QoS that are not mandatory for matching, but can be useful to have in the EDP messages.
 Property ``fastdds.serialize_optional_qos`` allows the user to include these optional QoS in the EDP messages.
+This property is configured at the |DomainParticipant-api| level through the policy :ref:`propertypolicyqos`.
+Hence, all associated endpoints to that |DomainParticipant-api| will send their optional QoS in the EDP messages.
+
 Optional QoS, like any other QoS, will only be serialized if they have non-default values.
 Not receiving information about a QoS in the EDP message means that it has a default value.
 Optional QoS will be serialized if the value of the property is set to ``TRUE``, ``True``, ``true`` or ``1``, any


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR documents the new property added in:

- https://github.com/eProsima/Fast-DDS/pull/5795#

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
