### PR TITLE
[25592] Reduce Read the Docs build time and fix version branch resolution

### DIFF
--- a/code/doxygen-config.in
+++ b/code/doxygen-config.in
@@ -1316,8 +1316,10 @@ IGNORE_PREFIX          =
 
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
+# Disabled: the API Reference is rendered by breathe from the XML output below, and this standalone HTML
+# documentation is never published (it is neither installed by CMakeLists.txt nor added to html_extra_path).
 
-GENERATE_HTML          = YES
+GENERATE_HTML          = NO
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -1886,8 +1888,9 @@ MATHJAX_CODEFILE       =
 # option.
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
+# Disabled along with GENERATE_HTML.
 
-SEARCHENGINE           = YES
+SEARCHENGINE           = NO
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
 # implemented using a web server instead of a web client using JavaScript. There
@@ -2263,8 +2266,10 @@ XML_OUTPUT             = xml
 # of the XML output.
 # The default value is: YES.
 # This tag requires that the tag GENERATE_XML is set to YES.
+# Disabled: the program listings account for a third of the XML that breathe has to parse on every build, and
+# none of the doxygen directives used in the API Reference renders them.
 
-XML_PROGRAMLISTING     = YES
+XML_PROGRAMLISTING     = NO
 
 # If the XML_NS_MEMB_FILE_SCOPE tag is set to YES, doxygen will include
 # namespace members in file scope as well, matching the HTML output.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -276,6 +276,15 @@ def get_git_branch():
     rtd_type = os.environ.get("READTHEDOCS_VERSION_TYPE")
     if rtd_type in ("branch", "tag"):
         version_name = os.environ.get("READTHEDOCS_VERSION")
+        if version_name in ("latest", "stable"):
+            # "latest" and "stable" are RTD pseudo-names, but RTD also exposes the git ref it actually
+            # checked out for them (e.g. "3.6.x" or "v3.6.1"). Preferring it keeps the API Reference and the
+            # GitHub links on the branch the documentation is really being built from instead of master.
+            # The ref is validated against the remote before being used for the checkout, so an unexpected
+            # value simply falls back to master as before.
+            git_identifier = os.environ.get("READTHEDOCS_GIT_IDENTIFIER")
+            if git_identifier and git_identifier not in ("latest", "stable"):
+                return git_identifier
         if version_name == "latest":
             # "latest" is an RTD pseudo-name, not a real branch → fall back to master.
             return None
@@ -420,6 +429,46 @@ def configure_doxyfile(
         file.write(filedata)
 
 
+def clone_repo_at_ref(url, path, preferred_ref, display_name):
+    """
+    Clone a repository at a given branch or tag, downloading as little as possible.
+
+    The existence of ``preferred_ref`` is checked with ``git ls-remote`` before cloning, so falling back to
+    master does not require downloading anything first. Only the tip of the resulting ref is fetched
+    (``--depth 1``), which is all that doxygen and SWIG need: the full history of Fast DDS is over 100 MB and
+    none of it is used.
+
+    :param url: URL of the repository to clone.
+    :param path: Local path where the repository will be cloned.
+    :param preferred_ref: Branch or tag to check out if the remote has it.
+    :param display_name: Repository name, used for logging.
+    :return: The cloned repository.
+    """
+    ref = preferred_ref
+    try:
+        remote_refs = git.cmd.Git().ls_remote("--heads", "--tags", url, ref)
+    except git.GitCommandError as e:
+        print("Failed to list the refs of {}. Git Error: {}".format(display_name, e))
+        remote_refs = ""
+
+    # ``git ls-remote`` matches the pattern against the tail of the ref path, so asking for "master" also
+    # matches a branch named "feature/some-work/master". Require an exact branch or tag match, otherwise the
+    # clone below would be attempted with a ref that does not exist and fail instead of falling back.
+    wanted_refs = ("refs/heads/{}".format(ref), "refs/tags/{}".format(ref))
+    if not any(
+        line.split("\t")[-1] in wanted_refs for line in remote_refs.splitlines()
+    ):
+        print(
+            '{} does not have branch or tag "{}"; falling back to master'.format(
+                display_name, ref
+            )
+        )
+        ref = "master"
+
+    print('Cloning {} at "{}"'.format(display_name, ref))
+    return git.Repo.clone_from(url, path, branch=ref, depth=1, single_branch=True)
+
+
 script_path = os.path.abspath(pathlib.Path(__file__).parent.absolute())
 # Project directories
 project_source_dir = os.path.abspath("{}/../code".format(script_path))
@@ -466,113 +515,93 @@ read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
 if read_the_docs_build:
     print("Read the Docs environment detected!")
 
-    # Remove repository if exists
-    if os.path.isdir(fastdds_repo_name):
-        print("Removing existing repository in {}".format(fastdds_repo_name))
-        shutil.rmtree(fastdds_repo_name)
-    if os.path.isdir(fastdds_python_repo_name):
-        print("Removing existing repository in {}".format(fastdds_python_repo_name))
-        shutil.rmtree(fastdds_python_repo_name)
-
-    # Create necessary directory path
-    os.makedirs(os.path.dirname(fastdds_repo_name), exist_ok=True)
-    os.makedirs(os.path.dirname(fastdds_python_repo_name), exist_ok=True)
-
-    # Clone repositories
-
-    # - Fast DDS
-    print("Cloning Fast DDS")
-    fastdds = git.Repo.clone_from(
-        "https://github.com/eProsima/Fast-DDS.git",
-        fastdds_repo_name,
+    doxygen_index = os.path.join(output_dir, "xml", "index.xml")
+    swig_output = os.path.join(
+        fastdds_python_repo_name, "fastdds_python", "src", "swig", "fastddsPYTHON_wrap.cxx"
     )
 
-    # Verify the desired branch/tag actually exists in the cloned remote, falling back to master if not.
-    fastdds_branch = fastdds_fallback_branch
-    if fastdds.refs.__contains__("origin/{}".format(fastdds_branch)):
-        fastdds_branch = "origin/{}".format(fastdds_branch)
-    elif fastdds.tags.__contains__(fastdds_branch):
-        # GitPython exposes tags by bare name, e.g. "v3.6.1".
-        pass
-    else:
+    # Read the Docs runs a separate sphinx-build, which imports this file again, for every enabled output
+    # format. Cloning the repositories and running doxygen and SWIG once per format would repeat several
+    # minutes of work, so the preparation is skipped when a previous run of this build already completed it.
+    if (
+        os.path.isdir(fastdds_repo_name)
+        and os.path.isdir(fastdds_python_repo_name)
+        and os.path.isfile(doxygen_index)
+        and os.path.isfile(swig_output)
+    ):
         print(
-            'Fast DDS does not have branch or tag "{}"; falling back to master'.format(
-                fastdds_branch
+            "Reusing the repositories, doxygen documentation and SWIG code already generated in {}".format(
+                project_binary_dir
             )
         )
-        fastdds_branch = "origin/master"
-
-    # Actual checkout
-    print('Checking out Fast DDS branch "{}"'.format(fastdds_branch))
-    fastdds.git.checkout(fastdds_branch)
-
-    # - Fast DDS Python Bindings
-    print("Cloning Fast DDS Python Bindings")
-    fastdds_python = git.Repo.clone_from(
-        "https://github.com/eProsima/Fast-DDS-python.git",
-        fastdds_python_repo_name,
-    )
-
-    # Verify the desired branch/tag actually exists in the cloned remote, falling back to master if not.
-    fastdds_python_branch = fastdds_python_fallback_branch
-    if fastdds_python.refs.__contains__("origin/{}".format(fastdds_python_branch)):
-        fastdds_python_branch = "origin/{}".format(fastdds_python_branch)
-    elif fastdds_python.tags.__contains__(fastdds_python_branch):
-        # GitPython exposes tags by bare name, e.g. "v3.6.1".
-        pass
     else:
-        print(
-            'Fast DDS Python does not have branch or tag "{}"; falling back to master'.format(
-                fastdds_python_branch
-            )
-        )
-        fastdds_python_branch = "origin/master"
+        # Remove the repositories left behind by an incomplete attempt, as cloning needs an empty directory
+        if os.path.isdir(fastdds_repo_name):
+            print("Removing existing repository in {}".format(fastdds_repo_name))
+            shutil.rmtree(fastdds_repo_name)
+        if os.path.isdir(fastdds_python_repo_name):
+            print("Removing existing repository in {}".format(fastdds_python_repo_name))
+            shutil.rmtree(fastdds_python_repo_name)
 
-    # Actual checkout
-    print('Checking out Fast DDS Python branch "{}"'.format(fastdds_python_branch))
-    fastdds_python.git.checkout(fastdds_python_branch)
+        # Create necessary directory path
+        os.makedirs(os.path.dirname(fastdds_repo_name), exist_ok=True)
+        os.makedirs(os.path.dirname(fastdds_python_repo_name), exist_ok=True)
 
-    os.makedirs(os.path.dirname(output_dir), exist_ok=True)
-    os.makedirs(os.path.dirname(doxygen_html), exist_ok=True)
-
-    # Configure Doxyfile
-    configure_doxyfile(
-        doxyfile_in,
-        doxyfile_out,
-        input_dir,
-        output_dir,
-        project_binary_dir,
-        project_source_dir,
-    )
-    # Generate doxygen documentation
-    doxygen_ret = subprocess.call("doxygen {}".format(doxyfile_out), shell=True)
-    if doxygen_ret != 0:
-        print("Doxygen failed with return code {}".format(doxygen_ret))
-        sys.exit(doxygen_ret)
-
-    # Generate SWIG code.
-    swig_ret = subprocess.call(
-        "swig \
-        -python \
-        -doxygen \
-        -I{}/include \
-        -DFASTDDS_DOCS_BUILD \
-        -outdir {}/fastdds_python/src/swig \
-        -c++ \
-        -interface _fastdds_python \
-        -o {}/fastdds_python/src/swig/fastddsPYTHON_wrap.cxx \
-        {}/fastdds_python/src/swig/fastdds.i".format(
+        # Clone repositories at the branch or tag this documentation is being built from
+        clone_repo_at_ref(
+            "https://github.com/eProsima/Fast-DDS.git",
             fastdds_repo_name,
+            fastdds_fallback_branch,
+            "Fast DDS",
+        )
+        clone_repo_at_ref(
+            "https://github.com/eProsima/Fast-DDS-python.git",
             fastdds_python_repo_name,
-            fastdds_python_repo_name,
-            fastdds_python_repo_name,
-        ),
-        shell=True,
-    )
+            fastdds_python_fallback_branch,
+            "Fast DDS Python Bindings",
+        )
 
-    if swig_ret != 0:
-        print("SWIG failed with return code {}".format(swig_ret))
-        sys.exit(swig_ret)
+        os.makedirs(os.path.dirname(output_dir), exist_ok=True)
+        os.makedirs(os.path.dirname(doxygen_html), exist_ok=True)
+
+        # Configure Doxyfile
+        configure_doxyfile(
+            doxyfile_in,
+            doxyfile_out,
+            input_dir,
+            output_dir,
+            project_binary_dir,
+            project_source_dir,
+        )
+        # Generate doxygen documentation
+        doxygen_ret = subprocess.call("doxygen {}".format(doxyfile_out), shell=True)
+        if doxygen_ret != 0:
+            print("Doxygen failed with return code {}".format(doxygen_ret))
+            sys.exit(doxygen_ret)
+
+        # Generate SWIG code.
+        swig_ret = subprocess.call(
+            "swig \
+            -python \
+            -doxygen \
+            -I{}/include \
+            -DFASTDDS_DOCS_BUILD \
+            -outdir {}/fastdds_python/src/swig \
+            -c++ \
+            -interface _fastdds_python \
+            -o {}/fastdds_python/src/swig/fastddsPYTHON_wrap.cxx \
+            {}/fastdds_python/src/swig/fastdds.i".format(
+                fastdds_repo_name,
+                fastdds_python_repo_name,
+                fastdds_python_repo_name,
+                fastdds_python_repo_name,
+            ),
+            shell=True,
+        )
+
+        if swig_ret != 0:
+            print("SWIG failed with return code {}".format(swig_ret))
+            sys.exit(swig_ret)
 
     fastdds_python_imported_location = "{}/fastdds_python/src/swig".format(
         fastdds_python_repo_name

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -429,42 +429,92 @@ def configure_doxyfile(
         file.write(filedata)
 
 
-def clone_repo_at_ref(url, path, preferred_ref, display_name):
+def resolve_remote_ref(url, preferred_ref, display_name):
     """
-    Clone a repository at a given branch or tag, downloading as little as possible.
+    Resolve the branch or tag a repository must be checked out at, without downloading it.
 
-    The existence of ``preferred_ref`` is checked with ``git ls-remote`` before cloning, so falling back to
-    master does not require downloading anything first. Only the tip of the resulting ref is fetched
-    (``--depth 1``), which is all that doxygen and SWIG need: the full history of Fast DDS is over 100 MB and
-    none of it is used.
+    ``git ls-remote`` is used so that falling back to master, when the remote does not have
+    ``preferred_ref``, does not require cloning anything first.
 
-    :param url: URL of the repository to clone.
-    :param path: Local path where the repository will be cloned.
-    :param preferred_ref: Branch or tag to check out if the remote has it.
+    :param url: URL of the repository.
+    :param preferred_ref: Branch or tag to use if the remote has it.
     :param display_name: Repository name, used for logging.
-    :return: The cloned repository.
+    :return: Tuple with the branch or tag to use and the commit it points to. The commit is ``None`` if the
+        remote could not be queried.
     """
     ref = preferred_ref
     try:
-        remote_refs = git.cmd.Git().ls_remote("--heads", "--tags", url, ref)
+        remote_refs = git.cmd.Git().ls_remote("--heads", "--tags", url, ref, "master")
     except git.GitCommandError as e:
         print("Failed to list the refs of {}. Git Error: {}".format(display_name, e))
-        remote_refs = ""
+        return ref, None
 
     # ``git ls-remote`` matches the pattern against the tail of the ref path, so asking for "master" also
     # matches a branch named "feature/some-work/master". Require an exact branch or tag match, otherwise the
-    # clone below would be attempted with a ref that does not exist and fail instead of falling back.
-    wanted_refs = ("refs/heads/{}".format(ref), "refs/tags/{}".format(ref))
-    if not any(
-        line.split("\t")[-1] in wanted_refs for line in remote_refs.splitlines()
-    ):
+    # clone would be attempted with a ref that does not exist and fail instead of falling back.
+    commits = {}
+    for line in remote_refs.splitlines():
+        commit, _, ref_path = line.partition("\t")
+        commits[ref_path] = commit
+
+    for candidate in (ref, "master"):
+        for ref_path in (
+            "refs/heads/{}".format(candidate),
+            "refs/tags/{}".format(candidate),
+        ):
+            if ref_path in commits:
+                return candidate, commits[ref_path]
         print(
             '{} does not have branch or tag "{}"; falling back to master'.format(
-                display_name, ref
+                display_name, candidate
             )
         )
-        ref = "master"
 
+    return "master", None
+
+
+def repo_is_at_commit(path, commit, display_name):
+    """
+    Check whether an already cloned repository is checked out at a given commit.
+
+    :param path: Local path of the repository.
+    :param commit: Commit that the repository is expected to be checked out at.
+    :param display_name: Repository name, used for logging.
+    :return: True only if the repository exists and its HEAD is that commit.
+    """
+    if not commit or not os.path.isdir(path):
+        return False
+
+    try:
+        head_commit = git.Repo(path).head.commit.hexsha
+    except Exception as e:
+        print("Could not read the HEAD of {}. Error: {}".format(display_name, e))
+        return False
+
+    if head_commit != commit:
+        print(
+            "{} is checked out at {} instead of {}".format(
+                display_name, head_commit[:10], commit[:10]
+            )
+        )
+        return False
+
+    return True
+
+
+def clone_repo_at_ref(url, path, ref, display_name):
+    """
+    Clone a repository at a given branch or tag, downloading as little as possible.
+
+    Only the tip of the ref is fetched (``--depth 1``), which is all that doxygen and SWIG need: the full
+    history of Fast DDS is over 100 MB and none of it is used.
+
+    :param url: URL of the repository to clone.
+    :param path: Local path where the repository will be cloned.
+    :param ref: Branch or tag to check out, as resolved by ``resolve_remote_ref``.
+    :param display_name: Repository name, used for logging.
+    :return: The cloned repository.
+    """
     print('Cloning {} at "{}"'.format(display_name, ref))
     return git.Repo.clone_from(url, path, branch=ref, depth=1, single_branch=True)
 
@@ -515,17 +565,32 @@ read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
 if read_the_docs_build:
     print("Read the Docs environment detected!")
 
+    fastdds_url = "https://github.com/eProsima/Fast-DDS.git"
+    fastdds_python_url = "https://github.com/eProsima/Fast-DDS-python.git"
+
     doxygen_index = os.path.join(output_dir, "xml", "index.xml")
     swig_output = os.path.join(
         fastdds_python_repo_name, "fastdds_python", "src", "swig", "fastddsPYTHON_wrap.cxx"
     )
 
+    # Branch or tag, and the commit it currently points to, that each repository must be checked out at
+    fastdds_ref, fastdds_commit = resolve_remote_ref(
+        fastdds_url, fastdds_fallback_branch, "Fast DDS"
+    )
+    fastdds_python_ref, fastdds_python_commit = resolve_remote_ref(
+        fastdds_python_url, fastdds_python_fallback_branch, "Fast DDS Python Bindings"
+    )
+
     # Read the Docs runs a separate sphinx-build, which imports this file again, for every enabled output
     # format. Cloning the repositories and running doxygen and SWIG once per format would repeat several
     # minutes of work, so the preparation is skipped when a previous run of this build already completed it.
+    # The repositories must be checked out at the expected commit, and not merely exist, for their doxygen
+    # documentation and SWIG code to be the ones this build needs.
     if (
-        os.path.isdir(fastdds_repo_name)
-        and os.path.isdir(fastdds_python_repo_name)
+        repo_is_at_commit(fastdds_repo_name, fastdds_commit, "Fast DDS")
+        and repo_is_at_commit(
+            fastdds_python_repo_name, fastdds_python_commit, "Fast DDS Python Bindings"
+        )
         and os.path.isfile(doxygen_index)
         and os.path.isfile(swig_output)
     ):
@@ -548,16 +613,11 @@ if read_the_docs_build:
         os.makedirs(os.path.dirname(fastdds_python_repo_name), exist_ok=True)
 
         # Clone repositories at the branch or tag this documentation is being built from
+        clone_repo_at_ref(fastdds_url, fastdds_repo_name, fastdds_ref, "Fast DDS")
         clone_repo_at_ref(
-            "https://github.com/eProsima/Fast-DDS.git",
-            fastdds_repo_name,
-            fastdds_fallback_branch,
-            "Fast DDS",
-        )
-        clone_repo_at_ref(
-            "https://github.com/eProsima/Fast-DDS-python.git",
+            fastdds_python_url,
             fastdds_python_repo_name,
-            fastdds_python_fallback_branch,
+            fastdds_python_ref,
             "Fast DDS Python Bindings",
         )
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -12,6 +12,15 @@ build:
   apt_packages:
     - plantuml
     - swig
+  jobs:
+    build:
+      # By default Read the Docs builds the downloadable documentation with an extra
+      # `sphinx-build -b singlehtml` run, which means building the whole documentation a second time (over 8
+      # minutes). The `html` format is built first and its output is already the complete documentation, so
+      # the downloadable file is simply that output compressed, which takes about a second.
+      htmlzip:
+        - mkdir -p $READTHEDOCS_OUTPUT/htmlzip
+        - python -m zipfile -c $READTHEDOCS_OUTPUT/htmlzip/fast-dds-docs.zip $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -23,7 +32,8 @@ sphinx:
 
 # Read the Docs builds each additional format with its own `sphinx-build` invocation, so every one of them
 # re-runs the whole documentation build. Only `htmlzip` is kept, as it provides the downloadable
-# documentation for offline reading; `pdf` and `epub` are not built.
+# documentation for offline reading, and it is generated from the already built HTML (see `build.jobs`
+# above) instead of running Sphinx again; `pdf` and `epub` are not built.
 formats:
   - htmlzip
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -21,10 +21,11 @@ sphinx:
 #mkdocs:
 #  configuration: mkdocs.yml
 
-# Additional formats (htmlzip, pdf, epub) are deliberately disabled: Read the Docs builds each one with its
-# own `sphinx-build` invocation, so every extra format re-runs the whole documentation build (including the
-# Fast DDS clone, doxygen and SWIG steps performed in conf.py). Enabling all of them tripled the build time.
-formats: []
+# Read the Docs builds each additional format with its own `sphinx-build` invocation, so every one of them
+# re-runs the whole documentation build. Only `htmlzip` is kept, as it provides the downloadable
+# documentation for offline reading; `pdf` and `epub` are not built.
+formats:
+  - htmlzip
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -21,8 +21,10 @@ sphinx:
 #mkdocs:
 #  configuration: mkdocs.yml
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+# Additional formats (htmlzip, pdf, epub) are deliberately disabled: Read the Docs builds each one with its
+# own `sphinx-build` invocation, so every extra format re-runs the whole documentation build (including the
+# Fast DDS clone, doxygen and SWIG steps performed in conf.py). Enabling all of them tripled the build time.
+formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
## Description

Read the Docs builds of `latest` / `3.x` were taking around **37 minutes** ([2248 s](https://app.readthedocs.org/api/v2/build/34217965.txt), 2199 s, 2244 s on recent builds). The suspicion was that the breathe-generated C++ API Reference was to blame. It is a large cost, but not the main one: the build was paying for the *same work four times over*.

Read the Docs runs a **separate `sphinx-build` per output format**, and `readthedocs.yaml` requested `formats: all`. The build log of a `latest` build shows where the 37 minutes go:

| Step | Time |
|---|---|
| `python -m sphinx -b html` | 735.9 s |
| `python -m sphinx -b singlehtml` (htmlzip) | 491.2 s |
| `python -m sphinx -b latex` (pdf) | 463.9 s |
| `python -m sphinx -b epub` | 392.9 s |
| `latexmk` | 72.1 s |
| apt + pip + git setup | ~70 s |

93% of the wall time is those four Sphinx invocations. Since each one imports `docs/conf.py` again, the preparation done there also ran four times: the log contains `Read the Docs environment detected!`, `Cloning Fast DDS`, `Cloning Fast DDS Python Bindings` and `Configuring Doxyfile` **4x each**, plus `Removing existing repository in ...` 6 times — runs 2 to 4 deleted and re-cloned Fast DDS (149 MB of history, no `--depth`) and Fast DDS Python, and re-ran doxygen and SWIG.

PR builds only took ~13 min because Read the Docs skips additional formats for external versions.

This PR contains four changes:

**1. Build only HTML, and generate the downloadable documentation from it (`readthedocs.yaml`)**

`formats: all` -> `formats: [htmlzip]`. The `latex` and `epub` runs and `latexmk` are removed: **-929 s (~15.5 min)**. The PDF and epub downloads disappear from the Read the Docs flyout menu. `htmlzip` is kept, as it is the format that provides the downloadable documentation for offline reading.

By default, `htmlzip` is not a copy of the HTML output: Read the Docs generates it with an extra `sphinx-build -b singlehtml` run, that is, by building the whole documentation a second time (491.2 s in the log above). Since `html` is built first and its output is already the complete documentation, `build.jobs.build.htmlzip` is overridden to compress that output instead:

```yaml
build:
  jobs:
    build:
      htmlzip:
        - mkdir -p $READTHEDOCS_OUTPUT/htmlzip
        - python -m zipfile -c $READTHEDOCS_OUTPUT/htmlzip/fast-dds-docs.zip $READTHEDOCS_OUTPUT/html
```

**491.2 s -> ~1 s**, and the downloaded file becomes the whole documentation site, navigation and search included, instead of a single page. Only the `htmlzip` job is overridden; every other format keeps its default command.

**2. Stop generating doxygen output that nothing consumes (`code/doxygen-config.in`)**

| Tag | Before | After | Reason |
|---|---|---|---|
| `XML_PROGRAMLISTING` | `YES` | `NO` | 11.5 MB of the 32.3 MB XML that breathe parses on every build were `<programlisting>` elements. None of the 492 directives used in the API Reference renders program listings. XML: 33 MB -> 22 MB. |
| `GENERATE_HTML` | `YES` | `NO` | 51 MB of standalone doxygen HTML was written to `@PROJECT_BINARY_DIR@/html/doxygen` and never published: `html_extra_path` is commented out, `CMakeLists.txt` installs only `doxygen/xml`, and no `.rst` file links into `doxygen/`. |
| `SEARCHENGINE` | `YES` | `NO` | Only applies to the HTML output disabled above. |

The API Reference is unaffected: breathe consumes the XML output, which is still generated.

**3. Clone Fast DDS cheaply, and prepare it once per build (`docs/conf.py`)**

`resolve_remote_ref()` resolves the branch or tag with `git ls-remote`, without downloading anything, so falling back to master when the remote does not have the wanted ref costs nothing. `clone_repo_at_ref()` then clones it with `--depth 1 --single-branch`, which is all doxygen and SWIG need — **4.5 MB and 1.6 s instead of 149 MB of history**.

The `shutil.rmtree` + re-clone on every import is replaced by a reuse check: the clone, doxygen and SWIG steps are skipped when the repositories are already checked out at the expected commit (`repo_is_at_commit()`, comparing `HEAD` against the commit resolved above) **and** `doxygen/xml/index.xml` and the SWIG wrapper are already in place. So the `htmlzip` run reuses everything the `html` run prepared instead of repeating it.

**4. Build the API Reference from the right branch (`docs/conf.py`)**

Unrelated bug found in the same logs: on the `latest` (3.6.x) build, `get_git_branch()` returns `None` for the `latest` pseudo-name, so the log reads `Current documentation branch could not be determined` followed by `Checking out Fast DDS branch "origin/master"`. The 3.6.x API Reference was therefore generated from Fast DDS **master** headers, and the GitHub links pointed at master.

`get_git_branch()` now prefers Read the Docs' `READTHEDOCS_GIT_IDENTIFIER` (the ref actually checked out, e.g. `3.6.x`) for the `latest` and `stable` pseudo-names. The value is validated against the remote by change 3, so an unexpected value still falls back to master exactly as before.

### Result

| | Before | After |
|---|---|---|
| Sphinx run (local, same command, fresh doctrees) | 405.2 s | **338.7 s** (-16.4%) |
| Doxygen | 4.6 s | 2.7 s |
| Doxygen XML parsed by breathe | 33 MB | 22 MB |
| Fast DDS clone | 149 MB of history | 4.5 MB, 1.6 s |
| Repository clone + doxygen + SWIG per build | 4 times | once |
| Downloadable documentation (`htmlzip`) | 491.2 s | ~1 s |
| `latest` / `3.x` build on Read the Docs | ~37 min | **~11 min** |
| PR build on Read the Docs | ~13 min | ~11 min |

The estimate for `latest` is the `html` run with 16.4% off (~615 s), about a second of compression, and the ~70 s of environment setup.

### Verification

* `colcon build --packages-select fastdds-docs` succeeds, `build succeeded` with no warnings.
* The API Reference output is unchanged: all **350** `fastdds/api_reference` HTML pages are **byte-identical** before and after the doxygen changes (51,136,889 bytes either way), compared with the same command and a fresh doctrees directory.
* `resolve_remote_ref()` was exercised against the real remotes for an existing branch (`3.6.x`), an existing tag (`v3.6.1`), a ref that only tail-matches an unrelated branch, and an absent ref: the first two are used with their commit, the last two fall back to master without failing.
* `repo_is_at_commit()` returns `True` only for a clone at the expected commit, and `False`, with a printed reason, for a clone at a different commit, a missing directory, a directory that is not a repository, and an unresolved commit.
* The `htmlzip` commands were run against a real HTML output: 1.1 s to compress 98 MB into a **15 MB** archive that unzips into a browsable site with the 559 pages, the 350 API Reference pages, the static assets, `searchindex.js` and the images. The build log confirms Read the Docs builds the `html` format first, so its output is in place when the `htmlzip` job runs.
* The Read the Docs block was executed with the clone, doxygen and SWIG steps stubbed out, covering its four paths: nothing cloned yet, everything present at the expected commit (reused), present at a **different** commit (re-cloned and regenerated), and present at the right commit but without the doxygen XML (regenerated).
* `get_git_branch()` was exercised for a `latest` build tracking `3.6.x` (now resolves to `3.6.x`), a `latest` build with no `READTHEDOCS_GIT_IDENTIFIER` (still `None`, unchanged), and an `external` PR build (still `None`, so the PR number is never used as a ref).

### Not included

Moving `fastdds/api_reference` into its own Read the Docs subproject. It is the biggest remaining lever — the API Reference is 65% of each Sphinx run (262 s of 405 s locally; excluding it drops the build to 143 s) — but it requires intersphinx to keep the ~1000 `:cpp:` aliases in `docs/03-exports/aliases-api.include` resolving from the prose, so it is left for a separate discussion.

## Contributor Checklist

- [x] Commit messages follow the project guidelines.
- N/A Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- N/A The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
