### PR TITLE
Support Member ID in IDL Parser (#33)

### DIFF
--- a/docs/fastdds/xtypes/idl_parsing.rst
+++ b/docs/fastdds/xtypes/idl_parsing.rst
@@ -32,6 +32,7 @@ For further information about the supported |DynamicTypes|, please, refer to :re
 * Union/struct forward declarations
 * Modules/scoped types
 * :ref:`xtypes_builtin_annotations`
+* Member ID
 
 The following types are currently not supported by the IDL parsing feature:
 
@@ -40,7 +41,6 @@ The following types are currently not supported by the IDL parsing feature:
 * :ref:`xtypes_supportedtypes_bitset`
 * :ref:`xtypes_custom_annotations`
 * Inheritance
-* Member ID
 
 Create a Dynamic Type from a IDL file
 -------------------------------------

--- a/docs/fastdds/xtypes/language_binding.rst
+++ b/docs/fastdds/xtypes/language_binding.rst
@@ -875,6 +875,11 @@ Please, refer to :ref:`builtin annotations <builtin_annotations>` for the comple
       - ✅
       - ❌
       - ✅
+    * - :code:`@autoid`
+      - |MemberDescriptor-api| :code:`id` property (automatic assignment).
+      - ❌
+      - ❌
+      - ✅ |Pro|
     * - :code:`@bit_bound`
       - |TypeDescriptor-api| :code:`bound` property for :ref:`xtypes_supportedtypes_bitset`. |br|
         |TypeDescriptor-api| :code:`literal_type` property for :ref:`xtypes_supportedtypes_enumeration`.
@@ -906,6 +911,11 @@ Please, refer to :ref:`builtin annotations <builtin_annotations>` for the comple
       - ✅
       - ❌
       - ✅
+    * - :code:`@hashid`
+      - |MemberDescriptor-api| :code:`id` property (hash-derived).
+      - ❌
+      - ❌
+      - ✅ |Pro|
     * - :code:`@id`
       - |MemberDescriptor-api| :code:`id` property.
       - ✅


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description

Cherry picked from: [https://github.com/eProsima/Fast-DDS-Pro-Docs/pull/33](https://github.com/eProsima/Fast-DDS-Pro-Docs/pull/33)

<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- [N/A] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
