### PR TITLE
[23432] Documentation for transport priority feature

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -4428,6 +4428,18 @@ void dds_qos_examples()
     }
 
     {
+        //DDS_CHANGE_TRANSPORT_PRIORITY_QOS_POLICY
+        // This example only applies to DataWriter entities
+        DataWriterQos writer_qos;
+        // The TransportPriorityQosPolicy is constructed with value 0 by default
+        // Change the strength to 12
+        writer_qos.transport_priority().value = 12;
+        // Use modified QoS in the creation of the corresponding DataWriter
+        writer_ = publisher_->create_datawriter(topic_, writer_qos);
+        //!--
+    }
+
+    {
         //DDS_CHANGE_PARTITION_QOS_POLICY
         // This example uses a Publisher, but it can also be applied to Subscriber entities
         PublisherQos publisher_qos;

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -1737,6 +1737,8 @@
                 </nack_supression_duration>
             </times>
 
+            <transport_priority>12</transport_priority>
+
             <unicastLocatorList>
                 <!-- LOCATOR_LIST -->
                 <locator>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -72,7 +72,7 @@
             <lease_duration>
                 <sec>1</sec>
             </lease_duration>
-	    <kind>AUTOMATIC</kind>
+            <kind>AUTOMATIC</kind>
         </liveliness>
     </qos>
 </data_reader>
@@ -82,7 +82,7 @@
 <data_writer profile_name="writer_xml_conf_ownership_profile">
     <qos>
       <ownership>
-	    <kind>EXCLUSIVE</kind>
+        <kind>EXCLUSIVE</kind>
       </ownership>
     </qos>
 </data_writer>
@@ -90,7 +90,7 @@
 <data_reader profile_name="reader_xml_conf_ownership_profile">
     <qos>
         <ownership>
-	    <kind>EXCLUSIVE</kind>
+            <kind>EXCLUSIVE</kind>
         </ownership>
     </qos>
 </data_reader>
@@ -100,7 +100,7 @@
 <data_writer profile_name="writer_xml_conf_ownership_strength_profile">
     <qos>
         <ownershipStrength>
-	    <value>10</value>
+            <value>10</value>
         </ownershipStrength>
     </qos>
 </data_writer>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -106,6 +106,12 @@
 </data_writer>
 <!--><-->
 
+<!-->PUBSUB_API_CONF_PUBSUB_TRANSPORT_PRIORITY<-->
+<data_writer profile_name="writer_xml_conf_transport_priority_profile">
+    <transport_priority>12</transport_priority>
+</data_writer>
+<!--><-->
+
 <!-->CONF-QOS-DATASHARING<-->
 <!--
 <?xml version="1.0" encoding="UTF-8" ?>

--- a/code/XMLTesterExample.xml
+++ b/code/XMLTesterExample.xml
@@ -610,6 +610,8 @@
                 </nack_supression_duration>
             </times>
 
+            <transport_priority>-20</transport_priority>
+
             <unicastLocatorList>
                 <locator>
                     <udpv4>

--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -1296,9 +1296,6 @@ Example
 TransportPriorityQosPolicy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. warning::
-    This QoS Policy will be implemented in future releases.
-
 The purpose of this QoS Policy is to allow the service to take advantage of those transports capable of sending
 messages with different priorities. It establishes the priority of the underlying transport used to send the data.
 See |TransportPriorityQosPolicy-api|
@@ -1310,7 +1307,7 @@ List of QoS Policy data members:
 +-------------------------------------------------------------------------------------+----------------+---------------+
 | Data Member Name                                                                    | Type           | Default Value |
 +=====================================================================================+================+===============+
-| |TransportPriorityQosPolicy::value-api|                                             | ``uint32_t``   | 0             |
+| |TransportPriorityQosPolicy::value-api|                                             | ``int32_t``    | 0             |
 +-------------------------------------------------------------------------------------+----------------+---------------+
 
 .. note::

--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -1315,6 +1315,22 @@ List of QoS Policy data members:
      :raw-html:`<br />`
      It can be changed on enabled entities.
 
+Example
+"""""""
+
+.. tab-set-code::
+
+    .. literalinclude:: /../code/DDSCodeTester.cpp
+        :language: c++
+        :dedent: 8
+        :start-after: //DDS_CHANGE_TRANSPORT_PRIORITY_QOS_POLICY
+        :end-before: //!
+
+    .. literalinclude:: /../code/XMLTester.xml
+        :language: xml
+        :start-after: <!-->PUBSUB_API_CONF_PUBSUB_TRANSPORT_PRIORITY
+        :end-before: <!--><-->
+
 
 .. _userdataqospolicy:
 

--- a/docs/fastdds/xml_configuration/datawriter.rst
+++ b/docs/fastdds/xml_configuration/datawriter.rst
@@ -55,9 +55,13 @@ The DataWriter configuration is performed through the XML elements listed in the
      - :ref:`CommonQOS`
      -
    * - ``<times>``
-     - It configures some time related parameters  of the DataWriter.
+     - It configures some time related parameters of the DataWriter.
      - :ref:`WriterTimes <pubtimes>`
      -
+   * - ``<transport_priority>``
+     - It configures the :ref:`transport priority <transportpriorityqospolicy>` of the DataWriter.
+     - ``int32_t``
+     - 0
    * - ``<unicastLocatorList>``
      - List of input unicast locators.
        It expects a :ref:`LocatorListType`.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This updates the documentation with the support of TransportPriority QoS policy.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#5933

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
