### PR TITLE
[#23483] Added cmake-arg 'USE_PYTHON_STABLE_ABI'

### DIFF
--- a/docs/installation/configuration/cmake_options.rst
+++ b/docs/installation/configuration/cmake_options.rst
@@ -154,6 +154,15 @@ dependency on other options.
 
         - ``OFF`` |br| ``Address`` |br| ``Thread``
         - ``OFF``
+    *   - :class:`USE_PYTHON_STABLE_ABI`
+        - Enables building a Python extension module using the Stable ABI (Application Binary Interface),
+          allowing the resulting binary to be used across multiple Python 3 minor versions without recompilation.
+
+          When is enabled, the extension is compatible with all newer (>= 3.9) Python 3.x interpreters
+          (e.g.: A module built for Python 3.13 will work unmodified on 3.12, 3.11, etc.)
+
+        - ``ON`` ``OFF``
+        - ``OFF``
 
 .. _POSIX: https://man7.org/linux/man-pages/man3/pthread_rwlockattr_setkind_np.3.html
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

- Added CMake argument: **'USE_PYTHON_STABLE_ABI'** in "7. CMake options" page.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [ ] Code snippets related to the added documentation have been provided.
- [ ] Documentation tests pass locally.
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
