### PR TITLE
Add support of optional in Dynamic Types (#28)

### DIFF
--- a/docs/fastdds/xtypes/language_binding.rst
+++ b/docs/fastdds/xtypes/language_binding.rst
@@ -600,7 +600,6 @@ This behavior is the same as setting the :code:`@default` and :code:`@id`
 
   Currently, Dynamic Language Binding API implementation does not support the following builtin annotations:
 
-  * :code:`@optional`
   * :code:`@must_understand`
   * :code:`@external`
   * :code:`@try_construct`
@@ -687,7 +686,6 @@ This behavior is the same as setting the :code:`@default` and :code:`@id`
 
   Currently, Dynamic Language Binding API implementation does not support the following builtin annotations:
 
-  * :code:`@optional`
   * :code:`@must_understand`
   * :code:`@external`
   * :code:`@try_construct`
@@ -930,7 +928,7 @@ Please, refer to :ref:`builtin annotations <builtin_annotations>` for the comple
       - ✅
     * - :code:`@optional`
       - |MemberDescriptor-api| :code:`is_optional` property.
-      - ❌
+      - ✅ |Pro|
       - ❌
       - ✅
     * - :code:`@position`


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description

Cherry picked from: [https://github.com/eProsima/Fast-DDS-Pro-Docs/pull/28](https://github.com/eProsima/Fast-DDS-Pro-Docs/pull/28)

<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- [N/A] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
