### PR TITLE
[23647] Add documentation for IP mobility

### DIFF
--- a/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
+++ b/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
@@ -7,6 +7,10 @@
 Dynamic network interfaces
 ==========================
 
+.. note::
+
+   Starting in Fast DDS v3.4.0, this feature has been deprecated in favor of :ref:`IP mobility <ip-mobility>`.
+
 DDS :ref:`Simple Discovery <simple_disc_settings>` relies on well-known multicast addresses and ports to relay the
 Participant announcement messages (see :ref:`disc_phases`).
 Such Participant announcement includes information about the unicast address-port pairs (a.k.a locators) where the

--- a/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
+++ b/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
@@ -9,9 +9,9 @@
 Dynamic network interfaces
 ==========================
 
-.. note::
+.. warning::
 
-   Starting in Fast DDS v3.4.0, this feature has been deprecated in favor of :ref:`IP mobility <ip-mobility>`.
+   Starting in Fast DDS v3.4.0, this feature has been deprecated in favor of :ref:`IP mobility <ip-mobility>` |Pro|.
 
 DDS :ref:`Simple Discovery <simple_disc_settings>` relies on well-known multicast addresses and ports to relay the
 Participant announcement messages (see :ref:`disc_phases`).

--- a/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
+++ b/docs/fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
@@ -2,6 +2,8 @@
 .. include:: ../../../03-exports/aliases-api.include
 .. include:: ../../../03-exports/roles.include
 
+:orphan:
+
 .. _dynamic-network-interfaces:
 
 Dynamic network interfaces

--- a/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
+++ b/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
@@ -9,7 +9,7 @@ IP mobility |Pro|
 
 DDS :ref:`Simple Discovery <simple_disc_settings>` relies on well-known multicast addresses and ports to relay the
 Participant announcement messages (see :ref:`disc_phases`).
-Such Participant announcement includes information about the unicast address-port pairs (a.k.a locators) where the
+Such Participant announcement includes information about the unicast address-port pairs (a.k.a. locators) where the
 Participant is expecting to receive incoming metatraffic data.
 The list with these unicast locators is automatically initialized taking into account the network interfaces that are
 available when the *Fast DDS* DomainParticipant is enabled.
@@ -30,6 +30,8 @@ Prerequisites
 This feature is intended to be used when *Fast DDS* automatically sets the listening unicast locators.
 Consequently, all the locator lists in |DomainParticipantQos::wire_protocol-api| must be empty when the
 participant is created.
+If any of them is not empty, no updates will be transmitted to other participants, and communication with
+them will stop.
 
 These locator lists are:
 

--- a/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
+++ b/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
@@ -19,5 +19,29 @@ protocol, so other participants start sending data to the new addresses.
 
 .. important::
 
+   This feature is still under development and only officially supported for UDPv4 Transport without whitelisting.
+
    This feature is only available in Windows and Linux.
    MacOS will be supported in future releases.
+
+Prerequisites
+-------------
+
+This feature is intended to be used when *Fast DDS* automatically sets the listening unicast locators.
+Consequently, all the locator lists in |DomainParticipantQos::wire_protocol-api| must be empty when the
+participant is created.
+
+These locator lists are:
+
+* |BuiltinAttributes::metatrafficUnicastLocatorList-api|
+* |BuiltinAttributes::metatrafficMulticastLocatorList-api|
+* |WireProtocolConfigQos::default_unicast_locator_list-api|
+* |WireProtocolConfigQos::default_multicast_locator_list-api|
+
+Please refer to :ref:`dds_layer_domainParticipantQos` for more information about these attributes.
+
+.. note::
+
+   Be aware of the remote locators' collections limits set within the |DomainParticipantQoS| (please refer to
+   :ref:`remotelocatorsallocationattributes`).
+   It is recommended to use the highest number of local addresses found on all the systems belonging to the same domain.

--- a/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
+++ b/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
@@ -7,11 +7,15 @@
 IP mobility |Pro|
 =================
 
-DDS :ref:`Simple Discovery <simple_disc_settings>` relies on well-known multicast addresses and ports to relay the Participant announcement messages (see :ref:`disc_phases`).
-Such Participant announcement includes information about the unicast address-port pairs (a.k.a. locators) where the Participant is expecting to receive incoming metatraffic data.
-The list with these unicast locators is automatically initialized taking into account the network interfaces that are available when the *Fast DDS* DomainParticipant is enabled.
+DDS :ref:`Simple Discovery <simple_disc_settings>` relies on well-known multicast addresses and ports to relay
+the Participant announcement messages (see :ref:`disc_phases`).
+Such Participant announcement includes information about the unicast address-port pairs (a.k.a. locators) where
+the Participant is expecting to receive incoming metatraffic data.
+The list with these unicast locators is automatically initialized taking into account the network interfaces that
+are available when the *Fast DDS* DomainParticipant is enabled.
 
-Fast DDS Pro detects changes in the system's IP addresses, and automatically updates them through the discovery protocol, so other participants start sending data to the new addresses.
+Fast DDS Pro detects changes in the system's IP addresses, and automatically updates them through the discovery
+protocol, so other participants start sending data to the new addresses.
 
 .. important::
 
@@ -24,8 +28,10 @@ Prerequisites
 -------------
 
 This feature is intended to be used when *Fast DDS* automatically sets the listening unicast locators.
-Consequently, all the locator lists in |DomainParticipantQos::wire_protocol-api| must be empty when the participant is created.
-If any of them is not empty, no updates will be transmitted to other participants, and communication with them will stop.
+Consequently, all the locator lists in |DomainParticipantQos::wire_protocol-api| must be empty when the participant
+is created.
+If any of them is not empty, no updates will be transmitted to other participants, and communication with them will
+stop.
 
 These locator lists are:
 
@@ -38,5 +44,7 @@ Please refer to :ref:`dds_layer_domainParticipantQos` for more information about
 
 .. note::
 
-   Be aware of the remote locators' collections limits set within the |DomainParticipantQoS| (please refer to :ref:`remotelocatorsallocationattributes`).
-   It is recommended to use the highest number of local addresses found on all the systems belonging to the same domain.
+   Be aware of the remote locators' collections limits set within the |DomainParticipantQoS|
+   (please refer to :ref:`remotelocatorsallocationattributes`).
+   It is recommended to use the highest number of local addresses found on all the systems belonging to the same
+   domain.

--- a/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
+++ b/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
@@ -7,3 +7,17 @@
 IP mobility |Pro|
 =================
 
+DDS :ref:`Simple Discovery <simple_disc_settings>` relies on well-known multicast addresses and ports to relay the
+Participant announcement messages (see :ref:`disc_phases`).
+Such Participant announcement includes information about the unicast address-port pairs (a.k.a locators) where the
+Participant is expecting to receive incoming metatraffic data.
+The list with these unicast locators is automatically initialized taking into account the network interfaces that are
+available when the *Fast DDS* DomainParticipant is enabled.
+
+Fast DDS Pro detects changes in the system's IP addresses, and automatically updates them through the discovery
+protocol, so other participants start sending data to the new addresses.
+
+.. important::
+
+   This feature is only available in Windows and Linux.
+   MacOS will be supported in future releases.

--- a/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
+++ b/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
@@ -7,19 +7,15 @@
 IP mobility |Pro|
 =================
 
-DDS :ref:`Simple Discovery <simple_disc_settings>` relies on well-known multicast addresses and ports to relay the
-Participant announcement messages (see :ref:`disc_phases`).
-Such Participant announcement includes information about the unicast address-port pairs (a.k.a. locators) where the
-Participant is expecting to receive incoming metatraffic data.
-The list with these unicast locators is automatically initialized taking into account the network interfaces that are
-available when the *Fast DDS* DomainParticipant is enabled.
+DDS :ref:`Simple Discovery <simple_disc_settings>` relies on well-known multicast addresses and ports to relay the Participant announcement messages (see :ref:`disc_phases`).
+Such Participant announcement includes information about the unicast address-port pairs (a.k.a. locators) where the Participant is expecting to receive incoming metatraffic data.
+The list with these unicast locators is automatically initialized taking into account the network interfaces that are available when the *Fast DDS* DomainParticipant is enabled.
 
-Fast DDS Pro detects changes in the system's IP addresses, and automatically updates them through the discovery
-protocol, so other participants start sending data to the new addresses.
+Fast DDS Pro detects changes in the system's IP addresses, and automatically updates them through the discovery protocol, so other participants start sending data to the new addresses.
 
 .. important::
 
-   This feature is still under development and only officially supported for UDPv4 Transport without whitelisting.
+   This feature is still under development and is only officially supported for UDPv4 Transport without whitelisting.
 
    This feature is only available in Windows and Linux.
    MacOS will be supported in future releases.
@@ -28,10 +24,8 @@ Prerequisites
 -------------
 
 This feature is intended to be used when *Fast DDS* automatically sets the listening unicast locators.
-Consequently, all the locator lists in |DomainParticipantQos::wire_protocol-api| must be empty when the
-participant is created.
-If any of them is not empty, no updates will be transmitted to other participants, and communication with
-them will stop.
+Consequently, all the locator lists in |DomainParticipantQos::wire_protocol-api| must be empty when the participant is created.
+If any of them is not empty, no updates will be transmitted to other participants, and communication with them will stop.
 
 These locator lists are:
 
@@ -44,6 +38,5 @@ Please refer to :ref:`dds_layer_domainParticipantQos` for more information about
 
 .. note::
 
-   Be aware of the remote locators' collections limits set within the |DomainParticipantQoS| (please refer to
-   :ref:`remotelocatorsallocationattributes`).
+   Be aware of the remote locators' collections limits set within the |DomainParticipantQoS| (please refer to :ref:`remotelocatorsallocationattributes`).
    It is recommended to use the highest number of local addresses found on all the systems belonging to the same domain.

--- a/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
+++ b/docs/fastdds/use_cases/ip_mobility/ip_mobility.rst
@@ -1,0 +1,9 @@
+.. include:: ../../../03-exports/aliases.include
+.. include:: ../../../03-exports/aliases-api.include
+.. include:: ../../../03-exports/roles.include
+
+.. _ip-mobility:
+
+IP mobility |Pro|
+=================
+

--- a/docs/fastdds/use_cases/tsn/tsn.rst
+++ b/docs/fastdds/use_cases/tsn/tsn.rst
@@ -40,7 +40,7 @@ The specification defines:
 Fast DDS TSN Implementation
 ---------------------------
 
-*Fast DDS* |Pro| provides the required scaffolding for using DDS over TSN compliant with the OMG specification.
+*Fast DDS Pro* provides the required scaffolding for using DDS over TSN compliant with the OMG specification.
 
 TSN flow configuration can be set via a mapping between a defined
 :ref:`TransportPriorityQosPolicy <transportpriorityqospolicy>` value and a set of tuple parameters.
@@ -55,12 +55,12 @@ sends.
 Supported transports
 ^^^^^^^^^^^^^^^^^^^^
 
-*Fast DDS* |Pro| currently supports two transports that can be used over TSN-capable networks:
+*Fast DDS Pro* currently supports two transports that can be used over TSN-capable networks:
 
 - **UDP Transport Support (UDPv4 / UDPv6)**
 
   *Fast DDS* supports DDSI-RTPS communication over standard POSIX `UDPv4` and `UDPv6` sockets.
-  *Fast DDS* |Pro| extends these transports to enable seamless operation on TSN-capable networks
+  *Fast DDS Pro* extends these transports to enable seamless operation on TSN-capable networks
   while preserving compatibility with existing DDS deployments.
 
   In this transport, the tuple parameters (`IPv4Tuple` / `IPv6Tuple`) are:
@@ -108,7 +108,7 @@ Supported transports
 
 - **Ethernet Transport Support**
 
-  *Fast DDS* |Pro| includes a custom `Ethernet` transport that operates directly at Layer 2 (data link layer),
+  *Fast DDS Pro* includes a custom `Ethernet` transport that operates directly at Layer 2 (data link layer),
   bypassing the TCP/IP stack for reduced latency and direct control over ethernet frames.
 
   *Fast DDS* extends the standard `Locator` class with a new kind for ethernet communication,
@@ -150,7 +150,7 @@ Supported transports
 
   .. note::
 
-    The *Fast DDS* |Pro| installation provides a helper file ``rtps_eth.lua`` under the ``share/fastdds``
+    The *Fast DDS Pro* installation provides a helper file ``rtps_eth.lua`` under the ``share/fastdds``
     subfolder.
     This script allows to easily dissect packets from this transport in Wireshark.
     For details on installing custom plugins, see the

--- a/docs/fastdds/use_cases/use_cases.rst
+++ b/docs/fastdds/use_cases/use_cases.rst
@@ -10,7 +10,7 @@ Use-Cases
 This section provides configuration examples for the following typical use cases when dealing
 with distributed systems:
 
-+ :ref:`use-case-dds-tsn` |Pro|.
++ :ref:`DDS-TSN <use-case-dds-tsn>` |Pro|.
   Describes how to configure *Fast DDS* to use DDS over Time-Sensitive Networking (TSN).
   This configuration leverages IEEE 802.1 standards to provide deterministic, real-time data delivery
   over Ethernet.

--- a/docs/fastdds/use_cases/use_cases.rst
+++ b/docs/fastdds/use_cases/use_cases.rst
@@ -17,6 +17,10 @@ with distributed systems:
   It ensures predictable latency and high reliability for critical applications by mapping DDS QoS policies
   to TSN capabilities and supporting both UDP/IP and raw Ethernet transports.
 
++ :ref:`IP mobility <ip-mobility>` |Pro|.
+  If the network interfaces are expected to change while the application is running, *Fast DDS Pro* provides an
+  automatic way of re-scanning the available interfaces and including them.
+
 + :ref:`use-case-tcp`.
   Describes how to configure *Fast DDS* to use the ``LARGE_DATA`` builtin transports mode.
   This mode enables efficient utilization of TCP transport without the need for constant reconfiguration
@@ -82,10 +86,6 @@ with distributed systems:
 + :ref:`use-case-unique-flows`.
   This use case illustrates the APIs that allow for the request of unique network flows, and for the identification
   of those in use.
-
-+ :ref:`dynamic-network-interfaces`.
-  If the network interfaces are expected to change while the application is running, *Fast DDS* provides an easy way
-  of re-scanning the available interfaces and including them.
 
 + :ref:`statistics_module`.
   This use case explains how to enable the Statistics module within the monitored application, and how to create a

--- a/docs/fastdds/use_cases/use_cases.rst
+++ b/docs/fastdds/use_cases/use_cases.rst
@@ -125,7 +125,7 @@ with distributed systems:
     /fastdds/use_cases/zero_copy/zero_copy.rst
     /fastdds/use_cases/unique_network_flows/unique_network_flows.rst
     /fastdds/use_cases/statistics_module/statistics_module.rst
-    /fastdds/use_cases/dynamic_network_interfaces/dynamic_network_interfaces.rst
+    /fastdds/use_cases/ip_mobility/ip_mobility.rst
     /fastdds/use_cases/dds_record_and_replay/dds_record_and_replay.rst
     /fastdds/use_cases/request_reply/request_reply.rst
     /fastdds/use_cases/remote_type_discovery_matching/remote_type_discovery_matching.rst


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Depends on:
* #1125

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!-- Related implementation PR:
* eProsima/Fast-DDS# -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_: Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
