### PR TITLE
[23592] Add missing fields to transport descriptor documentation

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -4045,6 +4045,26 @@
                 <port_queue_capacity>512</port_queue_capacity>
                 <healthy_check_timeout_ms>1000</healthy_check_timeout_ms>
                 <rtps_dump_file>rtsp_messages.log</rtps_dump_file>
+                <default_reception_threads>
+                    <scheduling_policy>-1</scheduling_policy>
+                    <priority>0</priority>
+                    <affinity>0</affinity>
+                    <stack_size>-1</stack_size>
+                </default_reception_threads>
+                <reception_threads>
+                    <reception_thread port="12345">
+                        <scheduling_policy>-1</scheduling_policy>
+                        <priority>0</priority>
+                        <affinity>0</affinity>
+                        <stack_size>-1</stack_size>
+                    </reception_thread>
+                </reception_threads>
+                <dump_thread>
+                    <scheduling_policy>-1</scheduling_policy>
+                    <priority>0</priority>
+                    <affinity>0</affinity>
+                    <stack_size>-1</stack_size>
+                </dump_thread>
             </transport_descriptor>
         </transport_descriptors>
 <!-->

--- a/docs/fastdds/xml_configuration/transports.rst
+++ b/docs/fastdds/xml_configuration/transports.rst
@@ -1,6 +1,7 @@
 .. include:: ../../03-exports/aliases.include
 .. include:: ../../03-exports/aliases-api.include
 .. include:: ../../03-exports/roles.include
+.. include:: ../includes/aliases.rst
 
 .. _transportdescriptors:
 
@@ -23,120 +24,146 @@ The following table lists all the available XML elements that can be defined wit
 element for the configuration of the transport layer.
 A more detailed explanation of each of these elements can be found in :ref:`comm-transports-configuration`.
 
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| Name                          | Description                                        | Values               | Default  |
-+===============================+====================================================+======================+==========+
-| ``<transport_id>``            | Unique name to identify each transport             | ``string``           |          |
-|                               | descriptor.                                        |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<type>``                    | Type of the transport descriptor.                  | UDPv4                | UDPv4    |
-|                               |                                                    +----------------------+          |
-|                               |                                                    | UDPv6                |          |
-|                               |                                                    +----------------------+          |
-|                               |                                                    | TCPv4                |          |
-|                               |                                                    +----------------------+          |
-|                               |                                                    | TCPv6                |          |
-|                               |                                                    +----------------------+          |
-|                               |                                                    | SHM                  |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<sendBufferSize>``          | Size in bytes of the send socket buffer.           | ``uint32_t``         | 0        |
-|                               | If the value is zero then *Fast DDS* will use      |                      |          |
-|                               | the system default socket size.                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<receiveBufferSize>``       | Size in bytes of the reception socket              | ``uint32_t``         | 0        |
-|                               | buffer. If the value is zero then *Fast DDS*       |                      |          |
-|                               | will use the system default socket size.           |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<maxMessageSize>``          | The maximum size in bytes of the transport's       | ``uint32_t``         | 65500    |
-|                               | message buffer.                                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<maxInitialPeersRange>``    | Number of channels opened with each initial        | ``uint32_t``         | 4        |
-|                               | remote peer.                                       |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<netmask_filter>``          | Transport's :ref:`netmask_filtering`               | OFF                  | AUTO     |
-|                               | configuration.                                     +----------------------+          |
-|                               |                                                    | AUTO                 |          |
-|                               |                                                    +----------------------+          |
-|                               |                                                    | ON                   |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<interfaces>``              | Allows defining an :ref:`ifaces_config`.           | :ref:`ifaces_config` |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<interfaceWhiteList>``      | Allows defining an interfaces |whitelist|.         | |whitelist|          |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<TTL>``                     | *Time To Live* (**UDP only**). See                 | ``uint8_t``          | 1        |
-|                               | :ref:`transport_udp_udp`.                          |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<non_blocking_send>``       | Whether to set the non-blocking send mode on       | ``bool``             | ``false``|
-|                               | the socket (**NOT available for SHM type**). See   |                      |          |
-|                               | :ref:`transport_udp_transportDescriptor` and       |                      |          |
-|                               | :ref:`transport_tcp_transportDescriptor`.          |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<output_port>``             | Port used for output bound.                        | ``uint16_t``         | 0        |
-|                               | If this field isn't defined, the output port       |                      |          |
-|                               | will be random (**UDP only**).                     |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<wan_addr>``                | Public WAN address when using **TCPv4**            |  IPv4 formatted      |          |
-|                               | **transports**. This field is optional if the      |  ``string``:         |          |
-|                               | transport doesn't need to define a WAN             |  ``XXX.XXX.XXX.XXX`` |          |
-|                               | address (**TCPv4 only**).                          |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<keep_alive_frequency_ms>`` | Frequency in milliseconds for sending              | ``uint32_t``         | 50000    |
-|                               | :ref:`RTCP <rtcpdefinition>`                       |                      |          |
-|                               | keep-alive requests (**TCP only**).                |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<keep_alive_timeout_ms>``   | Time in milliseconds since the last                | ``uint32_t``         | 10000    |
-|                               | keep-alive request was sent to consider a          |                      |          |
-|                               | connection as broken (**TCP only**).               |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<max_logical_port>``        | The maximum number of logical ports to try         | ``uint16_t``         | 100      |
-|                               | during :ref:`RTCP<rtcpdefinition>`                 |                      |          |
-|                               | negotiations (**TCP only**).                       |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<logical_port_range>``      | The maximum number of logical ports per            | ``uint16_t``         | 20       |
-|                               | request to try during                              |                      |          |
-|                               | :ref:`RTCP<rtcpdefinition>` negotiations           |                      |          |
-|                               | (**TCP only**).                                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<logical_port_increment>``  | Increment between logical ports to try during      | ``uint16_t``         |  2       |
-|                               | :ref:`RTCP<rtcpdefinition>` negotiation            |                      |          |
-|                               | (**TCP only**).                                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<listening_ports>``         | Local port to work as TCP acceptor for input       | ``List <uint16_t>``  |          |
-|                               | connections. If not set, the transport will        |                      |          |
-|                               | work as TCP client only. If set to 0, an           |                      |          |
-|                               | available port will be automatically assigned      |                      |          |
-|                               | (**TCP only**).                                    |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<tls>``                     | Allows to define TLS related parameters and        | :ref:`tcp-tls`       |          |
-|                               | options (**TCP only**).                            |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<calculate_crc>``           | Calculates the Cyclic Redundancy Code (CRC)        | ``bool``             | ``true`` |
-|                               | for error control (**TCP only**).                  |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<check_crc>``               | Check the CRC for error control (**TCP**           | ``bool``             | ``true`` |
-|                               | **only**).                                         |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<enable_tcp_nodelay>``      | Socket option for disabling the Nagle              | ``bool``             | ``false``|
-|                               | algorithm. (**TCP only**).                         |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<tcp_negotiation_timeout>`` | Time to wait for logical port negotiation (in ms)  | ``uint32_t``         | ``0``    |
-|                               |      (**TCP only**).                               |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<segment_size>``            | Size (in bytes) of the shared-memory segment.      | ``uint32_t``         | 262144   |
-|                               | (Optional, **SHM only**).                          |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<port_queue_capacity>``     | Capacity (in number of messages) available to      | ``uint32_t``         | 512      |
-|                               | every Listener (Optional, **SHM only**).           |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<healthy_check_timeout_ms>``| Maximum time-out (in milliseconds) used when       | ``uint32_t``         | 1000     |
-|                               | checking whether a Listener is alive               |                      |          |
-|                               | (Optional, **SHM only**).                          |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
-| ``<rtps_dump_file>``          | Complete path (including file) where RTPS          | ``string``           | Empty    |
-|                               | messages will be stored for debugging              |                      |          |
-|                               | purposes. An empty string indicates no trace       |                      |          |
-|                               | will be performed (Optional, **SHM only**).        |                      |          |
-+-------------------------------+----------------------------------------------------+----------------------+----------+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - Name
+     - Description
+     - Values
+     - Default
+   * - ``<transport_id>``
+     - Unique name to identify each transport descriptor.
+     - ``string``
+     -
+   * - ``<type>``
+     - Type of the transport descriptor.
+     - ``UDPv4``, ``UDPv6``, ``TCPv4``, ``TCPv6``, ``SHM``
+     - ``UDPv4``
+   * - ``<sendBufferSize>``
+     - Size in bytes of the send socket buffer. If the value is zero, *Fast DDS* will use the system default socket size.
+     - ``uint32_t``
+     - ``0``
+   * - ``<receiveBufferSize>``
+     - Size in bytes of the reception socket buffer. If the value is zero, *Fast DDS* will use the system default socket size.
+     - ``uint32_t``
+     - ``0``
+   * - ``<maxMessageSize>``
+     - The maximum size in bytes of the transport's message buffer.
+     - ``uint32_t``
+     - ``65500``
+   * - ``<maxInitialPeersRange>``
+     - Number of channels opened with each initial remote peer.
+     - ``uint32_t``
+     - ``4``
+   * - ``<netmask_filter>``
+     - Transport's :ref:`netmask_filtering` configuration.
+     - ``string``
+     - ``AUTO``
+   * - ``<interfaces>``
+     - Allows defining an :ref:`ifaces_config`.
+     - ``string``
+     -
+   * - ``<interfaceWhiteList>``
+     - Allows defining an interfaces |whitelist|.
+     - ``string``
+     -
+   * - ``<TTL>``
+     - Time To Live (UDP only). See  :ref:`transport_udp_udp`.
+     - ``uint8_t``
+     - ``1``
+   * - ``<non_blocking_send>``
+     - Whether to set the non-blocking send mode on the socket (NOT available for SHM type). See :ref:`transport_udp_transportDescriptor` and :ref:`transport_tcp_transportDescriptor`.
+     - ``bool``
+     - ``false``
+   * - ``<output_port>``
+     - Port used for output bound. If this field isn't defined, the output port will be random (UDP only).
+     - ``uint16_t``
+     - ``0``
+   * - ``<wan_addr>``
+     - Public WAN address when using TCPv4 transports. This field is optional if the transport doesn't need to define a WAN address (TCPv4 only).
+     - ``string``
+     -
+   * - ``<keep_alive_frequency_ms>``
+     - Frequency in milliseconds for sending :ref:`RTCP <rtcpdefinition>` keep-alive requests (TCP only).
+     - ``uint32_t``
+     - ``50000``
+   * - ``<keep_alive_timeout_ms>``
+     - Time in milliseconds since the last keep-alive request was sent to consider a connection as broken (TCP only).
+     - ``uint32_t``
+     - ``10000``
+   * - ``<max_logical_port>``
+     - The maximum number of logical ports to try during :ref:`RTCP <rtcpdefinition>` negotiations (TCP only).
+     - ``uint16_t``
+     - ``100``
+   * - ``<logical_port_range>``
+     - The maximum number of logical ports per request to try during :ref:`RTCP <rtcpdefinition>` negotiations (TCP only).
+     - ``uint16_t``
+     - ``20``
+   * - ``<logical_port_increment>``
+     - Increment between logical ports to try during :ref:`RTCP <rtcpdefinition>` negotiation (TCP only).
+     - ``uint16_t``
+     - ``2``
+   * - ``<listening_ports>``
+     - Local port to work as TCP acceptor for input connections. If not set, the transport will work as TCP client only. If set to 0, an available port will be automatically assigned (TCP only).
+     - ``List<uint16_t>``
+     -
+   * - ``<tls>``
+     - Allows to define TLS related parameters and options (TCP only).
+     - :ref:`tcp-tls`
+     -
+   * - ``<calculate_crc>``
+     - Calculates the Cyclic Redundancy Code (CRC) for error control (TCP only).
+     - ``bool``
+     - ``true``
+   * - ``<check_crc>``
+     - Check the CRC for error control (TCP only).
+     - ``bool``
+     - ``true``
+   * - ``<enable_tcp_nodelay>``
+     - Socket option for disabling the Nagle algorithm (TCP only).
+     - ``bool``
+     - ``false``
+   * - ``<tcp_negotiation_timeout>``
+     - Time to wait for logical port negotiation (in ms) (TCP only).
+     - ``uint32_t``
+     - ``0``
+   * - ``<keep_alive_thread>``
+     - Settings for the keep-alive thread.
+     - |ThreadSettings|
+     -
+   * - ``<accept_thread>``
+     - Settings for the accept thread.
+     - |ThreadSettings|
+     -
+   * - ``<segment_size>``
+     - Size (in bytes) of the shared-memory segment (Optional, SHM only).
+     - ``uint32_t``
+     - ``262144``
+   * - ``<port_queue_capacity>``
+     - Capacity (in number of messages) available to every Listener (Optional, SHM only).
+     - ``uint32_t``
+     - ``512``
+   * - ``<healthy_check_timeout_ms>``
+     - Maximum time-out (in milliseconds) used when checking whether a Listener is alive (Optional, SHM only).
+     - ``uint32_t``
+     - ``1000``
+   * - ``<rtps_dump_file>``
+     - Complete path (including file) where RTPS messages will be stored for debugging purposes. An empty string indicates no trace will be performed (Optional, SHM only).
+     - ``string``
+     - ``Empty``
+   * - ``<default_reception_threads>``
+     - Default |ThreadSettings| for the reception threads.
+     - |ThreadSettings|
+     -
+   * - ``<reception_threads>``
+     - |ThreadSettings| for the reception threads on specific ports.
+     - ``std::map<uint32_t, ThreadSettings>``
+     -
+   * - ``<dump_thread>``
+     - |ThreadSettings| for the SHM dump thread.
+     - |ThreadSettings|
+     -
 
 The following XML code shows an example of transport protocol configuration using all configurable parameters.
 More examples of transports descriptors can be found in the :ref:`comm-transports-configuration` section.
@@ -145,7 +172,7 @@ More examples of transports descriptors can be found in the :ref:`comm-transport
     :language: xml
     :start-after: <!--XML_PROFILES_TRANSPORT_DESCRIPTORS-->
     :end-before: <!--><-->
-    :lines: 2-4, 6-50, 52-53
+    :lines: 2-4, 6-70, 72-73
 
 .. _rtcpdefinition:
 

--- a/docs/fastdds/xml_configuration/transports.rst
+++ b/docs/fastdds/xml_configuration/transports.rst
@@ -1,7 +1,6 @@
 .. include:: ../../03-exports/aliases.include
 .. include:: ../../03-exports/aliases-api.include
 .. include:: ../../03-exports/roles.include
-.. include:: ../includes/aliases.rst
 
 .. _transportdescriptors:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR adds some missing fields to the transport descriptor documentation.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 3.2.x 2.14.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
