### PR TITLE
[23653] Documentation debt: TCP sockets and CA extensions configuration

### DIFF
--- a/docs/fastdds/security/auth_plugin/auth_plugin.rst
+++ b/docs/fastdds/security/auth_plugin/auth_plugin.rst
@@ -179,7 +179,7 @@ However, all other commands are only compatible with Linux OS.
     #default_keyfile = privkey.pem
     distinguished_name= req_distinguished_name
     #attributes = req_attributes
-    #x509_extensions = v3_ca # The extentions to add to the self signed cert
+    x509_extensions = root_ca_extensions # The extensions to add to the self signed cert
     string_mask = utf8only
 
     [ req_distinguished_name ]
@@ -189,6 +189,12 @@ However, all other commands are only compatible with Linux OS.
     0.organizationName = eProsima
     commonName = eProsima Main Test CA
     emailAddress = mainca@eprosima.com
+
+    [root_ca_extensions]
+    basicConstraints = critical, CA:true
+
+.. note::
+   For a self-signed **root CA**, the X.509 extension ``basicConstraints = CA:true`` is **required**. Without it, stacks might not recognize the certificate as a CA.
 
 After writing the configuration file, next commands generate the certificate using the
 Elliptic Curve Digital Signature Algorithm (ECDSA).

--- a/docs/fastdds/use_cases/large_data/large_data.rst
+++ b/docs/fastdds/use_cases/large_data/large_data.rst
@@ -124,6 +124,27 @@ For receiving sockets, the command is:
 
     $> sudo sysctl -w net.core.rmem_max=12582912
 
+Linux also defines per-socket TCP buffer sizes as triplets:
+
+.. code-block:: text
+
+    $> net.ipv4.tcp_wmem = <min> <default> <max> (TCP send buffer)
+    $> net.ipv4.tcp_rmem = <min> <default> <max> (TCP receive buffer)
+
+The middle value is the default used for most connections. If only the global maxima are raised, sockets may still
+use a small default and saturate during bursts.
+Set the current values for sending sockets with:
+
+.. code-block:: bash
+
+    $> sudo sysctl -w net.ipv4.tcp_wmem="4096 12582912 12582912"
+
+For receiving sockets, the command is:
+
+.. code-block:: bash
+
+    $> sudo sysctl -w net.ipv4.tcp_rmem="4096 12582912 12582912"
+
 Windows
 .......
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description


Adding root_CA extensions to the topic 8.1.1.1. and ensuring they’re applied.

Adding an option to change the min, default and max buffer size of sending and receiving sockets to the topic 15.4.1.1.1.
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 3.2.x 2.14.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #23653

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [ N/A] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
