### PR TITLE
[24125] Add documentation for writer side filtering on late joiners

### DIFF
--- a/code/ProDDSCodeTester.cpp
+++ b/code/ProDDSCodeTester.cpp
@@ -1,9 +1,10 @@
 #include <cstdint>
 
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/rtps/transport/ethernet/EthernetTransportDescriptor.hpp>
-#include <fastdds/rtps/transport/low-bandwidth/PayloadCompressionTransportDescriptor.hpp>
 #include <fastdds/rtps/transport/low-bandwidth/HeaderReductionTransportDescriptor.hpp>
+#include <fastdds/rtps/transport/low-bandwidth/PayloadCompressionTransportDescriptor.hpp>
 #include <fastdds/rtps/transport/udp_tsn/TSN_UDPv4TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/udp_tsn/UDPPriorityMappings.hpp>
 
@@ -450,4 +451,18 @@ void rpcdds_custom_scheduling_examples()
         }
     };
     //!--
+}
+
+void dds_domain_examples_pro()
+{
+    {
+        // CONTENT_FILTERING_ON_LATE_JOINERS_PROPERTY
+        DataWriterQos wqos;
+
+        // Enable content filtering on late joiners for this DataWriter
+        wqos.properties().properties().emplace_back(
+            "fastdds.content_filtering_on_late_joiners",
+            "true");
+        //!--
+    }
 }

--- a/code/ProXMLTester.xml
+++ b/code/ProXMLTester.xml
@@ -222,5 +222,28 @@
 <-->
 <!--><-->
 
+<!-->CONTENT_FILTERING_ON_LATE_JOINERS_PROPERTY<-->
+<!--
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds>
+    <profiles xmlns="http://www.eprosima.com">
+-->
+        <data_writer profile_name="cft_on_late_joiners_xml_profile">
+            <propertiesPolicy>
+                <properties>
+                    <!-- Enable content filtering on late joiners -->
+                    <property>
+                        <name>fastdds.content_filtering_on_late_joiners</name>
+                        <value>true</value>
+                    </property>
+                </properties>
+            </propertiesPolicy>
+        </data_writer>
+<!-->
+    </profiles>
+</dds>
+<-->
+<!--><-->
+
     </profiles>
 </dds>

--- a/docs/fastdds/dds_layer/topic/contentFilteredTopic/writerFiltering.rst
+++ b/docs/fastdds/dds_layer/topic/contentFilteredTopic/writerFiltering.rst
@@ -49,3 +49,41 @@ Publications made after the updated discovery information is received will use t
 
 If some critical application considers this race condition issue unbearable, filtering on the writer side
 can be disabled by setting the maximum value on |WriterResourceLimitsQos::reader_filters_allocation-api| to 0.
+
+.. _dds_layer_topic_contentFilteredTopic_writer_side_late_joiners:
+
+Writer side filtering on late joiners |Pro|
+-------------------------------------------
+
+By default, when a late joiner DataReader is discovered (non-volatile durability scenario), the DataWriter will not
+apply the filter for that DataReader on historical samples.
+This means that the late joiner DataReader will receive all historical samples, even those that would not match its
+filter, which could cause performance degradation on resource-limited systems.
+
+It is possible however to configure a DataWriter to perform writer-side filtering on late joiners by setting the
+|DataWriterQos| property ``fastdds.content_filtering_on_late_joiners`` to ``true``.
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - PropertyPolicyQos name
+     - PropertyPolicyQos value
+     - Default value
+   * - ``"fastdds.content_filtering_on_late_joiners"``
+     - ``bool``
+     - ``false``
+
+.. tab-set-code::
+
+    .. literalinclude:: /../code/ProDDSCodeTester.cpp
+        :language: c++
+        :start-after: // CONTENT_FILTERING_ON_LATE_JOINERS_PROPERTY
+        :end-before: //!--
+        :dedent: 8
+
+    .. literalinclude:: /../code/ProXMLTester.xml
+        :language: xml
+        :start-after: <!-->CONTENT_FILTERING_ON_LATE_JOINERS_PROPERTY<-->
+        :end-before: <!--><-->
+        :lines: 2-4,6-16,18-19


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Update documentation describing new pro feature.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
