### PR TITLE
[22973] Support modules in IDL parser

### DIFF
--- a/docs/fastdds/xtypes/idl_parsing.rst
+++ b/docs/fastdds/xtypes/idl_parsing.rst
@@ -30,7 +30,6 @@ For further information about the supported |DynamicTypes|, please, refer to :re
 * :ref:`xtypes_supportedtypes_sequence`
 * :ref:`xtypes_supportedtypes_union`
 * :ref:`xtypes_supportedtypes_enumeration`
-* :ref:`xtypes_annotations`
 * Arithmetic expressions
 * Union/struct forward declarations
 * Modules/scoped types
@@ -40,7 +39,7 @@ The following types are currently not supported by the IDL parsing feature:
 * :ref:`xtypes_supportedtypes_bitmask`
 * :ref:`xtypes_supportedtypes_map`
 * :ref:`xtypes_supportedtypes_bitset`
-* :ref:`xtypes_builtin_annotations`
+* :ref:`xtypes_annotations`
 * Inheritance
 * Member ID
 

--- a/docs/fastdds/xtypes/idl_parsing.rst
+++ b/docs/fastdds/xtypes/idl_parsing.rst
@@ -33,6 +33,7 @@ For further information about the supported |DynamicTypes|, please, refer to :re
 * :ref:`xtypes_annotations`
 * Arithmetic expressions
 * Union/struct forward declarations
+* Modules/scoped types
 
 The following types are currently not supported by the IDL parsing feature:
 
@@ -40,7 +41,6 @@ The following types are currently not supported by the IDL parsing feature:
 * :ref:`xtypes_supportedtypes_map`
 * :ref:`xtypes_supportedtypes_bitset`
 * :ref:`xtypes_builtin_annotations`
-* Module
 * Inheritance
 * Member ID
 
@@ -51,6 +51,11 @@ Example
 |DynamicTypeBuilderFactory-api| using |DynamicTypeBuilderFactory::create_type_w_uri|.
 After getting the DynamicType, objects of |DynamicPubSubType-api| class might be instantiated and used to write/read
 data.
+
+.. warning::
+
+    |DynamicTypeBuilderFactory::create_type_w_uri| requires the fully qualified name of the
+    type defined in the IDL file. If no scope is provided, global scope is assumed.
 
 .. note::
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description

This PR adds the documentation related to:
- https://github.com/eProsima/Fast-DDS/pull/5890
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_ Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
