### PR TITLE
[23271] Add documentation for custom request scheduling

### DIFF
--- a/docs/fastddsgen/interfaces/exceptions.rst
+++ b/docs/fastddsgen/interfaces/exceptions.rst
@@ -1,7 +1,7 @@
 .. _fastddsgen_interfaces_exceptions:
 
 Exceptions
-----------
+==========
 
 Exceptions are user-defined structures that can be raised by members of an interface.
 They are declared similarly to ``struct`` types; using the ``exception`` keyword,

--- a/docs/fastddsgen/interfaces/interfaces.rst
+++ b/docs/fastddsgen/interfaces/interfaces.rst
@@ -1,7 +1,7 @@
 .. _fastddsgen_interfaces_definition:
 
 Defining an IDL interface
--------------------------
+=========================
 
 *eProsima Fast DDS-Gen* allows the generation of the code required by both the client and the server
 to use the *Fast DDS* Request-Reply internal API (see :ref:`request_reply_api_intro`),
@@ -10,7 +10,7 @@ The following subsections will describe how to define an IDL interface for simpl
 and data streaming.
 
 IDL specification overview
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------
 
 The `OMG IDL specification <https://www.omg.org/spec/IDL/4.2/PDF>`_ defines interfaces
 that client and server objects may use, for example, in the context of a *Remote Procedure Calls* communication
@@ -45,7 +45,7 @@ Interfaces can also be forward declared, for example :code:`interface MyInterfac
 .. _fastddsgen_interfaces_data_streaming:
 
 Defining data streaming operations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------
 
 *eProsima Fast DDS-Gen* allows to generate code for data streaming in each use case
 described in :ref:`rpc_data_streaming_intro`, using the ``@feed`` builtin annotation in operations:
@@ -67,7 +67,7 @@ with ``@feed`` annotations input parameters, return types or both, respectively.
 
 
 Example
-^^^^^^^
+-------
 
 The following example shows how to define an interfaces, addressing the cases described before:
 

--- a/docs/fastddsgen/interfaces/introduction.rst
+++ b/docs/fastddsgen/interfaces/introduction.rst
@@ -22,3 +22,4 @@ and how to develop RPC Client/Server applications.
    /fastddsgen/interfaces/exceptions
    /fastddsgen/rpc_calculator_basic_app/intro
    /fastddsgen/rpc_calculator_feed_app/intro
+   /fastddsgen/rpc_server_schedule/intro

--- a/docs/fastddsgen/interfaces/introduction.rst
+++ b/docs/fastddsgen/interfaces/introduction.rst
@@ -11,8 +11,8 @@ from an IDL file. The IDL file must contain the operation that can be called on 
 and the parameters that can be passed to them. These operations are specified using the concept of interfaces
 defined in the OMG IDL `specification <https://www.omg.org/spec/IDL/4.2/PDF>`_.
 
-The next subsections serves as a guide to how to define your own IDL interface, how to define exceptions for its operations,
-and how to develop RPC Client/Server applications.
+The next subsections serves as a guide to how to define your own IDL interface, how to define exceptions for its
+operations, and how to develop RPC Client/Server applications.
 
 
 .. toctree::

--- a/docs/fastddsgen/interfaces/introduction.rst
+++ b/docs/fastddsgen/interfaces/introduction.rst
@@ -11,8 +11,14 @@ from an IDL file. The IDL file must contain the operation that can be called on 
 and the parameters that can be passed to them. These operations are specified using the concept of interfaces
 defined in the OMG IDL `specification <https://www.omg.org/spec/IDL/4.2/PDF>`_.
 
-The next subsections serves as a guide to how to define your own IDL interface and
-how to define exceptions for its operations.
+The next subsections serves as a guide to how to define your own IDL interface, how to define exceptions for its operations,
+and how to develop RPC Client/Server applications.
 
-.. include:: includes/interfaces.rst
-.. include:: includes/exceptions.rst
+
+.. toctree::
+   :maxdepth: 2
+
+   /fastddsgen/interfaces/interfaces
+   /fastddsgen/interfaces/exceptions
+   /fastddsgen/rpc_calculator_basic_app/intro
+   /fastddsgen/rpc_calculator_feed_app/intro

--- a/docs/fastddsgen/rpc_calculator_basic_app/includes/code_generation.rst
+++ b/docs/fastddsgen/rpc_calculator_basic_app/includes/code_generation.rst
@@ -138,11 +138,13 @@ the client sends a new request using its internal Requester and waits for the re
 calculatorServer
 """"""""""""""""
 
-Contains the ``CalculatorServerLogic`` class which implements the generic |RpcServer-api| interface, representing the public API of the server.
+Contains the ``CalculatorServerLogic`` class which implements the generic |RpcServer-api| interface, representing
+the public API of the server.
 User can run or stop a server calling |RpcServer::run-api| or |RpcServer::stop-api| methods, respectively.
 
 The generated class can be instantiated by the user calling ``create_CalculatorServer`` function.
-Two overloads of this funcion are created, allowing the user to :ref:`customize the scheduling <fastddsgen_rpc_server_schedule_intro>` of the incoming requests.
+Two overloads of this function are created, allowing the user to
+:ref:`customize the scheduling <fastddsgen_rpc_server_schedule_intro>` of the incoming requests.
 
 calculatorServerImpl
 """"""""""""""""""""

--- a/docs/fastddsgen/rpc_calculator_basic_app/includes/code_generation.rst
+++ b/docs/fastddsgen/rpc_calculator_basic_app/includes/code_generation.rst
@@ -138,11 +138,11 @@ the client sends a new request using its internal Requester and waits for the re
 calculatorServer
 """"""""""""""""
 
-Contains the ``CalculatorServerLogic`` class, which implements the server for the calculator interface and
-can be instantiated by the user calling ``create_CalculatorServer`` function.
+Contains the ``CalculatorServerLogic`` class which implements the generic |RpcServer-api| interface, representing the public API of the server.
+User can run or a stop a server calling |RpcServer::run-api| or |RpcServer::stop-api| methods, respectively.
 
-``CalculatorServer`` struct represents the public API of the server. User can run or a stop a server calling
-``CalculatorServer::run()`` or ``CalculatorServer::stop()`` methods, respectively.
+The generated class can be instantiated by the user calling ``create_CalculatorServer`` function.
+Two overloads of this funcion are created, allowing the user to :ref:`customize the scheduling <_fastddsgen_rpc_server_schedule_intro>` of the incoming requests.
 
 calculatorServerImpl
 """"""""""""""""""""

--- a/docs/fastddsgen/rpc_calculator_basic_app/includes/code_generation.rst
+++ b/docs/fastddsgen/rpc_calculator_basic_app/includes/code_generation.rst
@@ -139,10 +139,10 @@ calculatorServer
 """"""""""""""""
 
 Contains the ``CalculatorServerLogic`` class which implements the generic |RpcServer-api| interface, representing the public API of the server.
-User can run or a stop a server calling |RpcServer::run-api| or |RpcServer::stop-api| methods, respectively.
+User can run or stop a server calling |RpcServer::run-api| or |RpcServer::stop-api| methods, respectively.
 
 The generated class can be instantiated by the user calling ``create_CalculatorServer`` function.
-Two overloads of this funcion are created, allowing the user to :ref:`customize the scheduling <_fastddsgen_rpc_server_schedule_intro>` of the incoming requests.
+Two overloads of this funcion are created, allowing the user to :ref:`customize the scheduling <fastddsgen_rpc_server_schedule_intro>` of the incoming requests.
 
 calculatorServerImpl
 """"""""""""""""""""

--- a/docs/fastddsgen/rpc_server_schedule/intro.rst
+++ b/docs/fastddsgen/rpc_server_schedule/intro.rst
@@ -6,7 +6,8 @@
 Customizing RPC Server request scheduling
 =========================================
 
-When processing an interface inside an IDL file, *Fast DDS-Gen* generates two method overloads for the creation of a server.
+When processing an interface inside an IDL file, *Fast DDS-Gen* generates two method overloads for the creation of a
+server.
 
 The first overload creates a server with a request scheduling based on a thread pool.
 Each request will be processed in a separate thread.
@@ -17,9 +18,12 @@ This is done by creating a custom class implementing the |RpcServerSchedulingStr
 A shared pointer to the custom class is then passed in the ``scheduler`` argument of the method.
 
 Special care must be taken when implementing a custom scheduling strategy.
-Calls to |RpcServerSchedulingStrategy::schedule_request-api| will be performed from the thread executing the server's |RpcServer::run-api| method.
-This means that incoming messages will not be processed until the execution of |RpcServerSchedulingStrategy::schedule_request-api| finishes.
-This becomes particularly important for operations that have input feed parameters, since values for input feeds will not be processed while inside that method.
+Calls to |RpcServerSchedulingStrategy::schedule_request-api| will be performed from the thread executing the server's
+|RpcServer::run-api| method.
+This means that incoming messages will not be processed until the execution of
+|RpcServerSchedulingStrategy::schedule_request-api| finishes.
+This becomes particularly important for operations that have input feed parameters, since values for input feeds will
+not be processed while inside that method.
 
 Example
 """""""

--- a/docs/fastddsgen/rpc_server_schedule/intro.rst
+++ b/docs/fastddsgen/rpc_server_schedule/intro.rst
@@ -1,0 +1,33 @@
+.. include:: ../../03-exports/aliases-api.include
+.. include:: ../../03-exports/roles.include
+
+.. _fastddsgen_rpc_server_schedule_intro:
+
+Customizing RPC Server request scheduling
+=========================================
+
+When processing an interface inside an IDL file, *Fast DDS-Gen* generates two method overloads for the creation of a server.
+
+The first overload creates a server with a request scheduling based on a thread pool.
+Each request will be processed in a separate thread.
+The number of threads in the pool is specified in the ``thread_pool_size`` argument of the method.
+
+The second overload allows the user to inject a custom scheduling strategy for the created server.
+This is done by creating a custom class implementing the |RpcServerSchedulingStrategy-api| interface.
+A shared pointer to the custom class is then passed in the ``scheduler`` argument of the method.
+
+Special care must be taken when implementing a custom scheduling strategy.
+Calls to |RpcServerSchedulingStrategy::schedule_request-api| will be performed from the thread executing the server's |RpcServer::run-api| method.
+This means that incoming messages will not be processed until the execution of |RpcServerSchedulingStrategy::schedule_request-api| finishes.
+This becomes particularly important for operations that have input feed parameters, since values for input feeds will not be processed while inside that method.
+
+Example
+"""""""
+
+The following code snippet shows two examples of custom RPC server scheduling strategies:
+
+.. literalinclude:: /../code/DDSCodeTester.cpp
+      :language: c++
+      :start-after: //!--RPC_CUSTOM_SCHEDULING_EXAMPLES
+      :end-before: //!--
+      :dedent: 4

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,8 +72,6 @@
    /fastddsgen/python_bindings/python_bindings
    /fastddsgen/dataTypes/dataTypes
    /fastddsgen/interfaces/introduction
-   /fastddsgen/rpc_calculator_basic_app/intro
-   /fastddsgen/rpc_calculator_feed_app/intro
 
 .. _index_cli:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds documentation for the feature introduced in https://github.com/eProsima/Fast-DDS-Gen/pull/482, and refactored in https://github.com/eProsima/Fast-DDS-Gen/pull/485

It also refactors the documentation on Fast DDS Gen for IDL interfaces, so that all topics are grouped under a single first-level title.

It is built on top of the following PR, and should be merged afterwards:
* https://github.com/eProsima/Fast-DDS-docs/pull/1088

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
