### PR TITLE
Add all security plugins (#27)

### DIFF
--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -323,6 +323,10 @@ bool permissions_test(
     part_attr.properties.properties().emplace_back(
         "dds.sec.access.builtin.Access-Permissions.permissions",
         permissions_file);
+
+    // Activate Crypto:AES-GCM-GMAC plugin (all three security plugins must be configured together)
+    part_attr.properties.properties().emplace_back("dds.sec.crypto.plugin",
+            "builtin.AES-GCM-GMAC");
     RTPSParticipant* participant = RTPSDomain::createParticipant(0, part_attr);
     if (participant != nullptr)
     {

--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -324,9 +324,6 @@ bool permissions_test(
         "dds.sec.access.builtin.Access-Permissions.permissions",
         permissions_file);
 
-    // Activate Crypto:AES-GCM-GMAC plugin (all three security plugins must be configured together)
-    part_attr.properties.properties().emplace_back("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC");
     RTPSParticipant* participant = RTPSDomain::createParticipant(0, part_attr);
     if (participant != nullptr)
     {

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -8126,6 +8126,10 @@ bool dds_permissions_test(
         "dds.sec.access.builtin.Access-Permissions.permissions",
         permissions_file);
 
+    // Activate Crypto:AES-GCM-GMAC plugin (all three security plugins must be configured together)
+    pqos.properties().properties().emplace_back("dds.sec.crypto.plugin",
+            "builtin.AES-GCM-GMAC");
+
     DomainParticipant* domain_participant =
             DomainParticipantFactory::get_instance()->create_participant(1, pqos);
     if (nullptr != domain_participant)

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -8126,10 +8126,6 @@ bool dds_permissions_test(
         "dds.sec.access.builtin.Access-Permissions.permissions",
         permissions_file);
 
-    // Activate Crypto:AES-GCM-GMAC plugin (all three security plugins must be configured together)
-    pqos.properties().properties().emplace_back("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC");
-
     DomainParticipant* domain_participant =
             DomainParticipantFactory::get_instance()->create_participant(1, pqos);
     if (nullptr != domain_participant)

--- a/docs/fastdds/faq/security/security.rst
+++ b/docs/fastdds/faq/security/security.rst
@@ -46,7 +46,7 @@ Authentication
 
     |br| By setting the |DomainParticipantQos::properties-api| ``dds.sec.auth.plugin`` with the value`` ``builtin.PKI-DH``.
     For further information, refer to :ref:`auth-pki-dh`.
-    Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+    Note that since Fast DDS Pro ``v3.7.0``, secure participants must configure the authentication, access control, and
     cryptography plugins together.
 
 
@@ -136,7 +136,7 @@ Data encryption
 .. collapse::  How is the DDS:Crypto:AES-GCM-GMAC authentication plugin activated?
 
     |br| By setting the |DomainParticipantQos::properties-api| ``dds.sec.crypto.plugin`` with the value ``builtin.AES-GCM-GMAC``.
-    Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+    Note that since Fast DDS Pro ``v3.7.0``, secure participants must configure the authentication, access control, and
     cryptography plugins together.
     Moreover, this plugin needs the activation of the Authentication plugin: ``DDS:Auth:PKI-DH`` and the ``DDS:Access:Permissions``.
     For further information, refer to :ref:`crypto-aes-gcm-gmac`.

--- a/docs/fastdds/faq/security/security.rst
+++ b/docs/fastdds/faq/security/security.rst
@@ -46,6 +46,9 @@ Authentication
 
     |br| By setting the |DomainParticipantQos::properties-api| ``dds.sec.auth.plugin`` with the value`` ``builtin.PKI-DH``.
     For further information, refer to :ref:`auth-pki-dh`.
+    Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+    cryptography plugins together.
+
 
 ----------
 
@@ -133,6 +136,8 @@ Data encryption
 .. collapse::  How is the DDS:Crypto:AES-GCM-GMAC authentication plugin activated?
 
     |br| By setting the |DomainParticipantQos::properties-api| ``dds.sec.crypto.plugin`` with the value ``builtin.AES-GCM-GMAC``.
+    Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+    cryptography plugins together.
     Moreover, this plugin needs the activation of the Authentication plugin: ``DDS:Auth:PKI-DH`` and the ``DDS:Access:Permissions``.
     For further information, refer to :ref:`crypto-aes-gcm-gmac`.
 

--- a/docs/fastdds/property_policies/security.rst
+++ b/docs/fastdds/property_policies/security.rst
@@ -16,7 +16,7 @@ Authentication plugin settings
 The :ref:`DDS\:Auth\:PKI-DH <auth-pki-dh>` authentication plugin, can be activated setting the |DomainParticipantQos|
 |DomainParticipantQos::properties-api|
 ``dds.sec.auth.plugin`` with the value ``builtin.PKI-DH``.
-Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+Note that since Fast DDS Pro ``v3.7.0``, secure participants must configure the authentication, access control, and
 cryptography plugins together.
 
 The following table outlines the properties used for the :ref:`DDS\:Auth\:PKI-DH <auth-pki-dh>` plugin configuration.
@@ -133,7 +133,7 @@ Cryptographic plugin settings
 The :ref:`DDS\:Crypto\:AES-GCM-GMAC <crypto-aes-gcm-gmac>` authentication plugin,
 can be activated setting the |DomainParticipantQos| |DomainParticipantQos::properties-api|
 ``dds.sec.crypto.plugin`` with the value ``builtin.AES-GCM-GMAC``.
-Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+Note that since Fast DDS Pro ``v3.7.0``, secure participants must configure the authentication, access control, and
 cryptography plugins together.
 
 Moreover, this plugin needs the activation of the :ref:`auth-pki-dh`.

--- a/docs/fastdds/property_policies/security.rst
+++ b/docs/fastdds/property_policies/security.rst
@@ -16,6 +16,9 @@ Authentication plugin settings
 The :ref:`DDS\:Auth\:PKI-DH <auth-pki-dh>` authentication plugin, can be activated setting the |DomainParticipantQos|
 |DomainParticipantQos::properties-api|
 ``dds.sec.auth.plugin`` with the value ``builtin.PKI-DH``.
+Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+cryptography plugins together.
+
 The following table outlines the properties used for the :ref:`DDS\:Auth\:PKI-DH <auth-pki-dh>` plugin configuration.
 
 .. list-table::
@@ -130,6 +133,9 @@ Cryptographic plugin settings
 The :ref:`DDS\:Crypto\:AES-GCM-GMAC <crypto-aes-gcm-gmac>` authentication plugin,
 can be activated setting the |DomainParticipantQos| |DomainParticipantQos::properties-api|
 ``dds.sec.crypto.plugin`` with the value ``builtin.AES-GCM-GMAC``.
+Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+cryptography plugins together.
+
 Moreover, this plugin needs the activation of the :ref:`auth-pki-dh`.
 The :ref:`DDS\:Crypto\:AES-GCM-GMAC <crypto-aes-gcm-gmac>` plugin is configured using the
 :ref:`access-permissions`, i.e the cryptography plugin is configured through the properties

--- a/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
+++ b/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
@@ -37,7 +37,7 @@ in detail below.
 The DDS\:Access\:Permissions authentication plugin, can be activated setting the |DomainParticipantQos|
 |DomainParticipantQos::properties-api|
 ``dds.sec.access.plugin`` with the value ``builtin.Access-Permissions``.
-Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+Note that since Fast DDS Pro ``v3.7.0``, secure participants must configure the authentication, access control, and
 cryptography plugins together.
 
 The following table outlines the properties used for the DDS\:Access\:Permissions plugin configuration.
@@ -84,7 +84,7 @@ configuration.
         :end-before: <!--><-->
 
 .. important::
-  Since version v3.7.0, Fast DDS enforces to configure the three main security plugins
+  Since version v3.7.0, Fast DDS Pro enforces to configure the three main security plugins
   (authentication, access control and cryptography) to enable secure communication.
   The previous example focuses only on the access control plugin, but all three plugins must be configured.
 

--- a/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
+++ b/docs/fastdds/security/access_control_plugin/access_control_plugin.rst
@@ -37,6 +37,9 @@ in detail below.
 The DDS\:Access\:Permissions authentication plugin, can be activated setting the |DomainParticipantQos|
 |DomainParticipantQos::properties-api|
 ``dds.sec.access.plugin`` with the value ``builtin.Access-Permissions``.
+Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+cryptography plugins together.
+
 The following table outlines the properties used for the DDS\:Access\:Permissions plugin configuration.
 
 .. list-table::
@@ -79,6 +82,11 @@ configuration.
         :language: xml
         :start-after: <!-->DDS_SECURITY_ACCESS_CONTROL_PLUGIN<-->
         :end-before: <!--><-->
+
+.. important::
+  Since version v3.7.0, Fast DDS enforces to configure the three main security plugins
+  (authentication, access control and cryptography) to enable secure communication.
+  The previous example focuses only on the access control plugin, but all three plugins must be configured.
 
 .. _permissions_ca_cert:
 

--- a/docs/fastdds/security/auth_plugin/auth_plugin.rst
+++ b/docs/fastdds/security/auth_plugin/auth_plugin.rst
@@ -31,7 +31,7 @@ This shared secret can be used by other security plugins as :ref:`crypto-aes-gcm
 The DDS:\Auth\:PKI-DH authentication plugin, can be activated setting the |DomainParticipantQos|
 |DomainParticipantQos::properties-api|
 ``dds.sec.auth.plugin`` with the value ``builtin.PKI-DH``.
-Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+Note that since Fast DDS Pro ``v3.7.0``, secure participants must configure the authentication, access control, and
 cryptography plugins together.
 
 The following table outlines the properties used for the DDS:\Auth\:PKI-DH plugin configuration.
@@ -92,7 +92,7 @@ configuration.
         :end-before: <!--><-->
 
 .. important::
-  Since version v3.7.0, Fast DDS enforces to configure the three main security plugins
+  Since version v3.7.0, Fast DDS Pro enforces to configure the three main security plugins
   (authentication, access control and cryptography) to enable secure communication.
   The previous example focuses only on the authentication plugin, but all three plugins must be configured.
 

--- a/docs/fastdds/security/auth_plugin/auth_plugin.rst
+++ b/docs/fastdds/security/auth_plugin/auth_plugin.rst
@@ -31,6 +31,9 @@ This shared secret can be used by other security plugins as :ref:`crypto-aes-gcm
 The DDS:\Auth\:PKI-DH authentication plugin, can be activated setting the |DomainParticipantQos|
 |DomainParticipantQos::properties-api|
 ``dds.sec.auth.plugin`` with the value ``builtin.PKI-DH``.
+Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+cryptography plugins together.
+
 The following table outlines the properties used for the DDS:\Auth\:PKI-DH plugin configuration.
 
 .. list-table::
@@ -87,6 +90,11 @@ configuration.
         :language: xml
         :start-after: <!-->DDS_SECURITY_AUTH_PLUGIN<-->
         :end-before: <!--><-->
+
+.. important::
+  Since version v3.7.0, Fast DDS enforces to configure the three main security plugins
+  (authentication, access control and cryptography) to enable secure communication.
+  The previous example focuses only on the authentication plugin, but all three plugins must be configured.
 
 .. _generate_x509:
 

--- a/docs/fastdds/security/crypto_plugin/crypto_plugin.rst
+++ b/docs/fastdds/security/crypto_plugin/crypto_plugin.rst
@@ -29,7 +29,7 @@ It may also provide additional DataReader-specific Message Authentication Codes 
 The DDS\:Crypto\:AES-GCM-GMAC authentication plugin, can be activated setting the |DomainParticipantQos|
 |DomainParticipantQos::properties-api|
 ``dds.sec.crypto.plugin`` with the value ``builtin.AES-GCM-GMAC``.
-Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+Note that since Fast DDS Pro ``v3.7.0``, secure participants must configure the authentication, access control, and
 cryptography plugins together.
 
 Moreover, this plugin needs the activation of the :ref:`auth-pki-dh`.
@@ -53,6 +53,6 @@ configuration.
         :end-before: <!--><-->
 
 .. important::
-  Since version v3.7.0, Fast DDS enforces to configure the three main security plugins
+  Since version v3.7.0, Fast DDS Pro enforces to configure the three main security plugins
   (authentication, access control and cryptography) to enable secure communication.
   The previous example focuses only on the authentication plugin, but all three plugins must be configured.

--- a/docs/fastdds/security/crypto_plugin/crypto_plugin.rst
+++ b/docs/fastdds/security/crypto_plugin/crypto_plugin.rst
@@ -29,6 +29,9 @@ It may also provide additional DataReader-specific Message Authentication Codes 
 The DDS\:Crypto\:AES-GCM-GMAC authentication plugin, can be activated setting the |DomainParticipantQos|
 |DomainParticipantQos::properties-api|
 ``dds.sec.crypto.plugin`` with the value ``builtin.AES-GCM-GMAC``.
+Note that since Fast DDS ``v3.7.0``, secure participants must configure the authentication, access control, and
+cryptography plugins together.
+
 Moreover, this plugin needs the activation of the :ref:`auth-pki-dh`.
 The DDS\:Crypto\:\AES-GCM-GMAC plugin is configured using the :ref:`access-permissions`, i.e the cryptography
 plugin is configured through the properties and configuration files of the access control plugin.
@@ -48,3 +51,8 @@ configuration.
         :language: xml
         :start-after: <!-->DDS_SECURITY_CRYPTO_PLUGIN_DOMAINPARTICIPANT<-->
         :end-before: <!--><-->
+
+.. important::
+  Since version v3.7.0, Fast DDS enforces to configure the three main security plugins
+  (authentication, access control and cryptography) to enable secure communication.
+  The previous example focuses only on the authentication plugin, but all three plugins must be configured.

--- a/docs/fastdds/security/includes/intro.rst
+++ b/docs/fastdds/security/includes/intro.rst
@@ -38,7 +38,7 @@ A |Property-api| is defined by its name (:class:`std::string`)
 and its value (:class:`std::string`).
 
 .. important::
-  Since version v3.7.0, Fast DDS enforces to configure the three main security plugins
+  Since version v3.7.0, Fast DDS Pro enforces to configure the three main security plugins
   (authentication, access control and cryptography) to enable secure communication.
   A laxer configuration can be achieved by configuring the access control plugin to be
   permissive, but it is still mandatory to configure the authentication and cryptography plugins.

--- a/docs/fastdds/security/includes/intro.rst
+++ b/docs/fastdds/security/includes/intro.rst
@@ -37,6 +37,12 @@ Security plugins can be activated through the |DomainParticipantQos| properties.
 A |Property-api| is defined by its name (:class:`std::string`)
 and its value (:class:`std::string`).
 
+.. important::
+  Since version v3.7.0, Fast DDS enforces to configure the three main security plugins
+  (authentication, access control and cryptography) to enable secure communication.
+  A laxer configuration can be achieved by configuring the access control plugin to be
+  permissive, but it is still mandatory to configure the authentication and cryptography plugins.
+
 .. warning::
   For the full understanding of this documentation it is required the user to have basic knowledge of network security
   since terms like Certificate Authority (CA), Public Key Infrastructure (PKI), and Diffie-Hellman encryption protocol


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description

Cherry picked from: [https://github.com/eProsima/Fast-DDS-Pro-Docs/pull/27](https://github.com/eProsima/Fast-DDS-Pro-Docs/pull/27)

<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- [N/A] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
