### PR TITLE
[23264] Add `DataWriter` sample prefilter documentation

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -3307,6 +3307,9 @@ void dds_dataWriter_examples()
                     const FilterSampleInfo& filter_sample_info,
                     const eprosima::fastdds::rtps::GUID_t& reader_guid) const override
             {
+                static_cast<void>(payload);
+                static_cast<void>(filter_sample_info);
+
                 bool sample_should_be_sent = true;
 
                 auto custom_write_data =

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -88,6 +88,7 @@
 .. |DataWriter::register_instance_w_timestamp| replace:: :cpp:func:`DataWriter::register_instance_w_timestamp()<eprosima::fastdds::dds::DataWriter::register_instance_w_timestamp>`
 .. |DataWriter::unregister_instance_w_timestamp| replace:: :cpp:func:`DataWriter::unregister_instance_w_timestamp()<eprosima::fastdds::dds::DataWriter::unregister_instance_w_timestamp>`
 .. |DataWriter::dispose_w_timestamp| replace:: :cpp:func:`DataWriter::dispose_w_timestamp()<eprosima::fastdds::dds::DataWriter::dispose_w_timestamp>`
+.. |DataWriter::set_sample_prefilter| replace:: :cpp:func:`DataWriter::set_sample_prefilter()<eprosima::fastdds::dds::DataWriter::set_sample_prefilter>`
 
 .. |DataWriterListener-api| replace:: :cpp:class:`DataWriterListener <eprosima::fastdds::dds::DataWriterListener>`
 
@@ -238,6 +239,8 @@
 
 .. |IContentFilter-api| replace:: :cpp:class:`IContentFilter<eprosima::fastdds::dds::IContentFilter>`
 .. |IContentFilter::evaluate-api| replace:: :cpp:func:`evaluate()<eprosima::fastdds::dds::IContentFilter::evaluate>`
+.. |FilteredSampleInfo-api| replace:: :cpp:class:`FilteredSampleInfo<eprosima::fastdds::dds::IContentFilter::FilteredSampleInfo>`
+.. |FilteredSampleInfo::user_write_data-api| replace:: :cpp:member:`user_write_data<eprosima::fastdds::dds::IContentFilter::FilteredSampleInfo::user_write_data>`
 .. |IContentFilterFactory-api| replace:: :cpp:class:`IContentFilterFactory<eprosima::fastdds::dds::IContentFilterFactory>`
 .. |IContentFilterFactory::create_content_filter-api| replace:: :cpp:func:`create_content_filter()<eprosima::fastdds::dds::IContentFilterFactory::create_content_filter>`
 .. |IContentFilterFactory::delete_content_filter-api| replace:: :cpp:func:`delete_content_filter()<eprosima::fastdds::dds::IContentFilterFactory::delete_content_filter>`
@@ -1122,6 +1125,7 @@
 .. |WriteParams-api| replace:: :cpp:class:`WriteParams <eprosima::fastdds::rtps::WriteParams>`
 .. |WriteParams-sample_identity-api| replace:: :cpp:func:`sample_identity() <eprosima::fastdds::rtps::WriteParams::sample_identity>`
 .. |WriteParams-related_sample_identity-api| replace:: :cpp:func:`related_sample_identity() <eprosima::fastdds::rtps::WriteParams::related_sample_identity>`
+.. |WriteParams-user_write_data-api| replace:: :cpp:func:`user_write_data() <eprosima::fastdds::rtps::WriteParams::user_write_data>`
 
 .. |ThreadSettings::scheduling_policy-api| replace:: :cpp:member:`scheduling_policy<eprosima::fastdds::rtps::ThreadSettings::scheduling_policy>`
 .. |ThreadSettings::priority-api| replace:: :cpp:member:`priority<eprosima::fastdds::rtps::ThreadSettings::priority>`

--- a/docs/fastdds/dds_layer/publisher/dataWriter/publishingData.rst
+++ b/docs/fastdds/dds_layer/publisher/dataWriter/publishingData.rst
@@ -100,16 +100,11 @@ within |FilteredSampleInfo::user_write_data-api|.
 If the return value of |IContentFilter::evaluate-api| is ``false``, the sample will not be sent to the DataReader
 identified by its |Guid_t-api| in the method's input argument.
 
-Constraints
-^^^^^^^^^^^
+.. warning::
 
-The following constraints must be met when using the prefiltering mechanism:
-
-* The :ref:`dds_layer_topic_contentFilteredTopic_writer_restrictions` are fulfilled.
-
-* Prefiltering is currently incompatible with :ref:`datasharingqospolicy`.
-  Hence, ensure that the |DataSharingQosPolicy::kind-api| is set to ``OFF`` or
-  if ``AUTO`` is used, :ref:`constraints<datasharing-delivery-constraints>` are not met.
+    Prefiltering is currently incompatible with :ref:`datasharingqospolicy`.
+    Hence, ensure that the |DataSharingQosPolicy::kind-api| is set to ``OFF`` or
+    if ``AUTO`` is used, :ref:`constraints<datasharing-delivery-constraints>` are not met.
 
 Next is an example of how to use the prefiltering mechanism:
 

--- a/docs/fastdds/dds_layer/publisher/dataWriter/publishingData.rst
+++ b/docs/fastdds/dds_layer/publisher/dataWriter/publishingData.rst
@@ -99,6 +99,8 @@ the content of the sample (|SerializedPayload_t-api|) and/or the |WriteParams-us
 within |FilteredSampleInfo::user_write_data-api|.
 If the return value of |IContentFilter::evaluate-api| is ``false``, the sample will not be sent to the DataReader
 identified by its |Guid_t-api| in the method's input argument.
+It is strongly recommended that the |IContentFilter::evaluate-api| implementation does not perform any blocking
+operation neither use the DataWriter, as this may lead to deadlocks or undesired behavior.
 
 .. warning::
 

--- a/docs/fastdds/dds_layer/publisher/dataWriter/publishingData.rst
+++ b/docs/fastdds/dds_layer/publisher/dataWriter/publishingData.rst
@@ -89,7 +89,7 @@ Otherwise the DataWriter may run out of samples.
 Prefiltering out DataReaders
 ----------------------------
 
-User can use an overloaded of the |DataWriter::write-api| providing a |WriteParams-api| structure.
+The user can use an overload of the |DataWriter::write-api| method that allows providing a |WriteParams-api| structure.
 One of the members of this latter structure is the |WriteParams-user_write_data-api| in which the user
 can store extra information to be used by the prefiltering mechanism.
 
@@ -99,8 +99,8 @@ the content of the sample (|SerializedPayload_t-api|) and/or the |WriteParams-us
 within |FilteredSampleInfo::user_write_data-api|.
 If the return value of |IContentFilter::evaluate-api| is ``false``, the sample will not be sent to the DataReader
 identified by its |Guid_t-api| in the method's input argument.
-It is strongly recommended that the |IContentFilter::evaluate-api| implementation does not perform any blocking
-operation neither use the DataWriter, as this may lead to deadlocks or undesired behavior.
+It is strongly recommended that the |IContentFilter::evaluate-api| implementation neither performs any blocking
+operation nor uses the DataWriter, as this may lead to deadlocks or undesired behavior.
 
 .. warning::
 

--- a/docs/fastdds/dds_layer/publisher/dataWriter/publishingData.rst
+++ b/docs/fastdds/dds_layer/publisher/dataWriter/publishingData.rst
@@ -83,3 +83,38 @@ Otherwise the DataWriter may run out of samples.
     :start-after: //DDS_DATAWRITER_LOAN_SAMPLES
     :end-before: //!
     :dedent: 8
+
+.. _dds_layer_publisher_prefiltering:
+
+Prefiltering out DataReaders
+----------------------------
+
+User can use an overloaded of the |DataWriter::write-api| providing a |WriteParams-api| structure.
+One of the members of this latter structure is the |WriteParams-user_write_data-api| in which the user
+can store extra information to be used by the prefiltering mechanism.
+
+By implementing the |IContentFilter-api| and passing it to the DataWriter with |DataWriter::set_sample_prefilter|,
+user can prevent the DataWriter from sending samples to the matched DataReaders based on both:
+the content of the sample (|SerializedPayload_t-api|) and/or the |WriteParams-user_write_data-api|
+within |FilteredSampleInfo::user_write_data-api|.
+If the return value of |IContentFilter::evaluate-api| is ``false``, the sample will not be sent to the DataReader
+identified by its |Guid_t-api| in the method's input argument.
+
+Constraints
+^^^^^^^^^^^
+
+The following constraints must be met when using the prefiltering mechanism:
+
+* The :ref:`dds_layer_topic_contentFilteredTopic_writer_restrictions` are fulfilled.
+
+* Prefiltering is currently incompatible with :ref:`datasharingqospolicy`.
+  Hence, ensure that the |DataSharingQosPolicy::kind-api| is set to ``OFF`` or
+  if ``AUTO`` is used, :ref:`constraints<datasharing-delivery-constraints>` are not met.
+
+Next is an example of how to use the prefiltering mechanism:
+
+.. literalinclude:: /../code/DDSCodeTester.cpp
+    :language: c++
+    :start-after: //DDS_DATAWRITER_SAMPLE_PREFILTER
+    :end-before: //!
+    :dedent: 8

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -239,6 +239,10 @@ preallocated
 preallocates
 preallocation
 preconfigure
+prefilter
+Prefilter
+prefiltering
+Prefiltering
 prepended
 preprocessor
 programmatically


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the proper documentation of the corresponding feature in `Fast DDS`

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#5861


## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [X] Code snippets related to the added documentation have been provided.
- [X] Documentation tests pass locally.
- NO Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
