### PR TITLE
[24282] Documentation for should_endpoints_match callback

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -289,6 +289,18 @@ public:
         }
     }
 
+    bool should_endpoints_match(
+            const DomainParticipant* participant,
+            const eprosima::fastdds::rtps::SubscriptionBuiltinTopicData& reader_info,
+            const eprosima::fastdds::dds::PublicationBuiltinTopicData& writer_info) override
+    {
+        static_cast<void>(participant);
+        // For example, only allow matching between endpoints belonging to different participants.
+        // This prevents intra-participant communication while still allowing
+        // cross-participant communication for endpoints that pass standard QoS checks.
+        return reader_info.participant_guid != writer_info.participant_guid;
+    }
+
 };
 //!--
 

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -298,7 +298,7 @@ public:
         // For example, only allow matching between endpoints belonging to different participants.
         // This prevents intra-participant communication while still allowing
         // cross-participant communication for endpoints that pass standard QoS checks.
-        return reader_info.participant_guid != writer_info.participant_guid;
+        return reader_info.participant_guid.guidPrefix != writer_info.participant_guid.guidPrefix;
     }
 
 };

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -205,6 +205,7 @@
 .. |DomainParticipantListener::on_data_reader_discovery-api| replace:: :cpp:func:`on_data_reader_discovery()<eprosima::fastdds::dds::DomainParticipantListener::on_data_reader_discovery>`
 .. |DomainParticipantListener::on_data_writer_discovery-api| replace:: :cpp:func:`on_data_writer_discovery()<eprosima::fastdds::dds::DomainParticipantListener::on_data_writer_discovery>`
 .. |DomainParticipantListener::onParticipantAuthentication-api| replace:: :cpp:func:`onParticipantAuthentication()<eprosima::fastdds::dds::DomainParticipantListener::onParticipantAuthentication>`
+.. |DomainParticipantListener::should_endpoints_match-api| replace:: :cpp:func:`should_endpoints_match()<eprosima::fastdds::dds::DomainParticipantListener::should_endpoints_match>`
 
 .. |DomainParticipantQos-api| replace:: :cpp:class:`DomainParticipantQos<eprosima::fastdds::dds::DomainParticipantQos>`
 .. |DomainParticipantQos::allocation-api| replace:: :cpp:func:`allocation()<eprosima::fastdds::dds::DomainParticipantQos::allocation>`

--- a/docs/fastdds/dds_layer/domain/domainParticipantListener/domainParticipantListener.rst
+++ b/docs/fastdds/dds_layer/domain/domainParticipantListener/domainParticipantListener.rst
@@ -49,10 +49,10 @@ Additionally, DomainParticipantListener adds the following non-standard callback
   of a remote DomainParticipant (either on failure or success).
 
 * |DomainParticipantListener::should_endpoints_match-api|: Called after standard QoS matching rules have been
-  evaluated for a pair of local and remote endpoints (a :ref:`dds_layer_subscriber_dataReader` and a
+  evaluated for a pair of endpoints (a :ref:`dds_layer_subscriber_dataReader` and a
   :ref:`dds_layer_publisher_dataWriter` on the same topic with compatible QoS).
   It allows the application to apply custom matching logic as an additional filter on top of the standard rules.
-  The callback receives the |DomainParticipant-api| that discovered the remote endpoint, a
+  The callback receives the |DomainParticipant-api| calling the listener, a
   ``SubscriptionBuiltinTopicData`` with the reader information, and a ``PublicationBuiltinTopicData`` with the
   writer information.
   Returning ``true`` allows the match to proceed; returning ``false`` prevents it.

--- a/docs/fastdds/dds_layer/domain/domainParticipantListener/domainParticipantListener.rst
+++ b/docs/fastdds/dds_layer/domain/domainParticipantListener/domainParticipantListener.rst
@@ -48,6 +48,16 @@ Additionally, DomainParticipantListener adds the following non-standard callback
 * |DomainParticipantListener::onParticipantAuthentication-api|: Informs about the result of the authentication process
   of a remote DomainParticipant (either on failure or success).
 
+* |DomainParticipantListener::should_endpoints_match-api|: Called after standard QoS matching rules have been
+  evaluated for a pair of local and remote endpoints (a :ref:`dds_layer_subscriber_dataReader` and a
+  :ref:`dds_layer_publisher_dataWriter` on the same topic with compatible QoS).
+  It allows the application to apply custom matching logic as an additional filter on top of the standard rules.
+  The callback receives the |DomainParticipant-api| that discovered the remote endpoint, a
+  ``SubscriptionBuiltinTopicData`` with the reader information, and a ``PublicationBuiltinTopicData`` with the
+  writer information.
+  Returning ``true`` allows the match to proceed; returning ``false`` prevents it.
+  The default implementation always returns ``true``.
+
 .. important::
 
    For more information about callbacks and its hierarchy, please refer to


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Documentation for https://github.com/eProsima/Fast-DDS/pull/6336

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#6336

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
