### PR TITLE
[23169] Documentation for the optional serialization of `WireProtocolConfigQos`

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -988,7 +988,7 @@ void dds_domain_examples()
 
         pqos.properties().properties().emplace_back(
             "fastdds.serialize_optional_qos",
-            "true"); // True or TRUE or 1
+            "true"); // true or True or TRUE or 1
         //!--
     }
 }

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -988,7 +988,7 @@ void dds_domain_examples()
 
         pqos.properties().properties().emplace_back(
             "fastdds.serialize_optional_qos",
-            "True");
+            "true"); // True or TRUE or 1
         //!--
     }
 }

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3305,7 +3305,7 @@
                     <properties>
                         <property>
                             <name>fastdds.serialize_optional_qos</name>
-                            <value>true</value><!-- True, TRUE, 1 -->
+                            <value>true</value> <!-- true, True, TRUE, 1 -->
                         </property>
                     </properties>
                 </propertiesPolicy>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3305,7 +3305,7 @@
                     <properties>
                         <property>
                             <name>fastdds.serialize_optional_qos</name>
-                            <value>True</value>
+                            <value>true</value><!-- True, TRUE, 1 -->
                         </property>
                     </properties>
                 </propertiesPolicy>

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -480,24 +480,26 @@ The different property values have the following effects on the local |DomainPar
 Adding optional QoS to Discovery data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-During the Endpoint Discovery Phase (EDP), |DataWriters-api| and |DataReaders-api| acknowledge each other.
+During :ref:`discovery`, |DomainParticipants-api|, |DataWriters-api| and |DataReaders-api| acknowledge each other.
+This is performed in two phases, the Participant Discovery Phase (PDP) and the Endpoint Discovery Phase (EDP).
 To do that, the DomainParticipants share information about their DataWriters and DataReaders with each other,
-using the communication channels established during the PDP.
+using the communication channels established during the PDP phase.
 This information contains all data required to match the endpoints, such as the |Topic-api|, data type, and
 certain :ref:`QoS Policies <dds_layer_core_policy>` that might affect matching.
 Specific compatibility rules can be found in each QoS section of :ref:`QoS Policies <dds_layer_core_policy>`.
 
-However, there are some QoS that are not mandatory for matching, but can be useful to have in the EDP messages.
-Property ``fastdds.serialize_optional_qos`` allows the user to include these optional QoS in the EDP messages.
+However, there are some QoS that are not mandatory for matching, but can be useful to have upon discovery.
+Property ``fastdds.serialize_optional_qos`` allows the user to include these optional QoS during discovery.
 This property is configured at the |DomainParticipant-api| level through the policy :ref:`propertypolicyqos`.
-Hence, all associated endpoints to that |DomainParticipant-api| will send their optional QoS in the EDP messages.
+Hence, the |DomainParticipant-api| and all its associated endpoints will send their optional QoS
+in the discovery messages.
 
 Optional QoS, like any other QoS, will only be serialized if they have non-default values.
 Not receiving information about a QoS in the EDP message means that it has a default value.
 Optional QoS will be serialized if the value of the property is set to ``TRUE``, ``True``, ``true`` or ``1``, any
 other value will be considered as not set or ``FALSE``.
 
-The following table lists all the optional QoS that can be serialized in the EDP messages:
+The following table lists all the optional QoS that can be serialized in the discovery messages:
 
 .. list-table::
    :header-rows: 1
@@ -505,6 +507,8 @@ The following table lists all the optional QoS that can be serialized in the EDP
 
    * - PropertyPolicyQos
      - Applies to:
+   * - |WireProtocolConfigQos-api|
+     - |DomainParticipant-api|.
    * - |ResourceLimitsQosPolicy-api|
      - |DataWriter-api| and |DataReaders-api|.
    * - |TransportPriorityQosPolicy-api|

--- a/docs/fastdds/statistics/monitor_service/monitor_service_topics.rst
+++ b/docs/fastdds/statistics/monitor_service/monitor_service_topics.rst
@@ -28,36 +28,36 @@ The possible values are described in the following table:
 
 .. _monitoring_statuses:
 
-+---------+-----------------------------+----------------------------------------------------+
-|**Value**|          **Name**           | **Description**                                    |
-+---------+-----------------------------+----------------------------------------------------+
-|  0      |     ``ProxyInfo``           | Collection of Parameters describing the            |
-|         |                             | ``Proxy Data`` of that entity                      |
-+---------+-----------------------------+----------------------------------------------------+
-|  1      |     ``ConnectionList``      | List of connections that this entity is            |
-|         |                             | using with its matched remote entities.            |
-+---------+-----------------------------+----------------------------------------------------+
-|  2      |  ``IncompatibleQoSInfo``    | Status of the Incompatible QoS                     |
-|         |                             | of that entity.                                    |
-+---------+-----------------------------+----------------------------------------------------+
-|  3      | ``InconsistentTopicInfo``   | Status of Inconsistent topics that the             |
-|         |                             | topic of that entity has.                          |
-+---------+-----------------------------+----------------------------------------------------+
-|  4      |   ``LivelinessLostInfo``    | Tracks the status of the number of times           |
-|         |                             | a writer lost liveliness.                          |
-+---------+-----------------------------+----------------------------------------------------+
-|  5      |   ``LivelinessChangedInfo`` | Tracks the status of the number of times           |
-|         |                             | the liveliness changed in a reader.                |
-+---------+-----------------------------+----------------------------------------------------+
-|  6      |  ``DeadlineMissedInfo``     | The Status of the number of deadlines              |
-|         |                             | missed of a sample for that entity.                |
-+---------+-----------------------------+----------------------------------------------------+
-|  7      |     ``SampleLostInfo``      | Tracks the status of the number of times           |
-|         |                             | this entity lost samples.                          |
-+---------+-----------------------------+----------------------------------------------------+
-|  8      | ``ExtendedIncompatibleQoS`` | Stores the list of remote incompatible ``GUIDs``   |
-|         |                             | and QoS policies for each local entity guid.       |
-+---------+-----------------------------+----------------------------------------------------+
++---------+-----------------------------+------------------------------------------------------+
+|**Value**|          **Name**           | **Description**                                      |
++---------+-----------------------------+------------------------------------------------------+
+|  0      |     ``ProxyInfo``           | Collection of Parameters describing the              |
+|         |                             | ``Proxy Data`` of that entity. Contains optional qos.|
++---------+-----------------------------+------------------------------------------------------+
+|  1      |     ``ConnectionList``      | List of connections that this entity is              |
+|         |                             | using with its matched remote entities.              |
++---------+-----------------------------+------------------------------------------------------+
+|  2      |  ``IncompatibleQoSInfo``    | Status of the Incompatible QoS                       |
+|         |                             | of that entity.                                      |
++---------+-----------------------------+------------------------------------------------------+
+|  3      | ``InconsistentTopicInfo``   | Status of Inconsistent topics that the               |
+|         |                             | topic of that entity has.                            |
++---------+-----------------------------+------------------------------------------------------+
+|  4      |   ``LivelinessLostInfo``    | Tracks the status of the number of times             |
+|         |                             | a writer lost liveliness.                            |
++---------+-----------------------------+------------------------------------------------------+
+|  5      |   ``LivelinessChangedInfo`` | Tracks the status of the number of times             |
+|         |                             | the liveliness changed in a reader.                  |
++---------+-----------------------------+------------------------------------------------------+
+|  6      |  ``DeadlineMissedInfo``     | The Status of the number of deadlines                |
+|         |                             | missed of a sample for that entity.                  |
++---------+-----------------------------+------------------------------------------------------+
+|  7      |     ``SampleLostInfo``      | Tracks the status of the number of times             |
+|         |                             | this entity lost samples.                            |
++---------+-----------------------------+------------------------------------------------------+
+|  8      | ``ExtendedIncompatibleQoS`` | Stores the list of remote incompatible ``GUIDs``     |
+|         |                             | and QoS policies for each local entity guid.         |
++---------+-----------------------------+------------------------------------------------------+
 
 .. note::
 

--- a/docs/fastdds/statistics/monitor_service/monitor_service_topics.rst
+++ b/docs/fastdds/statistics/monitor_service/monitor_service_topics.rst
@@ -61,6 +61,12 @@ The possible values are described in the following table:
 
 .. note::
 
+    The ``ProxyInfo`` within the ``Monitor Service Status Topic``
+    always includes the :ref:`optional qos <property_serialize_optional_qos>` independently of the
+    ``fastdds.serialize_optional_qos`` property.
+
+.. note::
+
     If the service is enabled in a :ref:`RTPS layer <rtps_layer>` context, :ref:`not all
     the statuses will be published <monitor_service_in_rtps_note>`,
     only the ``ProxyInfo`` and ``ConnectionList``.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the proper documentation for the related feature.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#5818

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
