### PR TITLE
[25557] Renaming Fast DDS Monitor to DDS Monitor

### DIFF
--- a/docs/docker/fastdds_suite/fast_dds_suite.rst
+++ b/docs/docker/fastdds_suite/fast_dds_suite.rst
@@ -19,14 +19,14 @@ This Docker image contains the complete Fast DDS suite. This includes:
 
   You can read more about this application on the `Shapes Demo documentation page <https://eprosima-shapes-demo.readthedocs.io/>`_.
 
-- :ref:`Fast DDS Monitor <fast_dds_suite_monitor>`: eProsima Fast DDS Monitor is a graphical desktop application aimed
+- :ref:`DDS Monitor <fast_dds_suite_monitor>`: eProsima DDS Monitor is a graphical desktop application aimed
   at monitoring DDS environments deployed using the *eProsima Fast DDS* library. Thus, the user can monitor in real
   time the status of publication/subscription communications between DDS entities. They can also choose from a wide
   variety of communication parameters to be measured (latency, throughput, packet loss, etc.), as well as record and
   compute in real time statistical measurements on these parameters (mean, variance, standard deviation, etc.).
 
-  You can read more about this application on the `Fast DDS Monitor documentation page
-  <https://fast-dds-monitor.readthedocs.io/>`_.
+  You can read more about this application on the `DDS Monitor documentation page
+  <https://dds-monitor.docs.eprosima.com/>`_.
 
 - :ref:`DDS Router <fast_dds_suite_dds_router>`: eProsima DDS Router is an end-user software application that enables
   the connection of distributed DDS networks.
@@ -128,17 +128,17 @@ eProsima Shapes Demo usage information can be found on the `Shapes Demo document
 
 .. _fast_dds_suite_monitor:
 
-Fast DDS Monitor
-----------------
+DDS Monitor
+-----------
 
-To launch the Fast DDS Monitor, from a terminal run
+To launch DDS Monitor, from a terminal run
 
 .. code-block:: bash
 
-    fastdds_monitor
+    dds_monitor
 
-eProsima Fast DDS Monitor user manual can be found on the `Fast DDS Monitor documentation
-<https://fast-dds-monitor.readthedocs.io/en/latest/rst/user_manual/initialize_monitoring.html>`_.
+eProsima DDS Monitor user manual can be found on the `DDS Monitor documentation
+<https://dds-monitor.docs.eprosima.com/en/latest/rst/user_manual/initialize_monitoring.html>`_.
 
 .. _fast_dds_suite_dds_router:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description

Renaming Fast DDS Monitor to DDS Monitor
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [N/A] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [N/A] The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- [N/A] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
