### PR TITLE
[23520] Add release notes for v3.4.0

### DIFF
--- a/docs/fastdds/transport/low-bandwidth-transports.rst
+++ b/docs/fastdds/transport/low-bandwidth-transports.rst
@@ -2,6 +2,8 @@
 .. include:: ../../03-exports/aliases-api.include
 .. include:: ../../03-exports/roles.include
 
+.. _low_bandwidth_transports:
+
 Low Bandwidth Transports |Pro|
 ==============================
 

--- a/docs/notes/notes.rst
+++ b/docs/notes/notes.rst
@@ -5,7 +5,7 @@
 Information about the release lifecycle can be found
 `here <https://github.com/eProsima/Fast-DDS/blob/master/RELEASE_SUPPORT.md>`_.
 
-.. include:: previous_versions/v3.3.0.rst
+.. include:: previous_versions/v3.4.0.rst
 
 .. seealso::
 

--- a/docs/notes/previous_versions/supported_versions.rst
+++ b/docs/notes/previous_versions/supported_versions.rst
@@ -1,6 +1,11 @@
 Supported versions
 ==================
 
+Version 3.4
+-----------
+
+.. include:: v3.4.0.rst
+
 Version 3.3
 -----------
 

--- a/docs/notes/previous_versions/v3.3.0.rst
+++ b/docs/notes/previous_versions/v3.3.0.rst
@@ -1,5 +1,5 @@
-`Version 3.3.0 (latest) <https://fast-dds.docs.eprosima.com/en/v3.3.0/index.html>`_
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Version 3.3.0 <https://fast-dds.docs.eprosima.com/en/v3.3.0/index.html>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This minor release includes the following **features**:
 

--- a/docs/notes/previous_versions/v3.4.0.rst
+++ b/docs/notes/previous_versions/v3.4.0.rst
@@ -4,7 +4,7 @@
 This minor release includes the following **features**:
 
 * *Fast DDS Pro* features:
-    * Automatic detecition of changes in IP addresses and network interfaces (:ref:`IP mobility <ip-mobility>`)
+    * Automatic detection of changes in IP addresses and network interfaces (:ref:`IP mobility <ip-mobility>`)
     * Support for :ref:`DDS-TSN <use-case-dds-tsn>`
     * :ref:`Low Bandwidth Transports <low_bandwidth_transports>`
 * Pass value of `TransportPriorityQosPolicy` to transport layer

--- a/docs/notes/previous_versions/v3.4.0.rst
+++ b/docs/notes/previous_versions/v3.4.0.rst
@@ -21,6 +21,7 @@ This minor release includes the following **improvements**:
 * Fix doxygen documentation typos
 * Change ``eprosima::fastdds::rtps::octet`` to be ``uint8_t`` according to C++11 standard
 * Add ``tcp_negotiation_timeout`` to XML Schema
+* Some improvements on python generated code
 
 This minor release includes the following **fixes**:
 
@@ -33,6 +34,7 @@ This minor release includes the following **fixes**:
 * Allow empty partition list to match against ``"*"``
 * Fix duplicated transport when using specific XML with CLI
 * Fix topic argument in Discovery Server example
+* Fix type code generation for IDL files with no structs
 
 This minor release includes the following **CI management updates**:
 

--- a/docs/notes/previous_versions/v3.4.0.rst
+++ b/docs/notes/previous_versions/v3.4.0.rst
@@ -30,7 +30,7 @@ This minor release includes the following **fixes**:
 * Fix socket buffer size handling
 * Avoid setting thread affinity of 0 in Mac
 * Some RPC related fixes
-* Fix latency & troughput tests names
+* Fix latency & throughput tests names
 * Allow empty partition list to match against ``"*"``
 * Fix duplicated transport when using specific XML with CLI
 * Fix topic argument in Discovery Server example

--- a/docs/notes/previous_versions/v3.4.0.rst
+++ b/docs/notes/previous_versions/v3.4.0.rst
@@ -26,7 +26,7 @@ This minor release includes the following **improvements**:
 This minor release includes the following **fixes**:
 
 * Fix memory consumption issues in PKIDH plugin
-* Fix build with strict C++11
+* Fix tests build with strict C++11
 * Fix socket buffer size handling
 * Avoid setting thread affinity of 0 in Mac
 * Some RPC related fixes

--- a/docs/notes/previous_versions/v3.4.0.rst
+++ b/docs/notes/previous_versions/v3.4.0.rst
@@ -15,6 +15,7 @@ This minor release includes the following **features**:
 
 This minor release includes the following **improvements**:
 
+* :ref:`Linux binaries <linux_binaries>` installation with ``.deb`` packages
 * Update to Fast DDS Gen 4.2.0
 * Return sample notifying changes on instance state
 * Performance improvements with large history caches

--- a/docs/notes/previous_versions/v3.4.0.rst
+++ b/docs/notes/previous_versions/v3.4.0.rst
@@ -1,0 +1,47 @@
+`Version 3.4.0 (latest) <https://fast-dds.docs.eprosima.com/en/v3.4.0/index.html>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This minor release includes the following **features**:
+
+* *Fast DDS Pro* features:
+    * Automatic detecition of changes in IP addresses and network interfaces (:ref:`IP mobility <ip-mobility>`)
+    * Support for :ref:`DDS-TSN <use-case-dds-tsn>`
+    * :ref:`Low Bandwidth Transports <low_bandwidth_transports>`
+* Pass value of `TransportPriorityQosPolicy` to transport layer
+* Add field ``original_writer_info`` to ``WriteParams`` and ``SampleInfo``
+* Support annotated types and builtin annotations in IDL Parser
+* Iterate over declared types processed with IDL Parser
+* Support aliases in :ref:`Content Filtered Topic <dds_layer_topic_contentFilteredTopic>`
+
+This minor release includes the following **improvements**:
+
+* Update to Fast DDS Gen 4.2.0
+* Return sample notifying changes on instance state
+* Performance improvements with large history caches
+* Fix doxygen documentation typos
+* Change ``eprosima::fastdds::rtps::octet`` to be ``uint8_t`` according to C++11 standard
+* Add ``tcp_negotiation_timeout`` to XML Schema
+
+This minor release includes the following **fixes**:
+
+* Fix memory consumption issues in PKIDH plugin
+* Fix build with strict C++11
+* Fix socket buffer size handling
+* Avoid setting thread affinity of 0 in Mac
+* Some RPC related fixes
+* Fix latency & troughput tests names
+* Allow empty partition list to match against ``"*"``
+* Fix duplicated transport when using specific XML with CLI
+* Fix topic argument in Discovery Server example
+
+This minor release includes the following **CI management updates**:
+
+* Add ``--quiet`` to ``git submodule`` invocations in CI
+* Split Mac CI build and testing phases
+* Update fallback branches to use environment variables
+
+.. important::
+
+    When upgrading to version 3.4.0 it is **highly recommended** to regenerate generated source from IDL files
+    using at least `Fast DDS-Gen v4.2.0 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.2.0>`_.
+    But it is advisable to regenerate them using the latest patch version of ``Fast DDS-Gen v4.2.x``.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- _N/A_: Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
