### PR TITLE
Fix deprecation warning in CustomChainingTransport

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -114,6 +114,7 @@ public:
             const CustomChainingTransportDescriptor& descriptor)
         : ChainingTransport(descriptor)
         , descriptor_(descriptor)
+        , transport_priority_(0)
     {
     }
 
@@ -136,7 +137,7 @@ public:
 
         // Call low level transport
         return low_sender_resource->send(buffers, total_bytes, destination_locators_begin,
-                       destination_locators_end, timeout);
+                       destination_locators_end, timeout, transport_priority_);
     }
 
     void receive(
@@ -157,6 +158,7 @@ public:
 private:
 
     CustomChainingTransportDescriptor descriptor_;
+    uint32_t transport_priority_;
 };
 //!--
 

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -114,7 +114,6 @@ public:
             const CustomChainingTransportDescriptor& descriptor)
         : ChainingTransport(descriptor)
         , descriptor_(descriptor)
-        , transport_priority_(0)
     {
     }
 
@@ -137,7 +136,25 @@ public:
 
         // Call low level transport
         return low_sender_resource->send(buffers, total_bytes, destination_locators_begin,
-                       destination_locators_end, timeout, transport_priority_);
+                       destination_locators_end, timeout, 0);
+    }
+
+    bool send_w_priority(
+            eprosima::fastdds::rtps::SenderResource* low_sender_resource,
+            const std::vector<eprosima::fastdds::rtps::NetworkBuffer>& buffers,
+            uint32_t total_bytes,
+            eprosima::fastdds::rtps::LocatorsIterator* destination_locators_begin,
+            eprosima::fastdds::rtps::LocatorsIterator* destination_locators_end,
+            const std::chrono::steady_clock::time_point& timeout,
+            int32_t transport_priority) override
+    {
+        //
+        // Preprocess outcoming buffer.
+        //
+
+        // Call low level transport
+        return low_sender_resource->send(buffers, total_bytes, destination_locators_begin,
+                       destination_locators_end, timeout, transport_priority);
     }
 
     void receive(
@@ -158,7 +175,6 @@ public:
 private:
 
     CustomChainingTransportDescriptor descriptor_;
-    uint32_t transport_priority_;
 };
 //!--
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description

This PR fixes a deprecation warning in `DDSCodeTester.cpp` caused by calling `SenderResource::send()` without specifying the transport priority.

<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
